### PR TITLE
bump postcss-assets to 3.0.3

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -34,7 +34,7 @@
     "karma-phantomjs-launcher": "=0.2.1",
     "karma-requirejs": "=0.2.2",
     "karma-script-launcher": "=0.1.0",
-    "postcss-assets": "=3.0.2",
+    "postcss-assets": "=3.0.3",
     "postcss-import": "=7.0.0",
     "underscore": "=1.8.3"
   },


### PR DESCRIPTION
fixes `npm install` image-size missing repo issue
