### PR TITLE
Oop cyclic

### DIFF
--- a/server/src/sim/classes/portfolio.py
+++ b/server/src/sim/classes/portfolio.py
@@ -14,8 +14,6 @@ import os
 from numpy import arange
 
 from region import Region
-import defaults
-
 
 class Portfolio:
     def __init__(self, portfolioname):
@@ -31,7 +29,6 @@ class Portfolio:
            
         Version: 2015may28 by davidkedz
         """
-        #from time import time
         
         print('\nPortfolio %s has been activated.' % self.portfolioname)
         print('\nThe script that created this portfolio is in...')
@@ -192,18 +189,18 @@ class Portfolio:
                     else:
                         print('Simulation container ID numbers only range from 1 to %i, inclusive.' % len(currentregion.simboxlist))
                 
-                # Is the first word 'opt'? Then optimise all simulation objects in a simbox of choice.
-                elif subinputlist[0] == 'opt' and len(currentregion.simboxlist) > 0:
-                    simboxid = subinputlist[1]                
-                    
-                    try:
-                        int(simboxid)
-                    except ValueError:
-                        simboxid = 0
-                    if int(simboxid) in arange(1,len(currentregion.simboxlist)+1):
-                        currentregion.optsimbox(currentregion.simboxlist[int(simboxid)-1])
-                    else:
-                        print('Simulation container ID numbers only range from 1 to %i, inclusive.' % len(currentregion.simboxlist))                
+#                # Is the first word 'opt'? Then optimise all simulation objects in a simbox of choice.
+#                elif subinputlist[0] == 'opt' and len(currentregion.simboxlist) > 0:
+#                    simboxid = subinputlist[1]                
+#                    
+#                    try:
+#                        int(simboxid)
+#                    except ValueError:
+#                        simboxid = 0
+#                    if int(simboxid) in arange(1,len(currentregion.simboxlist)+1):
+#                        currentregion.optsimbox(currentregion.simboxlist[int(simboxid)-1])
+#                    else:
+#                        print('Simulation container ID numbers only range from 1 to %i, inclusive.' % len(currentregion.simboxlist))                
                 
                 # Is the first word 'plot' or 'multiplot'? Then plot all the processed results in a simbox of choice.
                 elif (subinputlist[0] == 'plot' or 'multiplot') and len(currentregion.simboxlist) > 0:
@@ -228,8 +225,8 @@ class Portfolio:
             print("To make a new simulation container in this region titled 'simbox_name', type: make simbox_name")
             if len(currentregion.simboxlist) > 0:
                 print("To initialise a new simulation titled 'sim_name', type: sim sim_name")
-                print("To run all unprocessed simulations in 'simbox_id', type: run simbox_id")
-                print("To optimise all unprocessed simulations in 'simbox_id', type: opt simbox_id")    # Heavy work ahead.
+                print("To process all unprocessed simulations in 'simbox_id', type: run simbox_id")
+                print("This will be a simple run or an optimisation depending on simulation container type.")
                 print("To plot each processed simulation in 'simbox_id', type: plot simbox_id")
                 print("To plot all processed simulations in 'simbox_id', type: multiplot simbox_id")
             print('To return to portfolio level, type: r')

--- a/server/src/sim/classes/portfolio.py
+++ b/server/src/sim/classes/portfolio.py
@@ -248,4 +248,8 @@ class Portfolio:
         
         for currentregion in self.regionlist:
             print('Initialising a simulation in region %s for this GPA.' % currentregion.getregionname())
-            currentregion.createsimbox('GPA-'+gpaname, isopt = True, createdefault = True)
+            tempsimbox = currentregion.createsimbox('GPA-'+gpaname, isopt = True, createdefault = True)
+            currentregion.createsiminsimbox('GPA-'+gpaname, tempsimbox)
+            currentregion.runsimbox(tempsimbox)
+            currentregion.runsimbox(tempsimbox)     # Do an extra run just to make sure that the optimised SimBudget is processed.
+            currentregion.plotsimbox(tempsimbox, multiplot = True)

--- a/server/src/sim/classes/portfolio.py
+++ b/server/src/sim/classes/portfolio.py
@@ -91,18 +91,16 @@ class Portfolio:
                     else:
                         print('Region ID numbers only range from 1 to %i, inclusive.' % len(self.regionlist))
                     
-                # Is the first word 'gpa'? Then, ideally, run geo-prioritisation analysis on subset derived from rest of the string.
-                elif cmdinputlist[0] == 'gpa' and len(self.regionlist) > 1:
-                    print('Gotcha! There is no geographical prioritisation analysis! This is just a stub.')
-                    
-                    # LINK TO GPA METHOD OR FUNCTION. MUST OPERATE ON A SUBSET LIST OF REGIONS.
+            # If command is 'gpa', create GPA SimBoxes in each region.
+            if cmdinput == 'gpa' and len(self.regionlist) > 1:
+                self.geoprioanalysis()
                     
             print('\n--------------------\n')
             self.printregionlist()
             print('')
             if len(self.regionlist) > 1:
                 print('Geographical prioritisation analysis now available.')
-                print('To run this analysis over all regions, type: gpa all')       # To be extended when the time comes.
+                print('To run this analysis, type: gpa')       # To be extended when the time comes.
             
             print("To make a new region titled 'region_name', type: make region_name")
             if len(self.regionlist) > 0:
@@ -244,3 +242,10 @@ class Portfolio:
                 fid += 1
                 print('%i: %s' % (fid, region.getregionname()))
                 region.printsimboxlist(assubset=True)
+    
+    def geoprioanalysis(self):
+        gpaname = raw_input('Enter a title for the current analysis: ')
+        
+        for currentregion in self.regionlist:
+            print('Initialising a simulation in region %s for this GPA.' % currentregion.getregionname())
+            currentregion.createsimbox('GPA-'+gpaname, isopt = True, createdefault = True)

--- a/server/src/sim/classes/region.py
+++ b/server/src/sim/classes/region.py
@@ -109,9 +109,11 @@ class Region:
             self.simboxlist.append(SimBox(simboxname,self))
         if createdefault:
             self.simboxlist[-1].createsim(simboxname + '-default')
-            
+        return self.simboxlist[-1]
+        
     def createsiminsimbox(self, simname, simbox):
-        simbox.createsim(simname)
+        new_sim = simbox.createsim(simname)
+        return new_sim
     
 # Combine into one SimBox dependent run method?
 #------------------------------------

--- a/server/src/sim/classes/region.py
+++ b/server/src/sim/classes/region.py
@@ -49,6 +49,7 @@ class Region:
         import dataio
         regiondict = dataio.loaddata(filename)
         if 'uuid' in regiondict.keys(): # This is a new-type JSON file
+            r.uuid = regiondict['uuid'] # Loading a region restores the original UUID
             r.fromdict(regiondict)
         else:
             r.fromdict_legacy(regiondict)
@@ -58,7 +59,7 @@ class Region:
         # Assign variables from a new-type JSON file created using Region.todict()
         self.metadata = regiondict['metadata']
         self.data = regiondict['data']
-        self.simboxlist = [SimBox.fromdict(x) for x in regiondict['simboxlist']]
+        self.simboxlist = [SimBox.fromdict(x,self) for x in regiondict['simboxlist']]
         self.options = regiondict['options'] # Populate default options here
         self.ccocs = regiondict['ccocs']
         self.calibrations = regiondict['calibrations']       
@@ -103,9 +104,9 @@ class Region:
 
     def createsimbox(self, simboxname, isopt = False, createdefault = True):
         if isopt:
-            self.simboxlist.append(SimBoxOpt(simboxname))
+            self.simboxlist.append(SimBoxOpt(simboxname,self))
         else:
-            self.simboxlist.append(SimBox(simboxname))
+            self.simboxlist.append(SimBox(simboxname,self))
         if createdefault:
             self.simboxlist[-1].createsim(simboxname + '-default', self.data, self.metadata, self.options)
             

--- a/server/src/sim/classes/region.py
+++ b/server/src/sim/classes/region.py
@@ -7,6 +7,7 @@ Created on Fri May 29 23:16:12 2015
 
 import defaults
 from simbox import SimBox, SimBoxOpt
+import sim
 import setoptions
 import uuid
 
@@ -82,7 +83,15 @@ class Region:
 
         self.data = tempD['data']
         self.options = tempD['opt']
-    
+
+        # Go through the scenarios and convert them
+        sbox = self.createsimbox('Scenarios')
+        for scenario in tempD['scens']: # Separate cases in the web list 
+            newsim = sim.SimParameter(scenario['scenario']['name'],self)
+            for par in scenario['scenario']['pars']:
+                newsim.create_override(par['names'],par['pops'],par['startyear'],par['endyear'],par['startval'],par['endval'])
+            sbox.simlist.append(newsim)
+
     def save(self,filename):
         import dataio
         dataio.savedata(filename,self.todict())

--- a/server/src/sim/classes/region.py
+++ b/server/src/sim/classes/region.py
@@ -108,22 +108,22 @@ class Region:
         else:
             self.simboxlist.append(SimBox(simboxname,self))
         if createdefault:
-            self.simboxlist[-1].createsim(simboxname + '-default', self.data, self.metadata, self.options)
+            self.simboxlist[-1].createsim(simboxname + '-default')
             
     def createsiminsimbox(self, simname, simbox):
-        simbox.createsim(simname, self.data, self.metadata, self.options)
+        simbox.createsim(simname)
     
 # Combine into one SimBox dependent run method?
 #------------------------------------
     # Runs through every simulation in simbox (if not processed) and processes them.
     def runsimbox(self, simbox):
-        simbox.runallsims(self.data, self.metadata, self.options, forcerun = False)
+        simbox.runallsims(forcerun = False)
     
     # Runs through every simulation in simbox (if not processed) and optimises them.
     # Currently uses default settings.
     def optsimbox(self, simbox):
         if isinstance(simbox, SimBoxOpt):
-            simbox.optallsims(self.data, self.metadata, self.options, forcerun = True)
+            simbox.optallsims(forcerun = True)
         else:
             print('Cannot optimise a standard container.')
 #------------------------------------

--- a/server/src/sim/classes/region.py
+++ b/server/src/sim/classes/region.py
@@ -119,13 +119,13 @@ class Region:
     def runsimbox(self, simbox):
         simbox.runallsims(forcerun = False)
     
-    # Runs through every simulation in simbox (if not processed) and optimises them.
-    # Currently uses default settings.
-    def optsimbox(self, simbox):
-        if isinstance(simbox, SimBoxOpt):
-            simbox.optallsims(forcerun = True)
-        else:
-            print('Cannot optimise a standard container.')
+#    # Runs through every simulation in simbox (if not processed) and optimises them.
+#    # Currently uses default settings.
+#    def optsimbox(self, simbox):
+#        if isinstance(simbox, SimBoxOpt):
+#            simbox.optallsims(forcerun = True)
+#        else:
+#            print('Cannot optimise a standard container.')
 #------------------------------------
         
     # Runs through every simulation in simbox (if processed) and plots them, either multiplot or individual style.

--- a/server/src/sim/classes/region.py
+++ b/server/src/sim/classes/region.py
@@ -85,12 +85,13 @@ class Region:
         self.options = tempD['opt']
 
         # Go through the scenarios and convert them
-        sbox = self.createsimbox('Scenarios')
-        for scenario in tempD['scens']: # Separate cases in the web list 
-            newsim = sim.SimParameter(scenario['scenario']['name'],self)
-            for par in scenario['scenario']['pars']:
-                newsim.create_override(par['names'],par['pops'],par['startyear'],par['endyear'],par['startval'],par['endval'])
-            sbox.simlist.append(newsim)
+        if 'scens' in tempD.keys():
+            sbox = self.createsimbox('Scenarios')
+            for scenario in tempD['scens']: # Separate cases in the web list 
+                newsim = sim.SimParameter(scenario['scenario']['name'],self)
+                for par in scenario['scenario']['pars']:
+                    newsim.create_override(par['names'],par['pops'],par['startyear'],par['endyear'],par['startval'],par['endval'])
+                sbox.simlist.append(newsim)
 
     def save(self,filename):
         import dataio

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -96,9 +96,7 @@ class Sim:
         tempD = makedatapars(tempD)
         self.parsdata = tempD['P']
         
-        from makemodelpars import makemodelpars
-        
-        self.parsmodel = makemodelpars(self.parsdata, r.options)
+        self.makemodelpars()
         
         from updatedata import makefittedpars
         
@@ -118,6 +116,7 @@ class Sim:
         # but are otherwise almost identical. Thus this is the function that is
         # expected to be re-implemented in the derived classes
         from makemodelpars import makemodelpars
+        r = self.getregion()
 
         self.parsmodel = makemodelpars(self.parsdata, r.options)
 
@@ -206,3 +205,99 @@ class SimBudget(Sim):
 #        viewmultiresults(tempD['plot']['optim'][-1]['multi'], show_wait = True)
 #        viewoptimresults(tempD['plot']['optim'][-1])
 #        viewoptimresults(tempD['plot']['optim'][-1])
+
+class SimParameter(Sim):
+    def __init__(self, name, region):
+        Sim.__init__(self, name, region)
+        self.parameter_overrides = []
+
+    def create_override(self,parname,pop,startyear,endyear,startval,endval):
+        # Create override for a single parameter, preserving the current dictionary representation of scenarios
+        # pop can be a population index, or a population shortname. 'all' is a valid shortname
+        #
+        # Also need to validate the parameter name
+        if type(pop) is str:
+            r = self.getregion()
+            poplist = [x['short_name'] for x in r.metadata['populations']] + ['all']
+            try:
+                popidx = poplist.index(pop) + 1 # For some reason (frontend?) these indexes are 1-based rather than 0-based
+            except:
+                print 'Population not found! Valid populations are:'
+                print poplist
+                raise Exception('InvalidPopulation')
+        else:
+            popidx = pop
+
+        assert(type(parname) is list)
+
+        override = {}
+        override['names'] = parname # This can be a list e.g. [u'condom', u'com']??
+        override['pops'] = popidx
+        override['startval'] = startval
+        override['startyear'] = startyear
+        override['endval'] = endval
+        override['endyear'] = endyear
+        self.parameter_overrides.append(override)
+
+    def makemodelpars(self):
+        from numpy import linspace, ndim
+        from nested import getnested, setnested
+        from utils import findinds
+
+        # First, get the base model parameters
+        Sim.makemodelpars(self) 
+
+        # Now compute the overrides as per scenarios.py -> makescenarios()
+        r = self.getregion()
+        for thesepars in self.parameter_overrides:
+            data = getnested(self.parsmodel, thesepars['names'])
+            if ndim(data)>1:
+                if thesepars['pops'] < len(data):
+                    newdata = data[thesepars['pops']] # If it's more than one dimension, use population data too
+                else:
+                    newdata = data[:] # Get all populations
+            else:
+                newdata = data # If it's not, just use the whole thing
+            
+            # Get current values
+            initialindex = findinds(r.options['partvec'], thesepars['startyear'])
+            finalindex = findinds(r.options['partvec'], thesepars['endyear'])
+            
+            if thesepars['startval'] == -1:
+                if ndim(newdata)==1: 
+                    initialvalue = newdata[initialindex]
+                else: 
+                    initialvalue = newdata[:,initialindex].mean(axis=0) # Get the mean if multiple populations
+            else:
+                initialvalue = thesepars['startval']
+            
+            if thesepars['endval'] == -1:
+                if ndim(newdata)==1: 
+                    finalvalue = newdata[finalindex]
+                else: 
+                    finalvalue = newdata[:,finalindex].mean() # Get the mean if multiple populations
+            else:
+                finalvalue = thesepars['endval'] 
+            
+            # Set new values
+            npts = finalindex-initialindex
+            newvalues = linspace(initialvalue, finalvalue, npts)
+            if ndim(newdata)==1:
+                newdata[initialindex:finalindex] = newvalues
+                newdata[finalindex:] = newvalues[-1] # Fill in the rest of the array with the last value
+                if ndim(data)==1:
+                    data = newdata
+                else:
+                    data[thesepars['pops']] = newdata
+            else:
+                for p in xrange(len(newdata)):
+                    newdata[p,initialindex:finalindex] = newvalues
+                    newdata[p,finalindex:] = newvalues[-1] # Fill in the rest of the array with the last value
+            
+            # Update data
+            if ndim(data)>1 and ndim(newdata)==1:
+                data[thesepars['pops']] = newdata # Data is multiple populations, but we're only resetting one
+            else:
+                data = newdata # In all other cases, reset the whole thing (if both are 1D, or if both are 2D
+
+            setnested(self.parsmodel, thesepars['names'], data)

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -179,7 +179,16 @@ class SimBudget(Sim):
         tempD['F'] = self.parsfitted
         tempD['R'] = self.debug['results']
         tempD['plot'] = dict()
-        tempD['plot']['optim'] = self.plotdataopt
         
         tempD['S'] = self.debug['structure']     # Error rising. Where does S come from? Do I need to run simulation first?
-        optimize(tempD, maxiters = 1)   # Temporary restriction on iterations. Not meant to be hardcoded!
+        optimize(tempD, maxiters = 2)   # Temporary restriction on iterations. Not meant to be hardcoded!
+        
+        self.plotdataopt = tempD['plot']['optim'][-1]       # What's this -1 business about?
+        
+#        # Figure out plotting shortly.
+#        from viewresults import viewmultiresults, viewoptimresults
+#        
+#        viewmultiresults(tempD['plot']['optim'][-1]['multi'], show_wait = True)
+#        viewmultiresults(tempD['plot']['optim'][-1]['multi'], show_wait = True)
+#        viewoptimresults(tempD['plot']['optim'][-1])
+#        viewoptimresults(tempD['plot']['optim'][-1])

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -5,8 +5,10 @@ Created on Fri Jun 05 23:27:38 2015
 @author: David Kedziora
 """
 
