### PR TITLE
Feature/621 remove the 5th option from cost coverage chart

### DIFF
--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -64,7 +64,6 @@ define(['./module', 'underscore'], function (module, _) {
         funding: $scope.state.knownFundingValue,
         scaleup: $scope.state.scaleUpParameter,
         nonhivdalys: $scope.state.nonHivDalys,
-        xupperlim: $scope.state.xAxisMaximum,
         cpibaseyear: $scope.state.displayYear,
         perperson: $scope.state.calculatePerPerson
       };
@@ -162,7 +161,6 @@ define(['./module', 'underscore'], function (module, _) {
       $scope.state.scaleUpParameter = program.ccparams.scaleup;
       $scope.state.nonHivDalys = program.ccparams.nonhivdalys;
       $scope.state.displayYear = program.ccparams.cpibaseyear;
-      $scope.state.xAxisMaximum = program.ccparams.xupperlim;
       $scope.state.calculatePerPerson = program.ccparams.perperson;
 
       var model = getPlotModel();

--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -162,6 +162,8 @@ define(['./module', 'underscore'], function (module, _) {
       $scope.state.nonHivDalys = program.ccparams.nonhivdalys;
       $scope.state.displayYear = program.ccparams.cpibaseyear;
       $scope.state.calculatePerPerson = program.ccparams.perperson;
+      console.log("info", info);
+      $scope.state.info = info;
 
       var model = getPlotModel();
       retrieveAndUpdateGraphs(model);

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -159,16 +159,16 @@
                   5. [Optional] Display program cost data in
                   <input type="number" class="txbox __inline __l"
                          name="displayYear"
-                         placeholder="e.g.{{ ::projectInfo.dataEnd }}"
-                         min="{{ ::projectInfo.dataStart }}"
-                         max="{{ ::projectInfo.dataEnd }}"
+                         placeholder="e.g.{{ state.info.dataEnd }}"
+                         min="{{ state.info.dataStart }}"
+                         max="{{ state.info.dataEnd }}"
                          ng-model="state.displayYear"
                          ng-change="updateCurves()">
                   prices
                   <div ng-messages="state.CostCoverageForm.displayYear.$error"
                        ng-show="state.CostCoverageForm.displayYear.$touched && state.CostCoverageForm.displayYear.$invalid">
-                    <div class="error-hint" ng-message="min">The year entered cannot be before the project start date, which is {{ ::projectInfo.dataStart }}</div>
-                    <div class="error-hint" ng-message="max">The year entered cannot be after the project end date, which is {{ ::projectInfo.dataEnd }}</div>
+                    <div class="error-hint" ng-message="min">The year entered cannot be before the project start date, which is {{ state.info.dataStart }}</div>
+                    <div class="error-hint" ng-message="max">The year entered cannot be after the project end date, which is {{ state.info.dataEnd }}</div>
                     <div class="error-hint" ng-message="number">The value should be a number</div>
                   </div>
                 </div>

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -156,20 +156,7 @@
                   </div>
                 </div>
                 <div class="section">
-                  5. [Optional] Specify the maximum funding (for plotting only):
-                  <input type="number" class="txbox __inline __xl"
-                         name="xAxisMaximum"
-                         min="1" placeholder="e.g. 1000000"
-                         ng-model="state.xAxisMaximum"
-                         ng-change="updateCurves()">
-                  <div ng-messages="state.CostCoverageForm.xAxisMaximum.$error"
-                       ng-show="state.CostCoverageForm.xAxisMaximum.$touched && state.CostCoverageForm.xAxisMaximum.$invalid">
-                    <div class="error-hint" ng-message="min">The minimum value is 1</div>
-                    <div class="error-hint" ng-message="number">The value should be a number</div>
-                  </div>
-                </div>
-                <div class="section">
-                  6. [Optional] Display program cost data in
+                  5. [Optional] Display program cost data in
                   <input type="number" class="txbox __inline __l"
                          name="displayYear"
                          placeholder="e.g.{{ ::projectInfo.dataEnd }}"
@@ -186,7 +173,7 @@
                   </div>
                 </div>
                 <div class="section">
-                  7. [Optional] Display program costs in dollar spent per person in the targeted population
+                  6. [Optional] Display program costs in dollar spent per person in the targeted population
                   <input type="checkbox" ng-model="state.calculatePerPerson" class="__inline" ng-change="updateCurves()"/>
                 </div>
               </form>

--- a/server/src/sim/makeccocs.py
+++ b/server/src/sim/makeccocs.py
@@ -83,7 +83,7 @@ def makecc(D=None, progname=None, ccparams=None, arteligcutoff=None, verbose=def
     if popadj: totalcost = totalcost/targetpopsize if len(totalcost)>1 else totalcost/mean(targetpopsize)
 
     # Get upper limit of x axis for plotting
-    xupperlim = max([x if ~isnan(x) else 0.0 for x in totalcost])*1.5
+    xupperlim = max([x if ~isnan(x) else 0.0 for x in totalcost])*15.
 
     # Populate output structure with scatter data
     plotdata['allxscatterdata'] = totalcost

--- a/server/src/sim/makeccocs.py
+++ b/server/src/sim/makeccocs.py
@@ -84,7 +84,6 @@ def makecc(D=None, progname=None, ccparams=None, arteligcutoff=None, verbose=def
 
     # Get upper limit of x axis for plotting
     xupperlim = max([x if ~isnan(x) else 0.0 for x in totalcost])*1.5
-    if (ccparams and 'xupperlim' in ccparams and ccparams['xupperlim'] and ~isnan(ccparams['xupperlim'])): xupperlim = ccparams['xupperlim']
 
     # Populate output structure with scatter data
     plotdata['allxscatterdata'] = totalcost

--- a/server/src/sim/makeproject.py
+++ b/server/src/sim/makeproject.py
@@ -17,6 +17,7 @@ def makeproject(projectname='example', pops = default_pops, progs = default_prog
     from printv import printv
     from numpy import arange
     from copy import deepcopy
+    from versioning import current_version
 
     printv('Making project...', 1, verbose)
 
@@ -29,6 +30,7 @@ def makeproject(projectname='example', pops = default_pops, progs = default_prog
     
     # Set up "G" -- general parameters structure
     D['G'] = dict()
+    D['G']['version'] = current_version # so that we know the version of new project with regard to data structure
     D['G']['projectname'] = projectname  
     D['G']['projectfilename'] = projectpath(projectname+'.prj')
     D['G']['workbookname'] = D['G']['projectname'] + '.xlsx'

--- a/server/src/sim/plotccocs.py
+++ b/server/src/sim/plotccocs.py
@@ -18,7 +18,6 @@ default_ccparams = {'saturation': .7,
                     'funding':9e6,
                     'scaleup':.2,
                     'nonhivdalys':nan,
-                    'xupperlim':2e7,
                     'cpibaseyear':nan,
                     'perperson':nan}
 default_coparams = [0.15, 0.3, 0.4, 0.55]

--- a/server/src/sim/run_makeccocs.py
+++ b/server/src/sim/run_makeccocs.py
@@ -38,7 +38,6 @@ ccparams = {'saturation': 0.9,
           'funding':800000.0, 
           'scaleup':None, 
           'nonhivdalys':None, 
-          'xupperlim':1000000, 
           'cpibaseyear':None, 
           'perperson':None}
 plotall(D=D, coparams=[], ccparams=ccparams)

--- a/server/src/sim/updatedata.py
+++ b/server/src/sim/updatedata.py
@@ -51,7 +51,6 @@ def addtoprograms(programs):
                                             'funding':None, 
                                             'scaleup':None, 
                                             'nonhivdalys':None, 
-                                            'xupperlim':None, 
                                             'cpibaseyear':None, 
                                             'perperson':None}
         programs[prognumber]['convertedccparams'] = None


### PR DESCRIPTION
The PR has fix for this issue:

https://trello.com/c/p2FsooQi/621-remove-the-5th-option-from-cost-coverage-chart

The param is still mentioned in 004_fix_ccparams.py, but I think that old insignificant file.