### PR TITLE
made __init__.py expect everything in optima to work except plotting

### DIFF
--- a/optima/__init__.py
+++ b/optima/__init__.py
@@ -31,7 +31,12 @@ You should have received a copy of the GNU Lesser General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-Version: 2016jan26
+Version: 2016jan29
 """
 
+# This means that if Optima is loaded as a module, it's expected to succeed
+import __builtin__
+__builtin__._failsilently = False
+
+# Actually do all the imports
 from optima import *


### PR DESCRIPTION
This branch uses the same idea as testimports.py such that if Optima is being loaded externally (e.g., by anything other than something in the optima/optima folder), it will *not* fail silently, making the errors a lot easier to trace.