### PR TITLE
Close output files and flush their buffers

### DIFF
--- a/server/src/sim/dataio.py
+++ b/server/src/sim/dataio.py
@@ -56,6 +56,7 @@ def savedata(filename, data, update=True, verbose=2):
 
     wfid = open(filename,'wb')
     dump(tojson(data), wfid)
+    wfid.close()
     printv('..created new file', 3, verbose)
     printv(' ...done saving data at %s.' % filename, 2, verbose)
     return filename
@@ -74,7 +75,7 @@ def loaddata(filename, verbose=2):
     import json
     rfid = open(filename,'rb')
     data = fromjson(json.load(rfid))
-
+    rfid.close()
     printv('...done loading data.', 2, verbose)
     return data
 


### PR DESCRIPTION
dataio.py opens various files for reading and writing, but it doesn't explicitly close the files, which means that the buffers are not guaranteed to be flushed. This caused some intermittent problems when writing JSON files and then immediately reading them back in. I've added close() commands to the affected functions