+import weakref
+
 class Sim:
-    def __init__(self, name):
+    def __init__(self, name,region):
         self.name = name
         self.processed = False      # This tag monitors if the simulation has been run.
         
@@ -21,10 +23,13 @@ class Sim:
         self.plotdata = None        # This used to be D['plot']['E']. Be aware that it is not D['plot']!        
         self.plotdataopt = []       # This used to be D['plot']['optim']. Be aware that it is not D['plot']!
     
+        self.region = weakref.ref(region)
+
     @classmethod
-    def fromdict(SimBox,simdict):
-        s = Sim(None)
-        s.name = simdict['name'] 
+    def fromdict(SimBox,simdict,region):
+        assert(simdict['region_uuid'] == region.uuid)
+
+        s = Sim(simdict['name'],region)
         s.processed  = simdict['processed']  
         s.parsdata  = simdict['parsdata']  
         s.parsmodel  = simdict['parsmodel']  
@@ -32,6 +37,7 @@ class Sim:
         s.debug  = simdict['debug']   
         s.plotdata  = simdict['plotdata']  
         s.plotdataopt  = simdict['plotdataopt']  
+        s.region = weakref.ref(region)
         return s
 
     def todict(self):
@@ -44,8 +50,16 @@ class Sim:
         simdict['debug']   = self.debug 
         simdict['plotdata']  = self.plotdata 
         simdict['plotdataopt']  = self.plotdataopt 
