### PR TITLE
changing if condition to take care of 0 in value of params

### DIFF
--- a/server/src/optima/model.py
+++ b/server/src/optima/model.py
@@ -358,7 +358,7 @@ def doCostCoverageEffect():
         if args.get('ccparams'):
             args['ccparams'] = dict([(key, (float(param) if param else None)) for (key,param) in args['ccparams'].iteritems()])
         if args.get('coparams'):
-            args['coparams'] = map(lambda param: float(param) if param else None, args['coparams'])
+            args['coparams'] = map(lambda param: float(param) if param or (type(param) is int and param == 0) else None, args['coparams'])
         # effectnames are actually effects
         figsize = (3,2)
         plotdata, plotdata_co, _ = makecco(**args) # plotdata is actually plotdata_cco


### PR DESCRIPTION
The PR has fix for this bug:
https://trello.com/c/OtAw1DbO/623-exception-when-enter-range-between-0-and-some-other-value-define-cost-coverage-options-to-adjust-curves