### PR TITLE
Fixing bug - labels not present when we down mpld3 chart as svg

### DIFF
--- a/client/source/js/modules/common/chart-toolbar-directive.js
+++ b/client/source/js/modules/common/chart-toolbar-directive.js
@@ -142,7 +142,7 @@ define(['angular', 'jquery', 'mpld3', 'underscore', 'saveAs', 'jsPDF', './svg-to
             var $originalSvg = elem.parent().find('svg');
             var orginalWidth = $originalSvg.width();
             var orginalHeight = $originalSvg.height();
-            if (isMpld3) {
+            if (scope.chartType === 'mpld3') {
               originalStyle = 'padding: ' + $originalSvg.css('padding');
             } else {
               originalStyle = $originalSvg.attr('style');


### PR DESCRIPTION
Fix for bug:
https://trello.com/c/xblSlXCl/631-y-axis-name-is-cut-off-when-export-figure-as-svg