### PR TITLE
Fix interp and manualfit list

### DIFF
--- a/optima/gui.py
+++ b/optima/gui.py
@@ -302,66 +302,19 @@ def manualfit(project=None, name='default', ind=0, verbose=2):
     ion() # We really need this here!
     nsigfigs = 3
     
-    ## Initialize lists that do not initialize themselves
     boxes = []
     texts = []
-    keylist = []
-    namelist = []
-    typelist = [] # Valid types are meta, pop, exp
     
     ## Get the list of parameters that can be fitted
     parset = dcp(project.parsets[name])
-    tmppars = parset.pars[0]
-    origpars = dcp(tmppars)
-
-    for key in tmppars.keys():
-        if hasattr(tmppars[key],'fittable'): # Don't worry if it doesn't work, not everything in tmppars is actually a parameter
-            if tmppars[key].fittable is not 'no':
-                keylist.append(key) # e.g. "initprev"
-                namelist.append(tmppars[key].name) # e.g. "HIV prevalence"
-                typelist.append(tmppars[key].fittable) # e.g. 'pop'
-    nkeys = len(keylist) # Number of keys...note, this expands due to different populations etc.
     
-    ## Convert to the full list of parameters to be fitted
-    def populatelists():
-        global tmppars, fulllabellist, fullkeylist, fullsubkeylist, fulltypelist, fullvallist
-        fulllabellist = [] # e.g. "Initial HIV prevalence -- FSW"
-        fullkeylist = [] # e.g. "initprev"
-        fullsubkeylist = [] # e.g. "fsw"
-        fulltypelist = [] # e.g. "pop"
-        fullvallist = [] # e.g. 0.3
-        for k in range(nkeys):
-            key = keylist[k]
-            if typelist[k]=='meta':
-                fullkeylist.append(key)
-                fullsubkeylist.append(None)
-                fulltypelist.append(typelist[k])
-                fullvallist.append(tmppars[key].m)
-                fulllabellist.append(namelist[k] + ' -- meta')
-            elif typelist[k]=='const':
-                fullkeylist.append(key)
-                fullsubkeylist.append(None)
-                fulltypelist.append(typelist[k])
-                fullvallist.append(tmppars[key].y)
-                fulllabellist.append(namelist[k])
-            elif typelist[k] in ['pop', 'pship']:
-                for subkey in tmppars[key].y.keys():
-                    fullkeylist.append(key)
-                    fullsubkeylist.append(subkey)
-                    fulltypelist.append(typelist[k])
-                    fullvallist.append(tmppars[key].y[subkey])
-                    fulllabellist.append(namelist[k] + ' -- ' + str(subkey))
-            elif typelist[k]=='exp':
-                for subkey in tmppars[key].p.keys():
-                    fullkeylist.append(key)
-                    fullsubkeylist.append(subkey)
-                    fulltypelist.append(typelist[k])
-                    fullvallist.append(tmppars[key].p[subkey][0])
-                    fulllabellist.append(namelist[k] + ' -- ' + str(subkey))
-            else:
-                printv('Parameter type "%s" not implemented!' % typelist[k], 2, verbose)
+    mflists = parset.manualfitlists()
+    fullkeylist    = mflists['keys']
+    fullsubkeylist = mflists['subkeys']
+    fulltypelist   = mflists['types']
+    fullvallist    = mflists['values']
+    fulllabellist  = mflists['labels']
     
-    populatelists()
     nfull = len(fulllabellist) # The total number of boxes needed
     results = project.runsim(name)
     pygui(results)

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -848,7 +848,6 @@ class Parameterset(object):
             raise OptimaException("Parameter with index {} not found!".format(ind))
 
         tmppars = self.pars[ind]
-
         mflists = {'keys':[], 'subkeys':[], 'types':[], 'values':[], 'labels':[]}
         keylist = mflists['keys']
         subkeylist = mflists['subkeys']
@@ -858,30 +857,35 @@ class Parameterset(object):
 
         for key in tmppars.keys():
             par = tmppars[key]
-            if (not hasattr(par,'fittable')) or (par.fittable == 'no'): # Don't worry if it doesn't work, not everything in tmppars is actually a parameter
-                continue
-            if par.fittable == 'meta':
-                keylist.append(key)
-                subkeylist.append(None)
-                typelist.append(par.fittable)
-                valuelist.append(par.m)
-                labellist.append('{} -- meta'.format(par.name))
-            elif par.fittable in ['pop', 'pship']:
-                for subkey in par.y.keys():
+            if hasattr(par,'fittable') and par.fittable != 'no': # Don't worry if it doesn't work, not everything in tmppars is actually a parameter
+                if par.fittable == 'meta':
                     keylist.append(key)
-                    subkeylist.append(subkey)
+                    subkeylist.append(None)
                     typelist.append(par.fittable)
-                    valuelist.append(par.y[subkey])
-                    labellist.append('{} -- {}'.format(par.name, str(subkey)))
-            elif par.fittable == 'exp':
-                for subkey in par.p.keys():
+                    valuelist.append(par.m)
+                    labellist.append('%s -- meta' % par.name)
+                elif par.fittable == 'const':
                     keylist.append(key)
-                    subkeylist.append(subkey)
+                    subkeylist.append(None)
                     typelist.append(par.fittable)
-                    valuelist.append(par.p[subkey][0])
-                    labellist.append('{} -- {}'.format(par.name, str(subkey)))
-            else:
-                print('Parameter type "%s" not implemented!' % par.fittable)
+                    valuelist.append(par.y)
+                    labellist.append(par.name)
+                elif par.fittable in ['pop', 'pship']:
+                    for subkey in par.y.keys():
+                        keylist.append(key)
+                        subkeylist.append(subkey)
+                        typelist.append(par.fittable)
+                        valuelist.append(par.y[subkey])
+                        labellist.append('%s -- %s' % (par.name, str(subkey)))
+                elif par.fittable == 'exp':
+                    for subkey in par.p.keys():
+                        keylist.append(key)
+                        subkeylist.append(subkey)
+                        typelist.append(par.fittable)
+                        valuelist.append(par.p[subkey][0])
+                        labellist.append('%s -- %s' % (par.name, str(subkey)))
+                else:
+                    print('Parameter type "%s" not implemented!' % par.fittable)
 
         return mflists
 

--- a/tests/testscenarios.py
+++ b/tests/testscenarios.py
@@ -354,9 +354,12 @@ if 'VMMC' in tests:
                       'Condoms': 1e7,
                       'VMMC': 1e8,
                       'FSW programs': 1e6,
-                      'HTC':2e7,
+                      'MSM programs': 1e6,
+                      'ART':1e6,
                       'PMTCT':1e6,
-                      'ART':1e6
+                      'HTC workplace programs':2e7,
+                      'HTC mobile clinics':2e7,
+                      'HTC medical facilities':2e7
                       }),
 
         ]


### PR DESCRIPTION
removes duplication between gui.py:manualfit and parameters.py. also allows parset.interp() to work with the following syntax: `mypars = P.parsets[0].interp(tvec=2015, asarray=False, onlyvisible=True)`. @robynstuart please review.