### PR TITLE
Feature/remove mpld3 from sim

### DIFF
--- a/server/src/optima/model.py
+++ b/server/src/optima/model.py
@@ -16,8 +16,8 @@ from signal import *
 from optima.dbconn import db
 from sim.autofit import autofit
 from sim.updatedata import updatedata
-from sim.plotccocs import plot_cost_outcome, plot_coverage_outcome
-from optima.plotting import generate_cost_coverage_chart
+from sim.plotccocs import plot_cost_outcome
+from optima.plotting import generate_cost_coverage_chart, generate_coverage_outcome_chart
 
 # route prefix: /api/model
 model = Blueprint('model',  __name__, static_folder = '../static')
@@ -328,7 +328,7 @@ def doCostCoverage(): # pylint: disable=R0914
         figsize = (3,2)
         plotdata_cco, plotdata_co, plotdata_cc, effectnames, D = plotallcurves(**args)
         dict_fig_cc = generate_cost_coverage_chart(plotdata_cc)
-        dict_fig_co = map(lambda key: plot_coverage_outcome(plotdata_co[key], figsize), plotdata_co.keys())
+        dict_fig_co = map(lambda key: generate_coverage_outcome_chart(plotdata_co[key]), plotdata_co.keys())
         dict_fig_cco = map(lambda key: plot_cost_outcome(plotdata_cco[key], figsize), plotdata_cco.keys())
         if do_save:
             D_dict = tojson(D)
@@ -361,7 +361,7 @@ def doCostCoverageEffect():
         # effectnames are actually effects
         figsize = (3,2)
         plotdata, plotdata_co, _ = makecco(**args) # plotdata is actually plotdata_cco
-        dict_fig_co = plot_coverage_outcome(plotdata_co, figsize)
+        dict_fig_co = generate_coverage_outcome_chart(plotdata_co)
         dict_fig_cco = plot_cost_outcome(plotdata, figsize)
     except Exception:
         var = traceback.format_exc()

--- a/server/src/optima/model.py
+++ b/server/src/optima/model.py
@@ -16,8 +16,7 @@ from signal import *
 from optima.dbconn import db
 from sim.autofit import autofit
 from sim.updatedata import updatedata
-from sim.plotccocs import plot_cost_outcome
-from optima.plotting import generate_cost_coverage_chart, generate_coverage_outcome_chart
+from optima.plotting import generate_cost_coverage_chart, generate_coverage_outcome_chart, generate_cost_outcome_chart
 
 # route prefix: /api/model
 model = Blueprint('model',  __name__, static_folder = '../static')
@@ -325,11 +324,10 @@ def doCostCoverage(): # pylint: disable=R0914
             D['programs'][programIndex]['effects'] = new_effects
         args['D'] = D
         # effectnames are actually effects
-        figsize = (3,2)
         plotdata_cco, plotdata_co, plotdata_cc, effectnames, D = plotallcurves(**args)
         dict_fig_cc = generate_cost_coverage_chart(plotdata_cc)
         dict_fig_co = map(lambda key: generate_coverage_outcome_chart(plotdata_co[key]), plotdata_co.keys())
-        dict_fig_cco = map(lambda key: plot_cost_outcome(plotdata_cco[key], figsize), plotdata_cco.keys())
+        dict_fig_cco = map(lambda key: generate_cost_outcome_chart(plotdata_cco[key]), plotdata_cco.keys())
         if do_save:
             D_dict = tojson(D)
             save_model(request.project_id, D_dict)
@@ -359,10 +357,9 @@ def doCostCoverageEffect():
         if args.get('coparams'):
             args['coparams'] = map(lambda param: float(param) if param or (type(param) is int and param == 0) else None, args['coparams'])
         # effectnames are actually effects
-        figsize = (3,2)
         plotdata, plotdata_co, _ = makecco(**args) # plotdata is actually plotdata_cco
         dict_fig_co = generate_coverage_outcome_chart(plotdata_co)
-        dict_fig_cco = plot_cost_outcome(plotdata, figsize)
+        dict_fig_cco = generate_cost_outcome_chart(plotdata)
     except Exception:
         var = traceback.format_exc()
         return jsonify({"exception":var}), 500

