### PR TITLE
Increasing the width of a couple of text boxes on cost coverage page

### DIFF
--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -60,7 +60,7 @@
 
                 <div class="section">
                   1. Specify the saturation coverage level:
-                  <input type="number" class="txbox __inline __m"
+                  <input type="number" class="txbox __inline __l"
                          name="saturationCoverageLevel"
                          min="1" max="100" step="1"
                          placeholder="e.g. 90"
@@ -79,7 +79,7 @@
                 </div>
                 <div class="section">
                   2. The estimated amount of funding needed to get between
-                  <input type="number" class="txbox __inline __m"
+                  <input type="number" class="txbox __inline __l"
                          name="knownMinCoverageLevel"
                          min="1" max="100"
                          placeholder="e.g. 50"
@@ -88,7 +88,7 @@
                          ng-required="costCoverageFormIsPartlyFilledOut()"
                          ng-change="updateCurves()">%
                   and
-                  <input type="number" class="txbox __inline __m"
+                  <input type="number" class="txbox __inline __l"
                          name="knownMaxCoverageLevel"
                          min="1" max="100"
                          placeholder="e.g. 60"


### PR DESCRIPTION
The PR will fix following issue:
https://trello.com/c/swlw2IGi/606-example-values-on-define-cost-coverage-define-objectives-are-cut-off-or-missing