+        simdict['region_uuid'] = self.getregion().uuid
         return simdict
-       
+    
+    def getregion(self):
+        # self.region is a weakref object, which means to get
+        # the region you need to do self.region() rather than
+        # self.region. This function abstracts away this 
+        # implementation detail in case it changes in future
+        return self.region()
+
     def setname(self, name):
         self.name = name
         

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -185,7 +185,18 @@ class Sim:
 class SimBudget(Sim):
     def __init__(self, name, region):
         Sim.__init__(self, name, region)
-        
+        self.plotdataopt = None
+
+    def todict(self):
+        simdict = Sim.todict(self)
+        simdict['type'] = 'SimBudget'
+        simdict['plotdataopt'] = self.plotdataopt
+        return simdict
+
+    def load_dict(self,simdict):
+        Sim.load_dict(self,simdict)
+        self.plotdataopt = simdict['plotdataopt']
+
     # Currently just optimises simulation according to defaults.
     def optimise(self):
         r = self.getregion()

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -11,7 +11,8 @@ class Sim:
     def __init__(self, name, region):
         self.name = name
         self.processed = False      # This tag monitors if the simulation has been run.
-        
+        self.initialised = False    # This tag monitors if the simulation has been initialised.
+
         self.parsdata = None        # This used to be D['P'].
         self.parsmodel = None       # This used to be D['M'].
         self.parsfitted = None      # This used to be D['F'].