--- a/server/src/optima/model.py
+++ b/server/src/optima/model.py
@@ -16,7 +16,8 @@ from signal import *
 from optima.dbconn import db
 from sim.autofit import autofit
 from sim.updatedata import updatedata
-from sim.plotccocs import plot_cost_coverage, plot_cost_outcome, plot_coverage_outcome
+from sim.plotccocs import plot_cost_outcome, plot_coverage_outcome
+from optima.plotting import generate_cost_coverage_chart
 
 # route prefix: /api/model
 model = Blueprint('model',  __name__, static_folder = '../static')
@@ -326,7 +327,7 @@ def doCostCoverage(): # pylint: disable=R0914
         # effectnames are actually effects
         figsize = (3,2)
         plotdata_cco, plotdata_co, plotdata_cc, effectnames, D = plotallcurves(**args)
-        dict_fig_cc = plot_cost_coverage(plotdata_cc, figsize)
+        dict_fig_cc = generate_cost_coverage_chart(plotdata_cc)
         dict_fig_co = map(lambda key: plot_coverage_outcome(plotdata_co[key], figsize), plotdata_co.keys())
         dict_fig_cco = map(lambda key: plot_cost_outcome(plotdata_cco[key], figsize), plotdata_cco.keys())
         if do_save:

--- a/server/src/optima/plotting.py
+++ b/server/src/optima/plotting.py
@@ -62,3 +62,27 @@ def generate_coverage_outcome_chart(plotdata):
     close(coverage_outcome_figure)
 
     return result
+
+def generate_cost_outcome_chart(plotdata):
+    """ Returns the cost-outcome chart as Mpld3 JSON format """
+
+    blank_figure = figure(figsize=(3,2), dpi=100)
+    cost_outcome_figure = plot_cost_outcome(plotdata, figure=blank_figure, closeFigure=False)
+
+    # clear all plugins from the figure
+    plugins.clear(cost_outcome_figure)
+    plugins.connect(
+        cost_outcome_figure,
+        # Box zoom is needed to manually create a zoom button in the JS front-end
+        plugins.BoxZoom(button=False, enabled=False),
+        OptimaTickFormatter())
+
+    result = fig_to_dict(cost_outcome_figure)
+
+    # close figure
+    axis = cost_outcome_figure.gca()
+    axis.cla()
+    cost_outcome_figure.clf()
+    close(cost_outcome_figure)
+
+    return result

--- a/server/src/optima/plotting.py
+++ b/server/src/optima/plotting.py
@@ -19,7 +19,7 @@ def generate_cost_coverage_chart(plotdata):
     """ Returns the cost-coverage chart as Mpld3 JSON format """
 
     blank_figure = figure(figsize=(3,2), dpi=100)
-    cost_coverage_figure = plot_cost_coverage(plotdata, figure=blank_figure, closeFigure=False)
+    cost_coverage_figure = plot_cost_coverage(plotdata, figure=blank_figure)
 
     # clear all plugins from the figure
     plugins.clear(cost_coverage_figure)
@@ -43,7 +43,7 @@ def generate_coverage_outcome_chart(plotdata):
     """ Returns the coverage-outcome chart as Mpld3 JSON format """
 
     blank_figure = figure(figsize=(3,2), dpi=100)
-    coverage_outcome_figure = plot_coverage_outcome(plotdata, figure=blank_figure, closeFigure=False)
+    coverage_outcome_figure = plot_coverage_outcome(plotdata, figure=blank_figure)
 
     # clear all plugins from the figure
     plugins.clear(coverage_outcome_figure)
@@ -67,7 +67,7 @@ def generate_cost_outcome_chart(plotdata):
     """ Returns the cost-outcome chart as Mpld3 JSON format """
 
     blank_figure = figure(figsize=(3,2), dpi=100)
-    cost_outcome_figure = plot_cost_outcome(plotdata, figure=blank_figure, closeFigure=False)
+    cost_outcome_figure = plot_cost_outcome(plotdata, figure=blank_figure)
 
     # clear all plugins from the figure
     plugins.clear(cost_outcome_figure)

