### PR TITLE
Comparison table

### DIFF
--- a/optima/loadspreadsheet.py
+++ b/optima/loadspreadsheet.py
@@ -289,7 +289,6 @@ def loadspreadsheet(filename='simple.xlsx', verbose=2):
                 data['pships']['inj'].append((data['pops']['short'][row],data['pops']['short'][col]))
     
 
-    printv('...done loading data.', 2, verbose)
     return data
 
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -7,7 +7,7 @@ def model(simpars=None, settings=None, verbose=None, die=False, debug=False):
     """
     Runs Optima's epidemiological model.
     
-    Version: 1.2 (2016feb04)
+    Version: 1.2 (2016feb06)
     """
     
     
@@ -39,7 +39,7 @@ def model(simpars=None, settings=None, verbose=None, die=False, debug=False):
     if verbose is None: verbose = settings.verbose # Verbosity of output
     
     # Would be at the top of the script, but need to figure out verbose first
-    printv('Running model...', 1, verbose, newline=False)
+    printv('Running model...', 1, verbose)
     
     # Initialize arrays
     raw_inci       = zeros((npops, npts)) # Total incidence
@@ -843,7 +843,6 @@ def model(simpars=None, settings=None, verbose=None, die=False, debug=False):
     raw['death']      = raw_death
     raw['otherdeath'] = raw_otherdeath
     
-    printv('  ...done running model.', 2, verbose)
     return raw # Return raw results
 
 

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -483,7 +483,6 @@ def makepars(data, label=None, verbose=2):
                             pars[condname].y[(key1,key2)] = array(tmpcond[act])[i,j,:]
                             pars[condname].t[(key1,key2)] = array(tmpcondpts[act])
     
-    printv('...done converting data to parameters.', 2, verbose)
     
     return pars
 
@@ -802,7 +801,6 @@ class Parameterset(object):
             simpars = makesimpars(pars=self.pars[ind], keys=keys, start=start, end=end, dt=dt, tvec=tvec, smoothness=smoothness, asarray=asarray, onlyvisible=onlyvisible, verbose=verbose, name=self.name, uid=self.uid)
             simparslist.append(simpars) # Wrap up
         
-        printv('...done making model parameters.', 2, verbose)
         return simparslist
     
     

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -440,8 +440,9 @@ class Programset(object):
                 if len(outcomes[outcome][key])!=nyrs:
                     raise OptimaException('Parameter lengths must match (len(outcome)=%i, nyrs=%i)' % (len(outcomes[outcome][key]), nyrs))
 
-        
         return outcomes
+        
+        
         
     def getpars(self, coverage, t=None, parset=None, results=None, ind=0, perturb=False, die=False, verbose=2):
         ''' Make pars'''
@@ -509,6 +510,19 @@ class Programset(object):
                 
 
         return pars
+    
+    
+    
+    def compareoutcomes(self, parset=None, year=None, ind=0):
+        ''' For every parameter affected by a program, return a list comparing the default parameter values with the budget ones '''
+        
+        defaultpars = parset.pars[ind] # WARNING
+        thiscoverage = self.getprogcoverage(budget=budget, t=year, parset=parset) 
+        thisparsdict = self.getpars(coverage=thiscoverage, t=year, parset=parset)
+        
+        comparison = odict()
+        
+        return comparison
 
     def plotallcoverage(self,t,parset,existingFigure=None,verbose=2,randseed=None,bounds=None):
         ''' Plot the cost-coverage curve for all programs'''

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -3,7 +3,7 @@ This module defines the Program and Programset classes, which are
 used to define a single program/modality (e.g., FSW programs) and a
 set of programs, respectively.
 
-Version: 2016feb02
+Version: 2016feb06
 """
 
 from optima import OptimaException, printv, uuid, today, sigfig, getdate, dcp, smoothinterp, findinds, odict, Settings, runmodel, sanitize, objatt, objmeth, gridcolormap, isnumber, vec2obj

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -6,7 +6,7 @@ set of programs, respectively.
 Version: 2016feb02
 """
 
