### PR TITLE
feat(cost coverage): add hint for case where no effects are defined

### DIFF
--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -198,6 +198,10 @@
         </div>
 
         <form name="state.CombinedAdjustmentForms">
+          <div ng-show="state.costOutcomeCharts.length === 0" class="info-hint">
+            You have not defined any effects for this program.
+          </div>
+
           <div class="section" ng-if="state.costOutcomeCharts.length" ng-repeat="chart in state.costOutcomeCharts track by chart.id">
             <h2 class="section">{{ state.outcomeTitles[$index] }}</h2>
 


### PR DESCRIPTION
@robynstuart I think we can merge this, but I want to double check first if I got the requirements right.

Please take a look at the questions & screenshot at: https://trello.com/c/9Gg0pc5R/649-create-a-warning-message-if-people-try-to-define-ccocs-for-spending-only-programs