### PR TITLE
feat(Login): login error message should not mention email

### DIFF
--- a/client/source/js/modules/auth/login-ctrl.js
+++ b/client/source/js/modules/auth/login-ctrl.js
@@ -27,7 +27,7 @@ define(['./module', '../sha224/sha224'], function (module, SHA224) {
         // error
         function (error) {
           if (error.status === 401) {
-            $scope.error = 'Wrong email or password. Please check credentials and try again';
+            $scope.error = 'Wrong username or password. Please check credentials and try again';
           } else {
             $scope.error = 'Server feels bad. Please try again in a bit';
           }


### PR DESCRIPTION
Fix for this small issue: https://trello.com/c/7Wj1bmx7/722-wrong-email-is-shown-when-enter-incorrect-username-while-logging-in
