### PR TITLE
Bug/625 it s not possible to enter value next to what is the minimum amount of money required

### DIFF
--- a/client/source/js/modules/analysis/optimization-ctrl.js
+++ b/client/source/js/modules/analysis/optimization-ctrl.js
@@ -69,7 +69,9 @@ define(['./module', 'angular', 'underscore'], function (module, angular, _) {
       // inside a wrapper object. This is due the fact that directives like ng-if
       // always create a child scope & the reference can get lost.
       // see https://github.com/angular/angular.js/wiki/Understanding-Scopes
-      $scope.state = {};
+
+      //This line is setting already existing state to blank again
+      //$scope.state = {};
       $scope.state.chartsForDataExport = [];
       $scope.state.types = typeSelector.types;
 

--- a/client/source/js/modules/analysis/optimization-ctrl.js
+++ b/client/source/js/modules/analysis/optimization-ctrl.js
@@ -42,19 +42,42 @@ define(['./module', 'angular', 'underscore'], function (module, angular, _) {
         activeTab: 1,
         activeOptimizationName: undefined,
         isTestRun: false,
-        timelimit: 3600
+        timelimit: 3600,
+        chartsForDataExport: [],
+        types: typeSelector.types,
+        moneyObjectives: [
+          { id: 'inci', title: 'Reduce the annual incidence of HIV' },
+          { id: 'incisex', title: 'Reduce the annual incidence of sexually transmitted HIV' },
+          { id: 'inciinj', title: 'Reduce the annual incidence of injecting-related HIV' },
+          { id: 'mtct', title: 'Reduce annual mother-to-child transmission of HIV' },
+          { id: 'mtctbreast', title: 'Reduce annual mother-to-child transmission of HIV among breastfeeding mothers' },
+          { id: 'mtctnonbreast', title: 'Reduce annual mother-to-child transmission of HIV among non-breastfeeding mothers' },
+          { id: 'deaths', title: 'Reduce annual AIDS-related deaths' },
+          { id: 'dalys', title: 'Reduce annual HIV-related DALYs' }
+        ],
+        objectivesToMinimize: [
+          {
+            name: "Cumulative new HIV infections",
+            slug: "inci",
+            title: "New infections weighting"
+          },
+          {
+            name: "Cumulative DALYs",
+            slug: "daly",
+            title: "DALYs weighting"
+          },
+          {
+            name: " Cumulative AIDS-related deaths",
+            slug: "death",
+            title: "Deaths weighting"
+          },
+          {
+            name: "Total HIV-related costs",
+            slug: "costann",
+            title: "Costs weighting"
+          }
+        ]
       };
-
-      $scope.state.moneyObjectives = [
-        { id: 'inci', title: 'Reduce the annual incidence of HIV' },
-        { id: 'incisex', title: 'Reduce the annual incidence of sexually transmitted HIV' },
-        { id: 'inciinj', title: 'Reduce the annual incidence of injecting-related HIV' },
-        { id: 'mtct', title: 'Reduce annual mother-to-child transmission of HIV' },
-        { id: 'mtctbreast', title: 'Reduce annual mother-to-child transmission of HIV among breastfeeding mothers' },
-        { id: 'mtctnonbreast', title: 'Reduce annual mother-to-child transmission of HIV among non-breastfeeding mothers' },
-        { id: 'deaths', title: 'Reduce annual AIDS-related deaths' },
-        { id: 'dalys', title: 'Reduce annual HIV-related DALYs' }
-      ];
 
       resetCharts();
 
@@ -65,17 +88,6 @@ define(['./module', 'angular', 'underscore'], function (module, angular, _) {
         return;
       }
 
-      // According to angular best-practices we should wrap every object/value
-      // inside a wrapper object. This is due the fact that directives like ng-if
-      // always create a child scope & the reference can get lost.
-      // see https://github.com/angular/angular.js/wiki/Understanding-Scopes
-
-      //This line is setting already existing state to blank again
-      //$scope.state = {};
-      $scope.state.chartsForDataExport = [];
-      $scope.state.types = typeSelector.types;
-
-      $scope.state.activeTab = 1;
       var errorMessages = [];
 
       // Set defaults
@@ -138,29 +150,6 @@ define(['./module', 'angular', 'underscore'], function (module, angular, _) {
           $scope.params.constraints.coverage[j].year = undefined;
         }
       }
-
-      $scope.state.objectivesToMinimize = [
-        {
-          name: "Cumulative new HIV infections",
-          slug: "inci",
-          title: "New infections weighting"
-        },
-        {
-          name: "Cumulative DALYs",
-          slug: "daly",
-          title: "DALYs weighting"
-        },
-        {
-          name: " Cumulative AIDS-related deaths",
-          slug: "death",
-          title: "Deaths weighting"
-        },
-        {
-          name: "Total HIV-related costs",
-          slug: "costann",
-          title: "Costs weighting"
-        }
-      ];
 
       // The graphs are shown/hidden after updating the graph type checkboxes.
       $scope.$watch('types', drawGraphs, true);

--- a/client/source/js/modules/analysis/optimization.html
+++ b/client/source/js/modules/analysis/optimization.html
@@ -224,9 +224,8 @@
           </div>
         </div>
 
-        <hr class="__dashed" style="clear: both; padding-top: 10px"/>
-
         <div class="section" ng-if="params.objectives.what == 'outcome'">
+          <hr class="__dashed" style="clear: both; padding-top: 10px"/>
 
           <h2>Funding assumptions</h2>
           <div class="float-left margin-left-s">
@@ -358,12 +357,12 @@
           </div>
         </div>
 
-        <hr style="clear: both; padding-top: 10px" class="__dashed"/>
-
         <div class="section" ng-if="params.objectives.what == 'outcome'">
+          <hr style="clear: both; padding-top: 10px" class="__dashed"/>
+
           <ng-form name="state.objectivesToMinimizeForm">
             <h2>Objective(s) to minimize</h2>
-            <div ng-repeat="objective in ::state.objectivesToMinimize" class="checkbox-block">
+            <div class="indented" ng-repeat="objective in ::state.objectivesToMinimize" class="checkbox-block">
               <label>
                 <input type="checkbox"
                        ng-model="params.objectives.outcome[objective.slug]"
@@ -382,7 +381,7 @@
 
           <ng-form name="state.outcomeWeightsForm">
 
-            <div ng-repeat="objective in ::state.objectivesToMinimize" ng-if="params.objectives.outcome[objective.slug] === true">
+            <div class="indented" ng-repeat="objective in ::state.objectivesToMinimize" ng-if="params.objectives.outcome[objective.slug] === true">
               <div class="objective-checkbox">
                 <div class="objective-checkbox__title"> {{ ::objective.title }} =</div>
                 <input type="number"
@@ -408,9 +407,11 @@
 
 
         <div class="section" ng-if="params.objectives.what == 'money'">
+          <hr style="clear: both; padding-top: 10px" class="__dashed"/>
+
           What is the minimum amount of money required to achieve the following objectives:
 
-          <div class="margin-top-xs" ng-repeat="item in ::state.moneyObjectives">
+          <div class="margin-top-xs indented" ng-repeat="item in ::state.moneyObjectives">
             <div class="checkbox-block">
               <label ng-init="iObjective = params.objectives.money.objectives[item.id]">
                 <input type="checkbox" ng-model="iObjective.use">
@@ -493,7 +494,7 @@
           <div class="cf margin-top-s">
             <h2>Cost assumptions</h2>
 
-            <div class="float-left margin-left-xs">
+            <div class="indented">
               <table class="table table-bordered table-hover table-striped" style="width: auto">
                 <thead>
                 <tr>

--- a/client/source/js/modules/analysis/optimization.html
+++ b/client/source/js/modules/analysis/optimization.html
@@ -152,7 +152,7 @@
                   <input type="radio" name="artcontinue" ng-model="params.objectives.artcontinue" value="4">
                   ART coverage will scale up, reaching
                   <input type="number"
-                         class="txbox __inline __m"
+                         class="txbox __inline __l"
                          value="90"
                          placeholder="e.g. 90"
                          min="0"


### PR DESCRIPTION
The PR has fix for:

1. Bug - https://trello.com/c/RObEWqyZ/625-it-s-not-possible-to-enter-value-next-to-what-is-the-minimum-amount-of-money-required-to-achieve-the-following-objectives-on-opt

2. Minor change of textbox width mentioned by Natalia: https://trello.com/c/qtqI80p7/624-example-value-on-optimization-analysis-define-constrains-page-is-not-visible-in-1920x1080

3. More layout changes as suggested by Natalia in: https://trello.com/c/MYWa4xlq/593-inadequate-line-spacing