@@ -109,9 +110,22 @@ class Sim:
         
         tempD = makefittedpars(tempD)
         self.parsfitted = tempD['F']
-    
+        
+        self.initialised = True
+
+    def makemodelpars(self):
+        # SimParameter, SimBudget and SimCoverge differ in how they calculate D.M
+        # but are otherwise almost identical. Thus this is the function that is
+        # expected to be re-implemented in the derived classes
+        from makemodelpars import makemodelpars
+
+        self.parsmodel = makemodelpars(self.parsdata, r.options)
+
     # Runs model given all the initialised parameters.
     def run(self):
+        if not self.initialised:
+            self.initialize()
+
         r = self.getregion()
 
         from model import model

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -23,7 +23,7 @@ class Sim:
         self.plotdata = None        # This used to be D['plot']['E']. Be aware that it is not D['plot']!        
         self.plotdataopt = []       # This used to be D['plot']['optim']. Be aware that it is not D['plot']!
     
-        self.region = weakref.ref(region)
+        self.setregion(region)
 
     @classmethod
     def fromdict(SimBox,simdict,region):
@@ -37,7 +37,7 @@ class Sim:
         s.debug  = simdict['debug']   
         s.plotdata  = simdict['plotdata']  
         s.plotdataopt  = simdict['plotdataopt']  
-        s.region = weakref.ref(region)
+        s.setregion(region)
         return s
 
     def todict(self):
@@ -53,6 +53,9 @@ class Sim:
         simdict['region_uuid'] = self.getregion().uuid
         return simdict
     
+    def setregion(self,region):
+        self.region = weakref.ref(region)
+
     def getregion(self):
         # self.region is a weakref object, which means to get
         # the region you need to do self.region() rather than
@@ -168,7 +171,7 @@ class SimBudget(Sim):
         regiondata = r.data
         regionmetadata = r.metadata
         regionoptions = r.options
-        
+
         from optimize import optimize
         
         tempD = dict()

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -71,8 +71,12 @@ class Sim:
     
     # Initialises P, M and F matrices belonging to the Sim object, but does not run simulation yet.
     # Very dangerous, as stability relies on the trust that no data passed in is being changed behind the scenes...
-    def initialise(self, regiondata, regionmetadata, regionoptions):
-        
+    def initialise(self):
+        r = self.getregion()
+        regiondata = r.data
+        regionmetadata = r.metadata
+        regionoptions = r.options
+
         from makedatapars import makedatapars
         from numpy import arange
 
@@ -103,8 +107,12 @@ class Sim:
         self.parsfitted = tempD['F']
     
     # Runs model given all the initialised parameters.
-    def run(self, regiondata, regionmetadata, regionoptions):
-        
+    def run(self):
+        r = self.getregion()
+        regiondata = r.data
+        regionmetadata = r.metadata
+        regionoptions = r.options
+
         from model import model
 
         allsims = []
@@ -155,7 +163,11 @@ class SimBudget(Sim):
         Sim.__init__(self, name)
         
     # Currently just optimises simulation according to defaults.
-    def optimise(self, regiondata, regionmetadata, regionoptions):
+    def optimise(self):
+        r = self.getregion()
+        regiondata = r.data
+        regionmetadata = r.metadata
+        regionoptions = r.options
         
         from optimize import optimize
         

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -116,8 +116,8 @@ class Sim:
         tempD['G'] = r.metadata
         tempD['M'] = self.parsmodel
         
-        tempD = makefittedpars(tempD)
-        self.parsfitted = tempD['F']
+        #tempD = makefittedpars(tempD)
+        self.parsfitted = r.D['F']
         
         self.initialised = True
 

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -124,7 +124,7 @@ class Sim:
     # Runs model given all the initialised parameters.
     def run(self):
         if not self.initialised:
-            self.initialize()
+            self.initialise()
 
         r = self.getregion()
 

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -8,7 +8,7 @@ Created on Fri Jun 05 23:27:38 2015
 import weakref
 
 class Sim:
-    def __init__(self, name,region):
+    def __init__(self, name, region):
         self.name = name
         self.processed = False      # This tag monitors if the simulation has been run.
         
