### PR TITLE
removed unused options

### DIFF
--- a/client/source/js/modules/analysis/optimization.html
+++ b/client/source/js/modules/analysis/optimization.html
@@ -129,7 +129,7 @@
               </ng-form>
 
             <!-- TODO 2015-08-24 ART programs were hidden for the workshop -->
-            <div class="top-spaced" style="display: none">
+            <!--<div class="top-spaced" style="display: none">
               <label>
                 <input type="checkbox" ng-model="params.objectives.year.artcontinue">
                 ART programs will continue:
@@ -185,10 +185,10 @@
                   </div>
                 </label>
               </div>
-            </div>
+            </div>-->
 
             <!-- TODO 2015-08-24 behavioral and contextual parameters were hidden for the workshop -->
-            <div class="top-spaced" style="display: none">
+<!--            <div class="top-spaced" style="display: none">
               <label>
                 <input type="checkbox" ng-model="params.objectives.year.otherprograms">
                 All other behavioral and contextual parameters:
@@ -204,7 +204,7 @@
                   remain at levels at the end of the program period
                 </label>
               </div>
-            </div>
+            </div>-->
           </div>
         </div>
 
@@ -551,7 +551,7 @@
           </div>
         </div>
 
-        <hr class="__dashed"/>
+        <!--<hr class="__dashed"/>-->
 
 <!--        <div class="checkbox-block">
           <label>


### PR DESCRIPTION
@Ashalynd and @robynstuart please review. idea is to disable the "No one who initiates ART..." and coverage constraint options on the optimization screen since these features do not seem to work and have been confusing users.
