### PR TITLE
feat(Calibrations): fix scroll styling

### DIFF
--- a/client/source/sass/main/project/_chart-container.scss
+++ b/client/source/sass/main/project/_chart-container.scss
@@ -55,7 +55,7 @@
 
 .chart_wrapper {
   height: 100%;
-  overflow: scroll;
+  overflow: auto;
   display: flex;
   width: 60%;
   flex-wrap: wrap;

--- a/client/source/sass/main/project/_layout.scss
+++ b/client/source/sass/main/project/_layout.scss
@@ -68,7 +68,7 @@
     margin: 2px;
     padding: 5px;
     border: 1px solid black;
-    overflow: scroll;
+    overflow: auto;
   }
 
   .option {


### PR DESCRIPTION
Minor fix for: https://trello.com/c/hLi2TAWb/787-useless-horizontal-scroll-bar-on-calibration-page