-from optima import OptimaException, printv, uuid, today, getdate, dcp, smoothinterp, findinds, odict, Settings, runmodel, sanitize, objatt, objmeth, gridcolormap, isnumber, vec2obj
+from optima import OptimaException, printv, uuid, today, sigfig, getdate, dcp, smoothinterp, findinds, odict, Settings, runmodel, sanitize, objatt, objmeth, gridcolormap, isnumber, vec2obj
 from numpy import ones, prod, array, arange, zeros, exp, linspace, append, sort, transpose, nan, isnan, ndarray, concatenate as cat, maximum, minimum
 import abc
 
@@ -513,16 +513,29 @@ class Programset(object):
     
     
     
-    def compareoutcomes(self, parset=None, year=None, ind=0):
+    def compareoutcomes(self, parset=None, year=None, ind=0, doprint=False):
         ''' For every parameter affected by a program, return a list comparing the default parameter values with the budget ones '''
+        outcomes = self.getoutcomes(t=year, parset=parset)
+        comparison = list()
+        maxnamelen = 0
+        maxkeylen = 0
+        for key1 in outcomes.keys():
+            for key2 in outcomes[key1].keys():
+                name = parset.pars[ind][key1].name
+                maxnamelen = max(len(name),maxnamelen)
+                maxkeylen = max(len(str(key2)),maxkeylen)
+                parvalue = parset.pars[ind][key1].interp(tvec=year, asarray=False)[key2]
+                budgetvalue = outcomes[key1][key2]
+                comparison.append([name, key2, parvalue[0], budgetvalue[0]])
         
-        defaultpars = parset.pars[ind] # WARNING
-        thiscoverage = self.getprogcoverage(budget=budget, t=year, parset=parset) 
-        thisparsdict = self.getpars(coverage=thiscoverage, t=year, parset=parset)
-        
-        comparison = odict()
-        
+        if doprint:
+            for item in comparison:
+                strctrl = '%%%is | %%%is | Par: %%8s | Budget: %%8s' % (maxnamelen, maxkeylen)
+                print(strctrl % (item[0], item[1], sigfig(item[2]), sigfig(item[3])))
+                
         return comparison
+
+
 
     def plotallcoverage(self,t,parset,existingFigure=None,verbose=2,randseed=None,bounds=None):
         ''' Plot the cost-coverage curve for all programs'''

--- a/optima/project.py
+++ b/optima/project.py
@@ -196,7 +196,7 @@ class Project(object):
         self.checkname(structlist, checkabsent=name, overwrite=overwrite)
         structlist[name] = item
         if consistentnames: structlist[name].name = name # Make sure names are consistent -- should be the case for everything except results, where keys are UIDs
-        printv('Item "%s" added to structure list "%s"' % (name, what), 1, self.settings.verbose)
+        printv('Item "%s" added to "%s"' % (name, what), 2, self.settings.verbose)
         self.modified = today()
         return None
 
@@ -206,7 +206,7 @@ class Project(object):
         structlist = self.getwhat(what=what)
         self.checkname(what, checkexists=name)
         structlist.pop(name)
-        printv('Item "%s" removed from structure list "%s"' % (name, what), 1, self.settings.verbose)
+        printv('Item "%s" removed from "%s"' % (name, what), 2, self.settings.verbose)
         self.modified = today()
         return None
 
@@ -221,7 +221,7 @@ class Project(object):
         structlist[new].created = today() # Update dates
         structlist[new].modified = today() # Update dates
         if hasattr(structlist[new], 'project'): structlist[new].project = self # Preserve information about project -- don't deep copy -- WARNING, may not work?
-        printv('Item "%s" copied to structure list "%s"' % (new, what), 1, self.settings.verbose)
+        printv('Item "%s" copied to "%s"' % (new, what), 2, self.settings.verbose)
         self.modified = today()
         return None
 
@@ -232,7 +232,7 @@ class Project(object):
         self.checkname(what, checkexists=orig, checkabsent=new, overwrite=overwrite)
         structlist[new] = structlist.pop(orig)
         structlist[new].name = new # Update name
-        printv('Item "%s" renamed to "%s" in structure list "%s"' % (orig, new, what), 1, self.settings.verbose)
+        printv('Item "%s" renamed to "%s" in "%s"' % (orig, new, what), 2, self.settings.verbose)
         self.modified = today()
         return None
         