--- a/server/src/optima/plotting.py
+++ b/server/src/optima/plotting.py
@@ -1,0 +1,40 @@
+from matplotlib.pylab import figure
+from matplotlib.pyplot import close
+from mpld3 import plugins, fig_to_dict
+from sim.plotccocs import plot_cost_coverage, plot_cost_outcome, plot_coverage_outcome
+
+class OptimaTickFormatter(plugins.PluginBase):
+    """
+    Optima Tick Formatter plugin
+
+    Since tickFormatting is not working properly we patch & customise it only in
+    the Front-end. See this issue for more information about the current status
+    of tick customisation: https://github.com/jakevdp/mpld3/issues/22
+    """
+
+    def __init__(self):
+        self.dict_ = {"type": "optimaTickFormatter"}
+
+def generate_cost_coverage_chart(plotdata):
+    """ Returns the cost-coverage figure in the Mpld3 JSON format """
+
+    blank_figure = figure(figsize=(3,2), dpi=100)
+    cost_coverage_figure = plot_cost_coverage(plotdata, figure=blank_figure, closeFigure=False)
+
+    # clear all plugins from the figure
+    plugins.clear(cost_coverage_figure)
+    plugins.connect(
+        cost_coverage_figure,
+        # Box zoom is needed to manually create a zoom button in the JS front-end
+        plugins.BoxZoom(button=False, enabled=False),
+        OptimaTickFormatter())
+
+    result = fig_to_dict(cost_coverage_figure)
+
+    # close figure
+    axis = cost_coverage_figure.gca()
+    axis.cla()
+    cost_coverage_figure.clf()
+    close(cost_coverage_figure)
+
+    return result

--- a/server/src/optima/plotting.py
+++ b/server/src/optima/plotting.py
@@ -15,27 +15,39 @@ class OptimaTickFormatter(plugins.PluginBase):
     def __init__(self):
         self.dict_ = {"type": "optimaTickFormatter"}
 
-def generate_cost_coverage_chart(plotdata):
-    """ Returns the cost-coverage chart as Mpld3 JSON format """
+def update_mpld3_plugins(chart):
+    """
+    Clears all existing plugings and set up the ones specific to Optima
 
-    blank_figure = figure(figsize=(3,2), dpi=100)
-    cost_coverage_figure = plot_cost_coverage(plotdata, figure=blank_figure)
-
-    # clear all plugins from the figure
-    plugins.clear(cost_coverage_figure)
+    This function modifies the figure passed in as parameter.
+    """
+    plugins.clear(chart)
     plugins.connect(
-        cost_coverage_figure,
+        chart,
         # Box zoom is needed to manually create a zoom button in the JS front-end
         plugins.BoxZoom(button=False, enabled=False),
         OptimaTickFormatter())
 
-    result = fig_to_dict(cost_coverage_figure)
+def close_figure(chart):
+    """
+    Clears & close the provided figure and it's axis.
 
-    # close figure
-    axis = cost_coverage_figure.gca()
+    This function modifies the figure passed in as parameter.
+    """
+    axis = chart.gca()
     axis.cla()
-    cost_coverage_figure.clf()
-    close(cost_coverage_figure)
+    chart.clf()
+    close(chart)
+
+def generate_cost_coverage_chart(plotdata):
+    """ Returns the cost-coverage chart as Mpld3 JSON format """
+
+    blank_figure = figure(figsize=(3,2), dpi=100)
+    cost_coverage_figure = plot_cost_coverage(plotdata, existingFigure=blank_figure)
+
+    update_mpld3_plugins(cost_coverage_figure)
+    result = fig_to_dict(cost_coverage_figure)
+    close_figure(cost_coverage_figure)
 
     return result
 
@@ -43,23 +55,11 @@ def generate_coverage_outcome_chart(plotdata):
     """ Returns the coverage-outcome chart as Mpld3 JSON format """
 
     blank_figure = figure(figsize=(3,2), dpi=100)
-    coverage_outcome_figure = plot_coverage_outcome(plotdata, figure=blank_figure)
+    coverage_outcome_figure = plot_coverage_outcome(plotdata, existingFigure=blank_figure)
 
-    # clear all plugins from the figure
-    plugins.clear(coverage_outcome_figure)
-    plugins.connect(
-        coverage_outcome_figure,
-        # Box zoom is needed to manually create a zoom button in the JS front-end
-        plugins.BoxZoom(button=False, enabled=False),
-        OptimaTickFormatter())
-
+    update_mpld3_plugins(coverage_outcome_figure)
     result = fig_to_dict(coverage_outcome_figure)
