### PR TITLE
Increasing width of text boxes on optimization analyses page

### DIFF
--- a/client/source/js/modules/analysis/optimization.html
+++ b/client/source/js/modules/analysis/optimization.html
@@ -151,8 +151,13 @@
                 <label>
                   <input type="radio" name="artcontinue" ng-model="params.objectives.artcontinue" value="4">
                   ART coverage will scale up, reaching
-                  <input type="number" class="txbox __inline __l" value="90"
+                  <input type="number"
+                         class="txbox __inline __m"
+                         value="90"
                          placeholder="e.g. 90"
+                         min="0"
+                         max="100"
+                         name="universalcov"
                          ng-model="params.objectives.year.universalcov">%
                   coverage of treatment-eligible people by
                   <input type="number" class="txbox __inline __l"
@@ -162,6 +167,14 @@
                          step="1"
                          ng-model="params.objectives.year.universal">
                   and then be maintained
+
+                  <div ng-messages="state.OptimizationForm.universalcov.$error"
+                       ng-show="state.OptimizationForm.universalcov.$touched && state.OptimizationForm.universalcov.$invalid">
+                    <div class="error-hint" ng-message="required">Please provide a value for ART coverage</div>
+                    <div class="error-hint" ng-message="min">The minimum percentage of ART coverage can only be 0</div>
+                    <div class="error-hint" ng-message="max">The maximum percentage of ART coverage can only be 0</div>
+                    <div class="error-hint" ng-message="number">The value of ART coverage should be a number</div>
+                  </div>
 
                   <div ng-messages="state.OptimizationForm.universal.$error"
                        ng-show="state.OptimizationForm.universal.$touched && state.OptimizationForm.universal.$invalid">

--- a/client/source/js/modules/analysis/optimization.html
+++ b/client/source/js/modules/analysis/optimization.html
@@ -151,7 +151,7 @@
                 <label>
                   <input type="radio" name="artcontinue" ng-model="params.objectives.artcontinue" value="4">
                   ART coverage will scale up, reaching
-                  <input type="number" class="txbox __inline __s" value="90"
+                  <input type="number" class="txbox __inline __l" value="90"
                          placeholder="e.g. 90"
                          ng-model="params.objectives.year.universalcov">%
                   coverage of treatment-eligible people by
@@ -228,7 +228,7 @@
                          required />
                   Optimize a fixed budget of total amount
                   <input type="number"
-                         class="txbox __inline __l"
+                         class="txbox __inline __xl"
                          ng-required="params.objectives.funding==='constant'"
                          ng-model="params.objectives.outcome.fixed"
                          min="0"


### PR DESCRIPTION
The PR has fix for:
https://trello.com/c/qtqI80p7/624-example-value-on-optimization-analysis-define-constrains-page-is-not-visible-in-1920x1080