--- a/optima/scenarios.py
+++ b/optima/scenarios.py
@@ -97,7 +97,6 @@ def runscenarios(project=None, verbose=2, defaultparset=0):
     multires = Multiresultset(resultsetlist=allresults, name='scenarios')
     for scen in scenlist: scen.resultsref = multires.uid # Copy results into each scenario that's been run
     
-    printv('...done running scenarios.', 2, verbose)
     return multires
 
 

--- a/optima/scenarios.py
+++ b/optima/scenarios.py
@@ -89,7 +89,7 @@ def runscenarios(project=None, verbose=2, defaultparset=0):
         progset = project.progsets[scenlist[scenno].progsetname] if isinstance(scenlist[scenno], Progscen) else None
 
         # Run model and add results
-        result = runmodel(pars=scenparset.pars[0], parset=scenparset, progset=progset, project=project, budget=budget, coverage=coverage, budgetyears=budgetyears, verbose=1)
+        result = runmodel(pars=scenparset.pars[0], parset=scenparset, progset=progset, project=project, budget=budget, coverage=coverage, budgetyears=budgetyears, verbose=0)
         result.name = scenlist[scenno].name # Give a name to these results so can be accessed for the plot legend
         allresults.append(result) 
         printv('Scenario: %i/%i' % (scenno+1, nscens), 2, verbose)

--- a/tests/benchmark.txt
+++ b/tests/benchmark.txt
@@ -39,3 +39,4 @@
 0.423 2016-Feb-06_20:15:21 ad05516 speeding-up-model
 0.425 2016-Feb-06_20:16:11 1b124c7 speeding-up-model
 0.887 2016-Feb-06_21:26:25 4a1a097 speeding-up-model
+0.419 2016-Feb-07_01:50:18 b37023d comparison-table

--- a/tests/testmakespreadsheet.py
+++ b/tests/testmakespreadsheet.py
@@ -1,7 +1,7 @@
 """
 A more standard version of testing if the spreadsheet works
 
-Version: 2016jan19 by cliffk
+Version: 2016feb06 by cliffk
 """
 
 
@@ -13,7 +13,7 @@ tests = [
 #'unittests',
 ]
 
-dosave = True
+dosave = False
 
 
 ##############################################################################

--- a/tests/testprograms.py
+++ b/tests/testprograms.py
@@ -15,6 +15,7 @@ Version: 2016feb06
 ## Define tests to run here!!!
 tests = [
 'makeprograms',
+'compareoutcomes',
 ]
 
 
@@ -36,18 +37,18 @@ print('Running tests:')
 for i,test in enumerate(tests): print(('%i.  '+test) % (i+1))
 blank()
 
+T = tic()
 
 ##############################################################################
 ## The tests
 ##############################################################################
 
-T = tic()
 
 
 
 
 
-## Project creation test
+## Programs creation test
 if 'makeprograms' in tests:
     t = tic()
 
@@ -350,8 +351,19 @@ if 'makeprograms' in tests:
     
     
 
+    done(t)
+    
+
+
+
+
+## Project creation test
+if 'compareoutcomes' in tests:
+    comparison = P.progsets[0].compareoutcomes(parset=P.parsets[0], year=2016, doprint=True)
+    
     
     done(t)
+
 
 
 

--- a/tests/testprograms.py
+++ b/tests/testprograms.py
@@ -360,8 +360,6 @@ if 'makeprograms' in tests:
 ## Project creation test
 if 'compareoutcomes' in tests:
     comparison = P.progsets[0].compareoutcomes(parset=P.parsets[0], year=2016, doprint=True)
-    
-    
     done(t)
 
 


### PR DESCRIPTION
adds method to programset to compare the currrent values from the parset to the current values from the budget. use doprint=True to print output, otherwise it returns it as a list of lists.

NB: we should think about whether or not it makes sense for a progset to have a 'parset' attribute. can you swap which parset you use with a given progset? if not, i think they should be linked.  then instead of

`comparison = P.progsets[0].compareoutcomes(parset=P.parsets[0], year=2016, doprint=True)`

the syntax would be

`comparison = P.progsets[0].compareoutcomes(year=2016, doprint=True)`

and likewise for getoutcomes etc.

@robynstuart please review.