@@ -160,8 +160,8 @@ class Sim:
 
 # Derived Sim class that should store budget data.
 class SimBudget(Sim):
-    def __init__(self, name):
-        Sim.__init__(self, name)
+    def __init__(self, name, region):
+        Sim.__init__(self, name, region)
         
     # Currently just optimises simulation according to defaults.
     def optimise(self):

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -27,22 +27,32 @@ class Sim:
         self.setregion(region)
 
     @classmethod
-    def fromdict(SimBox,simdict,region):
+    def fromdict(Sim,simdict,region):
+        # This function instantiates the correct subtype based on simdict['type']
         assert(simdict['region_uuid'] == region.uuid)
-
-        s = Sim(simdict['name'],region)
-        s.processed  = simdict['processed']  
-        s.parsdata  = simdict['parsdata']  
-        s.parsmodel  = simdict['parsmodel']  
-        s.parsfitted  = simdict['parsfitted']  
-        s.debug  = simdict['debug']   
-        s.plotdata  = simdict['plotdata']  
-        s.plotdataopt  = simdict['plotdataopt']  
+        print simdict['type']
+        if simdict['type'] == 'Sim':
+            s = Sim(simdict['name'],region)
+        if simdict['type'] == 'SimParameter':
+            s = SimParameter(simdict['name'],region)
+        if simdict['type'] == 'SimBudget':
+            s = SimBudget(simdict['name'],region)
         s.setregion(region)
+        s.load_dict(simdict)
         return s
+
+    def load_dict(self,simdict):
+        self.processed  = simdict['processed']  
+        self.parsdata  = simdict['parsdata']  
+        self.parsmodel  = simdict['parsmodel']  
+        self.parsfitted  = simdict['parsfitted']  
+        self.debug  = simdict['debug']   
+        self.plotdata  = simdict['plotdata']  
+        self.plotdataopt  = simdict['plotdataopt']  
 
     def todict(self):
         simdict = {}
+        simdict['type'] = 'Sim'
         simdict['name'] = self.name
         simdict['processed']  = self.processed 
         simdict['parsdata']  = self.parsdata 
@@ -210,6 +220,16 @@ class SimParameter(Sim):
     def __init__(self, name, region):
         Sim.__init__(self, name, region)
         self.parameter_overrides = []
+
+    def todict(self):
+        simdict = Sim.todict(self)
+        simdict['type'] = 'SimParameter'
+        simdict['parameter_overrides'] = self.parameter_overrides
+        return simdict
+
+    def load_dict(self,simdict):
+        Sim.load_dict(self,simdict)
+        self.parameter_overrides = simdict['parameter_overrides'] 
 
     def create_override(self,parname,pop,startyear,endyear,startval,endval):
         # Create override for a single parameter, preserving the current dictionary representation of scenarios

--- a/server/src/sim/classes/sim.py
+++ b/server/src/sim/classes/sim.py
@@ -61,7 +61,11 @@ class Sim:
         # the region you need to do self.region() rather than
         # self.region. This function abstracts away this 
         # implementation detail in case it changes in future
-        return self.region()
+        r = self.region()
+        if r is None:
+            raise Exception('The parent region has been garbage-collected and the reference is no longer valid')
+        else:
+            return r
 
     def setname(self, name):
         self.name = name

--- a/server/src/sim/classes/simbox.py
+++ b/server/src/sim/classes/simbox.py
@@ -71,17 +71,23 @@ class SimBox:
         tempD['G'] = r.metadata
 
         Rarr = []
+        cannotgetmulti = False
         for sim in self.simlist:
+            if not sim.isprocessed():
+                cannotgetmulti = True
             tmp = {}
             tmp['R'] = sim.debug['results']
             tmp['label'] = sim.name
 
             Rarr.append(tmp)
 
-        import gatherplotdata,viewresults
-        multidata = gatherplotdata.gathermultidata(tempD, Rarr,verbose=0)
-        #viewmultiresults(M, whichgraphs={'prev':[1,1], 'plhiv':[0,1], 'inci':[0,1], 'daly':[0,1], 'death':[0,1], 'dx':[0,1], 'tx1':[0,1], 'tx2':[0,1], 'costcum':[1,1]}, simstartyear=2000, simendyear=2030, onefig=True, verbose=2, show_wait=False, linewidth=2):
-        viewresults.viewmultiresults(multidata, show_wait = True)
+        if cannotgetmulti:
+            print('Some simulations in this container are not yet processed!')
+        else:
+            import gatherplotdata,viewresults
+            multidata = gatherplotdata.gathermultidata(tempD, Rarr,verbose=0)
+            #viewmultiresults(M, whichgraphs={'prev':[1,1], 'plhiv':[0,1], 'inci':[0,1], 'daly':[0,1], 'death':[0,1], 'dx':[0,1], 'tx1':[0,1], 'tx2':[0,1], 'costcum':[1,1]}, simstartyear=2000, simendyear=2030, onefig=True, verbose=2, show_wait=False, linewidth=2):
+            viewresults.viewmultiresults(multidata, show_wait = True)
 
     def printsimlist(self, assubsubset = False):
         # Prints with long arrow formats if assubsubset is true. Otherwise uses short arrows.        
@@ -115,10 +121,11 @@ class SimBoxOpt(SimBox):
             print('Optimisation containers can only contain one initial simulation!')
         else:
             print('Preparing new budget simulation for optimisation container %s...' % self.name)
-            self.simlist.append(SimBudget(simname+'-initial'))
+            self.simlist.append(SimBudget(simname+'-initial',self.getregion()))
             self.simlist[-1].initialise()
-                
-    def optallsims(self, forcerun = False):
+    
+    def runallsims(self, forcerun = False):
         for sim in self.simlist:
             if forcerun or not sim.isprocessed():
+                sim.run()           # Is this really necessary, just to get D['S']?
                 sim.optimise()

--- a/server/src/sim/classes/simbox.py
+++ b/server/src/sim/classes/simbox.py
@@ -51,7 +51,8 @@ class SimBox:
         print('Preparing new basic simulation for standard container %s...' % self.name)
         self.simlist.append(Sim(simname,self.getregion()))
         self.simlist[-1].initialise()