-
-    # close figure
-    axis = coverage_outcome_figure.gca()
-    axis.cla()
-    coverage_outcome_figure.clf()
-    close(coverage_outcome_figure)
+    close_figure(coverage_outcome_figure)
 
     return result
 
@@ -67,22 +67,10 @@ def generate_cost_outcome_chart(plotdata):
     """ Returns the cost-outcome chart as Mpld3 JSON format """
 
     blank_figure = figure(figsize=(3,2), dpi=100)
-    cost_outcome_figure = plot_cost_outcome(plotdata, figure=blank_figure)
+    cost_outcome_figure = plot_cost_outcome(plotdata, existingFigure=blank_figure)
 
-    # clear all plugins from the figure
-    plugins.clear(cost_outcome_figure)
-    plugins.connect(
-        cost_outcome_figure,
-        # Box zoom is needed to manually create a zoom button in the JS front-end
-        plugins.BoxZoom(button=False, enabled=False),
-        OptimaTickFormatter())
-
+    update_mpld3_plugins(cost_outcome_figure)
     result = fig_to_dict(cost_outcome_figure)
-
-    # close figure
-    axis = cost_outcome_figure.gca()
-    axis.cla()
-    cost_outcome_figure.clf()
-    close(cost_outcome_figure)
+    close_figure(cost_outcome_figure)
 
     return result

--- a/server/src/optima/plotting.py
+++ b/server/src/optima/plotting.py
@@ -16,7 +16,7 @@ class OptimaTickFormatter(plugins.PluginBase):
         self.dict_ = {"type": "optimaTickFormatter"}
 
 def generate_cost_coverage_chart(plotdata):
-    """ Returns the cost-coverage figure in the Mpld3 JSON format """
+    """ Returns the cost-coverage chart as Mpld3 JSON format """
 
     blank_figure = figure(figsize=(3,2), dpi=100)
     cost_coverage_figure = plot_cost_coverage(plotdata, figure=blank_figure, closeFigure=False)
@@ -36,5 +36,29 @@ def generate_cost_coverage_chart(plotdata):
     axis.cla()
     cost_coverage_figure.clf()
     close(cost_coverage_figure)
+
+    return result
+
+def generate_coverage_outcome_chart(plotdata):
+    """ Returns the coverage-outcome chart as Mpld3 JSON format """
+
+    blank_figure = figure(figsize=(3,2), dpi=100)
+    coverage_outcome_figure = plot_coverage_outcome(plotdata, figure=blank_figure, closeFigure=False)
+
+    # clear all plugins from the figure
+    plugins.clear(coverage_outcome_figure)
+    plugins.connect(
+        coverage_outcome_figure,
+        # Box zoom is needed to manually create a zoom button in the JS front-end
+        plugins.BoxZoom(button=False, enabled=False),
+        OptimaTickFormatter())
+
+    result = fig_to_dict(coverage_outcome_figure)
+
+    # close figure
+    axis = coverage_outcome_figure.gca()
+    axis.cla()
+    coverage_outcome_figure.clf()
+    close(coverage_outcome_figure)
 
     return result

--- a/server/src/sim/plotccocs.py
+++ b/server/src/sim/plotccocs.py
@@ -26,10 +26,10 @@ coverage_params = ['numost','numpmtct','numfirstline','numsecondline']
 ###############################################################################
 from makeccocs import makecc, makeco, makecco
 ###############################################################################
-def plot_cost_coverage(plotdata, figure=None, closeFigure=True):
+def plot_cost_coverage(plotdata, existingFigure=None, closeFigure=True):
     """ Plot the cost-coverage figure """
 
-    cost_coverage_figure = figure if figure else figure()
+    cost_coverage_figure = existingFigure if existingFigure else figure()
     cost_coverage_figure.hold(True)
 
     axis = cost_coverage_figure.gca()
