### PR TITLE
Reverting pr 427

### DIFF
--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -65,6 +65,7 @@ define(['./module', 'underscore'], function (module, _) {
         funding: $scope.state.knownFundingValue,
         scaleup: $scope.state.scaleUpParameter,
         nonhivdalys: $scope.state.nonHivDalys,
+        xupperlim: $scope.state.xAxisMaximum,
         cpibaseyear: $scope.state.displayYear,
         perperson: $scope.state.calculatePerPerson
       };
@@ -164,6 +165,7 @@ define(['./module', 'underscore'], function (module, _) {
       $scope.state.scaleUpParameter = program.ccparams.scaleup;
       $scope.state.nonHivDalys = program.ccparams.nonhivdalys;
       $scope.state.displayYear = program.ccparams.cpibaseyear;
+      $scope.state.xAxisMaximum = program.ccparams.xupperlim;
       $scope.state.calculatePerPerson = program.ccparams.perperson;
       $scope.state.info = info;
 

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -159,7 +159,20 @@
                   </div>
                 </div>
                 <div class="section">
-                  5. [Optional] Display program cost data in
+                  5. [Optional] Specify the maximum funding (for plotting only):
+                  <input type="number" class="txbox __inline __xl"
+                         name="xAxisMaximum"
+                         min="1" placeholder="e.g. 1000000"
+                         ng-model="state.xAxisMaximum"
+                         ng-change="updateCurves()">
+                  <div ng-messages="state.CostCoverageForm.xAxisMaximum.$error"
+                       ng-show="state.CostCoverageForm.xAxisMaximum.$touched && state.CostCoverageForm.xAxisMaximum.$invalid">
+                    <div class="error-hint" ng-message="min">The minimum value is 1</div>
+                    <div class="error-hint" ng-message="number">The value should be a number</div>
+                  </div>
+                </div>
+                <div class="section">
+                  6. [Optional] Display program cost data in
                   <input type="number" class="txbox __inline __l"
                          name="displayYear"
                          placeholder="e.g.{{ state.info.dataEnd }}"
@@ -176,7 +189,7 @@
                   </div>
                 </div>
                 <div class="section">
-                  6. [Optional] Display program costs in dollar spent per person in the targeted population
+                  7. [Optional] Display program costs in dollar spent per person in the targeted population
                   <input type="checkbox" ng-model="state.calculatePerPerson" class="__inline" ng-change="updateCurves()"/>
                 </div>
               </form>

--- a/server/src/sim/makeccocs.py
+++ b/server/src/sim/makeccocs.py
@@ -84,6 +84,7 @@ def makecc(D=None, progname=None, ccparams=None, arteligcutoff=None, verbose=def
 
     # Get upper limit of x axis for plotting
     xupperlim = max([x if ~isnan(x) else 0.0 for x in totalcost])*15.
+    if (ccparams and 'xupperlim' in ccparams and ccparams['xupperlim'] and ~isnan(ccparams['xupperlim'])): xupperlim = ccparams['xupperlim']
 
     # Populate output structure with scatter data
     plotdata['allxscatterdata'] = totalcost

--- a/server/src/sim/plotccocs.py
+++ b/server/src/sim/plotccocs.py
@@ -19,6 +19,7 @@ default_ccparams = {'saturation': .7,
                     'funding':9e5,
                     'scaleup':.2,
                     'nonhivdalys':nan,
+                    'xupperlim':2e7,
                     'cpibaseyear':nan,
                     'perperson':nan}
 default_coparams = [0.15, 0.3, 0.4, 0.55]

--- a/server/src/sim/run_makeccocs.py
+++ b/server/src/sim/run_makeccocs.py
@@ -38,7 +38,8 @@ ccparams = {'saturation': 0.9,
           'funding':800000.0, 
           'scaleup':None, 
           'nonhivdalys':None, 
-          'cpibaseyear':None, 
+          'cpibaseyear':None,
+          'xupperlim':1000000,
           'perperson':None}
 plotall(D=D, coparams=[], ccparams=ccparams)
 if show_wait:

--- a/server/src/sim/updatedata.py
+++ b/server/src/sim/updatedata.py
@@ -50,7 +50,8 @@ def addtoprograms(programs):
                                             'coverageupper':None, 
                                             'funding':None, 
                                             'scaleup':None, 
-                                            'nonhivdalys':None, 
+                                            'nonhivdalys':None,
+                                            'xupperlim':None,
                                             'cpibaseyear':None, 
                                             'perperson':None}
         programs[prognumber]['convertedccparams'] = None


### PR DESCRIPTION
Hey @robynstuart ,

The PR has code changes related to setting upper limit on x-axis reverted.

One more thing I noticed while redoing the changes is that on page 
"Define cost-coverage-outcome assumptions"

The optional parameters (3,4,5,6,7) are passed only when params 1,2 have some value, but I am not sure if its a desired behavior or a bug.