-    
+        return self.simlist[-1]
+        
     def runallsims(self, forcerun = False):
         for sim in self.simlist:
             if forcerun or not sim.isprocessed():

--- a/server/src/sim/classes/simbox.py
+++ b/server/src/sim/classes/simbox.py
@@ -12,7 +12,7 @@ class SimBox:
     def __init__(self, name,region):
         self.name = name
         self.simlist = []
-        self.region = weakref.ref(region)
+        self.setregion(region)
 
     @classmethod
     def fromdict(SimBox,simboxdict,region):
@@ -20,7 +20,7 @@ class SimBox:
 
         s = SimBox(simboxdict['name'],region)
         s.simlist = [Sim.fromdict(x,region) for x in simboxdict['simlist']]
-        s.region = weakref.ref(region)
+        s.setregion(region)
 
         return s
 
@@ -32,6 +32,9 @@ class SimBox:
 
         return simboxdict
     
+    def setregion(self,region):
+        self.region = weakref.ref(region)
+
     def getregion(self):
         # self.region is a weakref object, which means to get
         # the region you need to do self.region() rather than

--- a/server/src/sim/classes/simbox.py
+++ b/server/src/sim/classes/simbox.py
@@ -63,7 +63,7 @@ class SimBox:
                 sim.plotresults()
 
     # Needs to check processing like plotallsims.
-    def viewmultiresults(self, regionmetadata):
+    def viewmultiresults(self):
         # Superimpose plots, like in the scenarios page in the frontend
         r = self.region()
 

--- a/server/src/sim/classes/simbox.py
+++ b/server/src/sim/classes/simbox.py
@@ -40,15 +40,15 @@ class SimBox:
         return self.region()
 
     # Creates a simulation object but makes sure to initialise it immediately after, ready for processing.
-    def createsim(self, simname, regiondata, regionmetadata, regionoptions):
+    def createsim(self, simname):
         print('Preparing new basic simulation for standard container %s...' % self.name)
         self.simlist.append(Sim(simname,self.getregion()))
-        self.simlist[-1].initialise(regiondata, regionmetadata, regionoptions)
+        self.simlist[-1].initialise()
     
-    def runallsims(self, regiondata, regionmetadata, regionoptions, forcerun = False):
+    def runallsims(self, forcerun = False):
         for sim in self.simlist:
             if forcerun or not sim.isprocessed():
-                sim.run(regiondata, regionmetadata, regionoptions)
+                sim.run()
                 
     def plotallsims(self):
         for sim in self.simlist:
@@ -98,19 +98,19 @@ class SimBox:
         
 # A container just for Sims with budgets.
 class SimBoxOpt(SimBox):
-    def __init__(self, name):
-        SimBox.__init__(self, name)
+    def __init__(self,name,region):
+        SimBox.__init__(self,name,region)
         
     # Overwrites the standard Sim create method. This is where budget data would be attached.
-    def createsim(self, simname, regiondata, regionmetadata, regionoptions):
+    def createsim(self, simname):
         if len(self.simlist) > 0:
             print('Optimisation containers can only contain one initial simulation!')
         else:
             print('Preparing new budget simulation for optimisation container %s...' % self.name)
             self.simlist.append(SimBudget(simname+'-initial'))
-            self.simlist[-1].initialise(regiondata, regionmetadata, regionoptions)
+            self.simlist[-1].initialise()
                 
-    def optallsims(self, regiondata, regionmetadata, regionoptions, forcerun = False):
+    def optallsims(self, forcerun = False):
         for sim in self.simlist:
             if forcerun or not sim.isprocessed():
-                sim.optimise(regiondata, regionmetadata, regionoptions)
+                sim.optimise()

--- a/server/src/sim/classes/simbox.py
+++ b/server/src/sim/classes/simbox.py
@@ -65,9 +65,10 @@ class SimBox:
     # Needs to check processing like plotallsims.
     def viewmultiresults(self, regionmetadata):
         # Superimpose plots, like in the scenarios page in the frontend
+        r = self.region()
 
         tempD = {}
-        tempD['G'] = regionmetadata
+        tempD['G'] = r.metadata
 
         Rarr = []
         for sim in self.simlist:

--- a/server/src/sim/classes/simbox.py
+++ b/server/src/sim/classes/simbox.py
@@ -40,7 +40,11 @@ class SimBox:
         # the region you need to do self.region() rather than
         # self.region. This function abstracts away this 
         # implementation detail in case it changes in future
-        return self.region()
+        r = self.region()
+        if r is None:
+            raise Exception('The parent region has been garbage-collected and the reference is no longer valid')
+        else:
+            return r
 
     # Creates a simulation object but makes sure to initialise it immediately after, ready for processing.
     def createsim(self, simname):

--- a/server/src/sim/classes/simbox.py
+++ b/server/src/sim/classes/simbox.py
@@ -129,7 +129,7 @@ class SimBoxOpt(SimBox):
     def createsimopt(self, sim):
         if not sim == None:
             print('Converting optimisation results into a new budget simulation...')
-            self.simlist.append(SimBudget((sim.getname()[:-8] if sim.getname().endswith('-initial') else sim.getname())+'-opt',self.getregion()))
+            self.simlist.append(SimBudget(sim.getname(),self.getregion()))
             
             # The copy can't be completely deep or shallow, so we load the new SimBudget with a developer-made method.
             self.simlist[-1].specialoptload(sim)

--- a/server/src/sim/optimize.py
+++ b/server/src/sim/optimize.py
@@ -173,7 +173,7 @@ def objectivecalc(optimparams, options):
     
     
     
-def optimize(D, objectives=None, constraints=None, maxiters=1000, timelimit=None, verbose=5, name='Default', stoppingfunc = None):
+def optimize(D, objectives=None, constraints=None, maxiters=1000, timelimit=None, verbose=5, name='Default', stoppingfunc = None, returnresult=False):
     """ Perform the actual optimization """
     from time import sleep
     