@@ -81,13 +81,13 @@ def plotcc(D, progname=default_progname, ccparams=default_ccparams, arteligcutof
     plot_cost_coverage(plotdata_cc)
 
 ###############################################################################
-def plot_coverage_outcome(plotdata, figure=None, closeFigure=True):
+def plot_coverage_outcome(plotdata, existingFigure=None, closeFigure=True):
     """ Plot the coverage-outcome figure """
 
     if not plotdata:
         return None
 
-    coverage_outcome_figure = figure if figure else figure()
+    coverage_outcome_figure = existingFigure if existingFigure else figure()
     coverage_outcome_figure.hold(True)
 
     axis = coverage_outcome_figure.gca()
@@ -139,13 +139,13 @@ def plotco(D, progname=default_progname, effect=default_effect, coparams=default
     plot_coverage_outcome(plotdata_co)
 
 #################################################################################
-def plot_cost_outcome(plotdata, figure=None, closeFigure=True):
+def plot_cost_outcome(plotdata, existingFigure=None, closeFigure=True):
     """ Plot the cost-outcome figure """
 
     if not plotdata:
         return None
 
-    cost_outcome_figure = figure if figure else figure()
+    cost_outcome_figure = existingFigure if existingFigure else figure()
     cost_outcome_figure.hold(True)
 
     axis = cost_outcome_figure.gca()

--- a/server/src/sim/plotccocs.py
+++ b/server/src/sim/plotccocs.py
@@ -83,64 +83,55 @@ def plotcc(D, progname=default_progname, ccparams=default_ccparams, arteligcutof
     plot_cost_coverage(plotdata_cc)
 
 ###############################################################################
-def plot_coverage_outcome(plotdata, figsize = None):
+def plot_coverage_outcome(plotdata, figure=None, closeFigure=True):
     """ Plot the coverage-outcome figure """
-    result = None
-    coverage_outcome_figure = None
-    if plotdata:
-        if figsize:
-            coverage_outcome_figure = figure(figsize = figsize, dpi=100)
-        else:
-            coverage_outcome_figure = figure()
-        coverage_outcome_figure.hold(True)
 
-        axis = coverage_outcome_figure.gca()
+    if plotdata == None:
+        return None
 
-        if 'xlinedata' in plotdata.keys():
-            axis.plot(
-                plotdata['xlinedata'],
-                plotdata['ylinedata'][0],
-                linestyle='-',
-                linewidth=2,
-                color='#a6cee3')
-            axis.plot(
-                plotdata['xlinedata'],
-                plotdata['ylinedata'][1],
-                linestyle='--',
-                linewidth=2,
-                color='#000000')
-            axis.plot(
-                plotdata['xlinedata'],
-                plotdata['ylinedata'][2],
-                linestyle='--',
-                linewidth=2,
-                color='#000000')
-        axis.scatter(
-            plotdata['xscatterdata'],
-            plotdata['yscatterdata'],
-            color='#666666')
+    coverage_outcome_figure = figure if figure else figure()
+    coverage_outcome_figure.hold(True)
 
-        axis.set_title(plotdata['title'])
-        axis.tick_params(axis='both', which='major', labelsize=11)
-        axis.set_xlabel(plotdata['xlabel'], fontsize=11)
-        axis.set_ylabel(plotdata['ylabel'], fontsize=11)
-        axis.get_xaxis().set_major_locator(MaxNLocator(nbins=3))
-        axis.set_xlim([plotdata['xlowerlim'], plotdata['xupperlim']])
-        axis.set_ylim([plotdata['ylowerlim'], plotdata['yupperlim']])
+    axis = coverage_outcome_figure.gca()
 
-        # clear all plugins from the figure
-        plugins.clear(coverage_outcome_figure)
-        plugins.connect(
-            coverage_outcome_figure,
-            # Box zoom is needed to manually create a zoom button in the JS front-end
-            plugins.BoxZoom(button=False, enabled=False),
-            OptimaTickFormatter())
+    if 'xlinedata' in plotdata.keys():
+        axis.plot(
+            plotdata['xlinedata'],
+            plotdata['ylinedata'][0],
+            linestyle='-',
+            linewidth=2,
+            color='#a6cee3')
+        axis.plot(
+            plotdata['xlinedata'],
+            plotdata['ylinedata'][1],
+            linestyle='--',
+            linewidth=2,
+            color='#000000')
+        axis.plot(
+            plotdata['xlinedata'],
+            plotdata['ylinedata'][2],
+            linestyle='--',
+            linewidth=2,
+            color='#000000')
+    axis.scatter(
+        plotdata['xscatterdata'],
+        plotdata['yscatterdata'],
+        color='#666666')
 
-        result = fig_to_dict(coverage_outcome_figure)
+    axis.set_title(plotdata['title'])
+    axis.tick_params(axis='both', which='major', labelsize=11)
+    axis.set_xlabel(plotdata['xlabel'], fontsize=11)
+    axis.set_ylabel(plotdata['ylabel'], fontsize=11)
+    axis.get_xaxis().set_major_locator(MaxNLocator(nbins=3))
+    axis.set_xlim([plotdata['xlowerlim'], plotdata['xupperlim']])
+    axis.set_ylim([plotdata['ylowerlim'], plotdata['yupperlim']])
+
+    if closeFigure:
         coverage_outcome_figure.clf()
         axis.cla()
         close(coverage_outcome_figure)
-    return result
+
+    return coverage_outcome_figure
 
 
 def plotco(D, progname=default_progname, effect=default_effect, coparams=default_coparams, arteligcutoff=default_arteligcutoff):

--- a/server/src/sim/plotccocs.py
+++ b/server/src/sim/plotccocs.py
@@ -7,8 +7,6 @@ from matplotlib.pylab import figure
 from matplotlib.pyplot import close
 from matplotlib.ticker import MaxNLocator
 from numpy import nan
-from mpld3 import plugins, fig_to_dict
-from utils import OptimaTickFormatter
 
 # Set defaults for testing makeccocs
 default_progname = 'NSP'

--- a/server/src/sim/plotccocs.py
+++ b/server/src/sim/plotccocs.py
@@ -3,7 +3,7 @@ Plots cost-coverage, coverage-outcome and cost-outcome curves
 
 Version: 2015jan19 by robynstuart
 """
-from matplotlib.pylab import figure #plot, hold, xlabel, ylabel, title, xlim, ylim, gca, scatter
+from matplotlib.pylab import figure
 from matplotlib.pyplot import close
 from matplotlib.ticker import MaxNLocator
 from numpy import nan
@@ -28,16 +28,10 @@ coverage_params = ['numost','numpmtct','numfirstline','numsecondline']
 ###############################################################################
 from makeccocs import makecc, makeco, makecco
 ###############################################################################
-def plot_cost_coverage(plotdata, figsize=None):
+def plot_cost_coverage(plotdata, figure=None, closeFigure=True):
     """ Plot the cost-coverage figure """
 
-    result = None
-    cost_coverage_figure = None
-    if figsize:
-        cost_coverage_figure = figure(figsize=figsize, dpi=100)
-    else:
-        cost_coverage_figure = figure()
-
+    cost_coverage_figure = figure if figure else figure()
     cost_coverage_figure.hold(True)
 
     axis = cost_coverage_figure.gca()
@@ -74,20 +68,12 @@ def plot_cost_coverage(plotdata, figsize=None):
     axis.get_xaxis().set_major_locator(MaxNLocator(nbins=3))
     axis.set_title(plotdata['title'])
 
-    # clear all plugins from the figure
-    plugins.clear(cost_coverage_figure)
-    plugins.connect(
-        cost_coverage_figure,
-        # Box zoom is needed to manually create a zoom button in the JS front-end
-        plugins.BoxZoom(button=False, enabled=False),
-        OptimaTickFormatter())
+    if closeFigure:
+        cost_coverage_figure.clf()
+        axis.cla()
+        close(cost_coverage_figure)
 
-    result = fig_to_dict(cost_coverage_figure)
-    cost_coverage_figure.clf()
-    axis.cla()
-    close(cost_coverage_figure)
-
-    return result
+    return cost_coverage_figure
 
 
 def plotcc(D, progname=default_progname, ccparams=default_ccparams, arteligcutoff=default_arteligcutoff):

--- a/server/src/sim/plotccocs.py
+++ b/server/src/sim/plotccocs.py
@@ -26,7 +26,7 @@ coverage_params = ['numost','numpmtct','numfirstline','numsecondline']
 ###############################################################################
 from makeccocs import makecc, makeco, makecco
 ###############################################################################
-def plot_cost_coverage(plotdata, existingFigure=None, closeFigure=True):
+def plot_cost_coverage(plotdata, existingFigure=None):
     """ Plot the cost-coverage figure """
 
     cost_coverage_figure = existingFigure if existingFigure else figure()
@@ -66,11 +66,6 @@ def plot_cost_coverage(plotdata, existingFigure=None, closeFigure=True):
     axis.get_xaxis().set_major_locator(MaxNLocator(nbins=3))
     axis.set_title(plotdata['title'])
 
-    if closeFigure:
-        cost_coverage_figure.clf()
-        axis.cla()
-        close(cost_coverage_figure)
-
     return cost_coverage_figure
 
 
@@ -81,7 +76,7 @@ def plotcc(D, progname=default_progname, ccparams=default_ccparams, arteligcutof
     plot_cost_coverage(plotdata_cc)
 
 ###############################################################################
-def plot_coverage_outcome(plotdata, existingFigure=None, closeFigure=True):
+def plot_coverage_outcome(plotdata, existingFigure=None):
     """ Plot the coverage-outcome figure """
 
     if not plotdata:
@@ -124,11 +119,6 @@ def plot_coverage_outcome(plotdata, existingFigure=None, closeFigure=True):
     axis.set_xlim([plotdata['xlowerlim'], plotdata['xupperlim']])
     axis.set_ylim([plotdata['ylowerlim'], plotdata['yupperlim']])
 
-    if closeFigure:
-        coverage_outcome_figure.clf()
-        axis.cla()
-        close(coverage_outcome_figure)
-
     return coverage_outcome_figure
 
 
@@ -139,7 +129,7 @@ def plotco(D, progname=default_progname, effect=default_effect, coparams=default
     plot_coverage_outcome(plotdata_co)
 
 #################################################################################
-def plot_cost_outcome(plotdata, existingFigure=None, closeFigure=True):
+def plot_cost_outcome(plotdata, existingFigure=None):
     """ Plot the cost-outcome figure """
 
     if not plotdata:
@@ -185,11 +175,6 @@ def plot_cost_outcome(plotdata, existingFigure=None, closeFigure=True):
     axis.get_xaxis().set_major_locator(MaxNLocator(nbins=3))
     axis.set_xlim([plotdata['xlowerlim'],plotdata['xupperlim']])
     axis.set_ylim([plotdata['ylowerlim'],plotdata['yupperlim']])
-
-    if closeFigure:
-        cost_outcome_figure.clf()
-        axis.cla()
-        close(cost_outcome_figure)
 
     return cost_outcome_figure
 

--- a/server/src/sim/plotccocs.py
+++ b/server/src/sim/plotccocs.py
@@ -86,7 +86,7 @@ def plotcc(D, progname=default_progname, ccparams=default_ccparams, arteligcutof
 def plot_coverage_outcome(plotdata, figure=None, closeFigure=True):
     """ Plot the coverage-outcome figure """
 
-    if plotdata == None:
+    if not plotdata:
         return None
 
     coverage_outcome_figure = figure if figure else figure()
@@ -141,68 +141,59 @@ def plotco(D, progname=default_progname, effect=default_effect, coparams=default
     plot_coverage_outcome(plotdata_co)
 
 #################################################################################
-def plot_cost_outcome(plotdata, figsize = None):
+def plot_cost_outcome(plotdata, figure=None, closeFigure=True):
     """ Plot the cost-outcome figure """
 
-    cost_outcome_figure = None
-    result = None
-    if plotdata:
-        if figsize:
-            cost_outcome_figure = figure(figsize = figsize, dpi=100)
-        else:
-            cost_outcome_figure = figure()
-        cost_outcome_figure.hold(True)
+    if not plotdata:
+        return None
 
-        axis = cost_outcome_figure.gca()
+    cost_outcome_figure = figure if figure else figure()
+    cost_outcome_figure.hold(True)
 
-        if 'xlinedata' in plotdata.keys():
-            axis.plot(
-                plotdata['xlinedata'],
-                plotdata['ylinedata'][0],
-                linestyle='-',
-                linewidth=2,
-                color='#a6cee3')
-            axis.plot(
-                plotdata['xlinedata'],
-                plotdata['ylinedata'][1],
-                linestyle='--',
-                linewidth=2,
-                color='#000000')
-            axis.plot(
-                plotdata['xlinedata'],
-                plotdata['ylinedata'][2],
-                linestyle='--',
-                linewidth=2,
-                color='#000000')
-        axis.scatter(
-            plotdata['xscatterdata'],
-            plotdata['yscatterdata'],
-            color='#666666')
-        axis.scatter(
-            plotdata['xcurrentdata'],
-            plotdata['ycurrentdata'],
-            color='#d22c2c')
+    axis = cost_outcome_figure.gca()
 
-        axis.set_title(plotdata['title'])
-        axis.tick_params(axis='both', which='major', labelsize=11)
-        axis.set_xlabel(plotdata['xlabel'], fontsize=11)
-        axis.set_ylabel(plotdata['ylabel'], fontsize=11)
-        axis.get_xaxis().set_major_locator(MaxNLocator(nbins=3))
-        axis.set_xlim([plotdata['xlowerlim'],plotdata['xupperlim']])
-        axis.set_ylim([plotdata['ylowerlim'],plotdata['yupperlim']])
+    if 'xlinedata' in plotdata.keys():
+        axis.plot(
+            plotdata['xlinedata'],
+            plotdata['ylinedata'][0],
+            linestyle='-',
+            linewidth=2,
+            color='#a6cee3')
+        axis.plot(
+            plotdata['xlinedata'],
+            plotdata['ylinedata'][1],
+            linestyle='--',
+            linewidth=2,
+            color='#000000')
+        axis.plot(
+            plotdata['xlinedata'],
+            plotdata['ylinedata'][2],
+            linestyle='--',
+            linewidth=2,
+            color='#000000')
+    axis.scatter(
+        plotdata['xscatterdata'],
+        plotdata['yscatterdata'],
+        color='#666666')
+    axis.scatter(
+        plotdata['xcurrentdata'],
+        plotdata['ycurrentdata'],
+        color='#d22c2c')
 
-        # clear all plugins from the figure
-        plugins.clear(cost_outcome_figure)
-        plugins.connect(
-            cost_outcome_figure,
-            # Box zoom is needed to manually create a zoom button in the JS front-end
-            plugins.BoxZoom(button=False, enabled=False),
-            OptimaTickFormatter())
-        result = fig_to_dict(cost_outcome_figure)
+    axis.set_title(plotdata['title'])
+    axis.tick_params(axis='both', which='major', labelsize=11)
+    axis.set_xlabel(plotdata['xlabel'], fontsize=11)
+    axis.set_ylabel(plotdata['ylabel'], fontsize=11)
+    axis.get_xaxis().set_major_locator(MaxNLocator(nbins=3))
+    axis.set_xlim([plotdata['xlowerlim'],plotdata['xupperlim']])
+    axis.set_ylim([plotdata['ylowerlim'],plotdata['yupperlim']])
+
+    if closeFigure:
         cost_outcome_figure.clf()
         axis.cla()
         close(cost_outcome_figure)
-    return result
+
+    return cost_outcome_figure
 
 
 def plotcco(D, progname=default_progname, effect=default_effect, ccparams=default_ccparams, coparams=default_coparams, \

--- a/server/src/sim/utils.py
+++ b/server/src/sim/utils.py
@@ -1,4 +1,3 @@
-from mpld3 import plugins
 
 def sanitize(arraywithnans):
         """ Sanitize input to remove NaNs. Warning, does not work on multidimensional data!! """
@@ -235,15 +234,3 @@ def checkmem(origvariable, descend=0, order='n', plot=False, verbose=0):
         pie(array(printbytes)[inds], labels=array(printnames)[inds], autopct='%0.2f')
 
     return None
-
-class OptimaTickFormatter(plugins.PluginBase):
-    """
-    Optima Tick Formatter plugin
-
-    Since tickFormatting is not working properly we patch & customise it only in
-    the Front-end. See this issue for more information about the current status
-    of tick customisation: https://github.com/jakevdp/mpld3/issues/22
-    """
-
-    def __init__(self):
-        self.dict_ = {"type": "optimaTickFormatter"}


### PR DESCRIPTION
https://trello.com/c/My1IieTK/638-remove-mpld3-from-src-sim

As discussed with @Ashalynd we are introducing a plotting.py in server. In sim we will generate & return matplotlib figures to be plotted. Hint: for the sim BE we can't close the figures as they closing would mean you won't see the plot in the BE.

For the FE we close the figures in plotting.py after retrieved the necessary data.

@Ashalynd & @robynstuart can you review these changes?
@cliffckerr With this PR we would remove mpld3 from sim again.
@robynstuart I was running `python run_makeccocs.py -p -w` to see if the BE works & charts get plotted. Is this correct?