@@ -565,6 +565,11 @@ def optimize(D, objectives=None, constraints=None, maxiters=1000, timelimit=None
     D = saveoptimization(D, name, objectives, constraints, result_to_save, verbose=2)
 
     printv('...done optimizing programs.', 2, verbose)
+    
+    # This is new code for the OOP structure. Legacy users will not run this line because returnresult is false by default.
+    if returnresult:
+        D['result'] = result['Rarr'][-1]['R']
+    
     return D
 
 

--- a/server/src/sim/optimize.py
+++ b/server/src/sim/optimize.py
@@ -569,6 +569,7 @@ def optimize(D, objectives=None, constraints=None, maxiters=1000, timelimit=None
     # This is new code for the OOP structure. Legacy users will not run this line because returnresult is false by default.
     if returnresult:
         D['result'] = result['Rarr'][-1]['R']
+#        D['test'] = result  # Temp.
     
     return D
 

--- a/server/src/sim/tests/demo_regions.py
+++ b/server/src/sim/tests/demo_regions.py
@@ -37,7 +37,7 @@ def test_from_xlsx():
 
 def test_uncerresults():
 	r = test_from_json()
-	r.simboxlist[0].plotallsims()
+	r.simboxlist[-1].plotallsims()
 
 
 def test_multiresults():

--- a/server/src/sim/tests/demo_regions.py
+++ b/server/src/sim/tests/demo_regions.py
@@ -8,8 +8,8 @@ def test_from_json():
 	# Test running a simulation from JSON
 	r = region.Region.load('./regions/Haiti.json')
 	r.createsimbox('Simbox 1')
-	r.simboxlist[0].createsim('sim1') 
-	r.runsimbox(r.simboxlist[0])
+	r.simboxlist[-1].createsim('sim1') 
+	r.runsimbox(r.simboxlist[-1])
 	return r
 
 

--- a/server/src/sim/tests/demo_regions.py
+++ b/server/src/sim/tests/demo_regions.py
@@ -8,7 +8,7 @@ def test_from_json():
 	# Test running a simulation from JSON
 	r = region.Region.load('./regions/Haiti.json')
 	r.createsimbox('Simbox 1')
-	r.simboxlist[0].createsim('sim1',r.data,r.metadata,r.options) # This is really confusing....
+	r.simboxlist[0].createsim('sim1') 
 	r.runsimbox(r.simboxlist[0])
 	return r
 
@@ -18,7 +18,7 @@ def test_saving_and_loading():
 	r.save('./regions/Haiti_newstyle.json')
 	r2 = region.Region.load('./regions/Haiti_newstyle.json') # Load new style JSON
 	r2.createsimbox('Simbox 1')
-	r2.simboxlist[0].createsim('sim1',r2.data,r2.metadata,r2.options)
+	r2.simboxlist[0].createsim('sim1')
 	r2.runsimbox(r2.simboxlist[0])
 	r2.save('./regions/Haiti_newstyle_withsim.json')
 	r3 = region.Region.load('./regions/Haiti_newstyle_withsim.json') # Load new style JSON
@@ -32,7 +32,7 @@ def test_from_xlsx():
 	r.makeworkbook('./regions/Haiti_Test.xlsx') # Write to a dummy file for test purposes
 	r.loadworkbook('./regions/Haiti.xlsx')
 	r.createsimbox('Simbox 1')
-	r.simboxlist[0].createsim('sim1',r.data,r.metadata,r.options) # This is really confusing....
+	r.simboxlist[0].createsim('sim1') # This is really confusing....
 	r.runsimbox(r.simboxlist[0])
 
 def test_uncerresults():
@@ -42,7 +42,7 @@ def test_uncerresults():
 
 def test_multiresults():
 	r = test_from_json()
-	r.simboxlist[0].createsim('sim2',r.data,r.metadata,r.options) # This should really be r.simboxlist.createsim('sim_name') ...
+	r.simboxlist[0].createsim('sim2') # This should really be r.simboxlist.createsim('sim_name') ...
 	r.runsimbox(r.simboxlist[0])
 	r.simboxlist[0].viewmultiresults(r.metadata)
 

--- a/server/src/sim/tests/demo_regions.py
+++ b/server/src/sim/tests/demo_regions.py
@@ -44,7 +44,7 @@ def test_multiresults():
 	r = test_from_json()
 	r.simboxlist[0].createsim('sim2') # This should really be r.simboxlist.createsim('sim_name') ...
 	r.runsimbox(r.simboxlist[0])
-	r.simboxlist[0].viewmultiresults(r.metadata)
+	r.simboxlist[0].viewmultiresults()
 
 test_saving_and_loading()
 test_from_json()

--- a/server/src/sim/tests/demo_scenario.py
+++ b/server/src/sim/tests/demo_scenario.py
@@ -5,17 +5,25 @@ import defaults
 import region
 import sim
 
-# Make the region
-r = region.Region.load('./regions/georgia_working.json')
+def create_scenarios():
+	r = region.Region.load('./regions/georgia_working.json')
 
-# Make the simulations
-sim1 = sim.Sim('Base',r)
-sim2 = sim.SimParameter('Test & Treat only',r)
-sim2.create_override(['propaware'],'all',2015,2030,0.6,0.9)
-sim2.create_override(['txtotal'],'all',2015,2030,0.4,0.81)
+	# Make the simulations
+	sim1 = sim.Sim('Base',r)
+	sim2 = sim.SimParameter('Test & Treat only',r)
+	sim2.create_override(['propaware'],'all',2015,2030,0.6,0.9)
+	sim2.create_override(['txtotal'],'all',2015,2030,0.4,0.81)
 
-# Put them in a simbox, run them, and plot results
-sbox = r.createsimbox('Test scenarios')
-sbox.simlist = [sim1,sim2]
-sbox.runallsims()
-sbox.viewmultiresults()
+	# Put them in a simbox, run them, and plot results
+	sbox = r.createsimbox('Test scenarios')
+	sbox.simlist = [sim1,sim2]
+	sbox.runallsims()
+	sbox.viewmultiresults()
+
+def run_existing():
+	r = region.Region.load('./regions/georgia_working.json')
+	sbox = r.simboxlist[0]
+	sbox.runallsims()
+	sbox.viewmultiresults()
+
+run_existing()

--- a/server/src/sim/tests/demo_scenario.py
+++ b/server/src/sim/tests/demo_scenario.py
@@ -15,10 +15,31 @@ def create_scenarios():
 	sim2.create_override(['txtotal'],'all',2015,2030,0.4,0.81)
 
 	# Put them in a simbox, run them, and plot results
-	sbox = r.createsimbox('Test scenarios')
-	sbox.simlist = [sim1,sim2]
+
 	sbox.runallsims()
 	sbox.viewmultiresults()
+
+def save_and_load_scenarios():
+	r = region.Region.load('./regions/georgia_working.json')
+	r.simboxlist = []
+	sim1 = sim.Sim('Base',r)
+	sim2 = sim.SimParameter('Test & Treat only',r)
+	sim2.create_override(['propaware'],'all',2015,2030,0.6,0.9)
+	sbox = r.createsimbox('Test scenarios')
+	sbox.simlist = [sim1,sim2]
+	r.save('./regions/georgia_working_updated.json')
+	r2 = region.Region.load('./regions/georgia_working_updated.json')
+
+	print r.simboxlist[0].simlist[0]
+	print r.simboxlist[0].simlist[1]
+	print r2.simboxlist[0].simlist[0]
+	print r2.simboxlist[0].simlist[1]
+	print r.simboxlist[0].simlist[1].parameter_overrides[0]
+	print r2.simboxlist[0].simlist[1].parameter_overrides[0]
+
+	#sbox = r.simboxlist[0]
+	#sbox.runallsims()
+	#sbox.viewmultiresults()
 
 def run_existing():
 	r = region.Region.load('./regions/georgia_working.json')
@@ -26,4 +47,4 @@ def run_existing():
 	sbox.runallsims()
 	sbox.viewmultiresults()
 
-run_existing()
+save_and_load_scenarios()

--- a/server/src/sim/tests/demo_scenario.py
+++ b/server/src/sim/tests/demo_scenario.py
@@ -47,4 +47,5 @@ def run_existing():
 	sbox.runallsims()
 	sbox.viewmultiresults()
 
-save_and_load_scenarios()
+#save_and_load_scenarios()
+run_existing()

--- a/server/src/sim/tests/demo_scenario.py
+++ b/server/src/sim/tests/demo_scenario.py
@@ -1,0 +1,21 @@
+# This demonstration creates a region, saves a corresponding XLSX file
+# and then loads it back again
+import add_optima_paths
+import defaults
+import region
+import sim
+
+# Make the region
+r = region.Region.load('./regions/georgia_working.json')
+
+# Make the simulations
+sim1 = sim.Sim('Base',r)
+sim2 = sim.SimParameter('Test & Treat only',r)
+sim2.create_override(['propaware'],'all',2015,2030,0.6,0.9)
+sim2.create_override(['txtotal'],'all',2015,2030,0.4,0.81)
+
+# Put them in a simbox, run them, and plot results
+sbox = r.createsimbox('Test scenarios')
+sbox.simlist = [sim1,sim2]
+sbox.runallsims()
+sbox.viewmultiresults()

--- a/server/src/sim/tests/demo_scenario.py
+++ b/server/src/sim/tests/demo_scenario.py
@@ -15,7 +15,8 @@ def create_scenarios():
 	sim2.create_override(['txtotal'],'all',2015,2030,0.4,0.81)
 
 	# Put them in a simbox, run them, and plot results
-
+	sbox = r.createsimbox('Test scenarios')
+	sbox.simlist = [sim1,sim2]
 	sbox.runallsims()
 	sbox.viewmultiresults()
 
@@ -48,4 +49,4 @@ def run_existing():
 	sbox.viewmultiresults()
 
 #save_and_load_scenarios()
-run_existing()
+create_scenarios()


### PR DESCRIPTION
@davidkedz 

So this proposal incorporates a cyclic reference in the Simbox and Sim classes. It's not that weird - for example, a doubly-linked list structure (one of the most basic data types they teach in CS) has objects containing references to both their parent and child. The problems this solves are

- You no longer have to include multiple arguments in a number of places, because the properties can be obtained from the region directly
- You can no longer introduce bugs by mixing bits and pieces of different regions in said function calls
- By interacting more directly with the Simboxes and Sims, there is a reduced need for wrapper methods in Region(). This is a big issue, because the wrapper methods make the region a (mentally) heavier class, and because region.py will be changed much more frequently than is necessary if all clean syntax requires helper methods
- The simulation only makes sense in terms of its parent region - this is enforced by having only one region reference within the Sim. With the current structure, you can pass in data from one region, metadata from another region etc. and thus put the Sim into an invalid state. This would most likely occur inadvertently/unintentionally

The biggest questions about storing the references to the parent region are

- How do we make sure that data isn't duplicated, both in memory and on disk
- How do we make sure that garbage collection still works properly

**Making sure data isn't duplicated**
The Simboxes and Sims use the weakref() module (Python builtin) to store what is essentially a pointer to the region. This pointer behaves in a similar way to pointers in C/C++ in that the data for the region is not duplicated. The getregion() method resolves the pointer, and it is called within the class methods as required. Calling getregion() also means that the Simboxes and Sims will always look up the current state of the region they are contained. Saving and loading files is currently accomplished by the todict() and fromdict() methods. The todict() method records the region UUID rather than the reference to the region. A Sim and Simbox can only be used in the context of a region. The fromdict() method therefore also requires a region argument. The region that is passed in needs to correspond to the original parent region, so fromdict() checks the UUID to make sure they match. Currently, this functionality is all wrapped in the region save/load methods, so it is transparent to the user. However, in future this functionality will make it possible to save and load Sims and Simboxes to be shared without sending the region, as long as both users already have the same parent Region object. 

**Garbage collection**
The weakref() class is designed to work properly with garbage collection. Specifically, it does not count as a full reference to the object for garbage collection purposes, and thus it will not stop the parent from being destroyed. This means that the failure mode is the getregion() method returning a NoneType object. We can check for this in future and print a helpful message. For most usages, everything will work fine. One usage pattern that is not supported would be

    def simfactory():
        r = Region()
        s = Sim('test,r)
        return s

But this is fine, because a Sim only makes sense in the context of the region. So the weakref system will enforce our intended usage

---

So...I wasn't initially sold on having cyclic references either because a number of potential problems came to mind. I made several mistakes already in passing around the region data manually, and am increasingly thinking that the extensive wrapper methods are adding unnecessarily complexity. I think that the implementation of cyclic references here ended up being much easier than we initially envisaged and can avoid the problems we previously discussed. Thoughts? (let's not decide immediately)