### PR TITLE
added functions for cleaning results out of a project

### DIFF
--- a/optima/__init__.py
+++ b/optima/__init__.py
@@ -68,7 +68,7 @@ from .colortools import alpinecolormap, bicolormap, gridcolormap, vectocolor
 
 ## Utilities
 from . import utils # Load high-level module as well
-from .utils import blank, checkmem, dataindex, defaultrepr, findinds, getdate, gitinfo, isnumber, loadobj, loads, objectid, objatt, objmeth, objrepr, odict, OptimaException, pd, perturb, printarr, printdata, printv, quantile, runcommand, sanitize, saveobj, saves, scaleratio, setdate, sigfig, smoothinterp, tic, toc, vec2obj
+from .utils import blank, checkmem, cleanresults, dataindex, defaultrepr, findinds, getdate, gitinfo, isnumber, loadobj, loads, objectid, objatt, objmeth, objrepr, odict, OptimaException, pd, perturb, printarr, printdata, printv, quantile, runcommand, sanitize, saveobj, saves, scaleratio, setdate, sigfig, smoothinterp, tic, toc, vec2obj
 
 
 #####################################################################################################################

--- a/optima/defaults.py
+++ b/optima/defaults.py
@@ -3,10 +3,10 @@ Defines the default parameters for each program.
 
 Version: 2016jan28
 """
+import os
+import optima as op
 from optima import OptimaException, Project, Program, Programset, printv
 
-
-spreadsheetpath = '../tests/' # WARNING, will this work on all systems? If not can just move XLSX files into the Optima directory I suppose...
 
 def defaultprograms(project, addpars=False, addcostcov=False, filterprograms=None):
     ''' Make some default programs'''
@@ -311,9 +311,15 @@ def defaultproject(which='simple', addprogset=True, verbose=2, **kwargs):
     Options for easily creating default projects based on different spreadsheets, including
     program information -- useful for testing 
     
-    Version: 2016feb02
+    Version: 2016mar24
     '''
     
+    
+    # Figure out the path 
+    optimapath = op.__file__
+    parentdir = optimapath.split(os.sep)[:-2] # exclude /optima/__init__.pyc
+    testdir = parentdir + ['tests'+os.sep]
+    spreadsheetpath = os.sep.join(testdir)
     
     
     ##########################################################################################################################

--- a/optima/project.py
+++ b/optima/project.py
@@ -1,5 +1,5 @@
 from optima import OptimaException, Settings, Parameterset, Programset, Resultset, BOC, Parscen, Optim # Import classes
-from optima import odict, getdate, today, uuid, dcp, objrepr, printv, isnumber # Import utilities
+from optima import odict, getdate, today, uuid, dcp, objrepr, printv, isnumber, saveobj # Import utilities
 from optima import loadspreadsheet, model, gitinfo, sensitivity, manualfit, autofit, runscenarios 
 from optima import defaultobjectives, defaultconstraints, loadeconomicsspreadsheet, runmodel # Import functions
 from optima import __version__ # Get current version
@@ -285,6 +285,7 @@ class Project(object):
         return keyname # Can be useful to know what ended up being chosen
     
     def rmresult(self, name=-1):
+        ''' Remove a single result by name '''
         resultuids = self.results.keys() # Pull out UID keys
         resultnames = [res.name for res in self.results.values()] # Pull out names
         if isnumber(name) and name<len(self.results):  # Remove by index rather than name
@@ -299,9 +300,28 @@ class Project(object):
             raise OptimaException(errormsg)
     
     
+    def cleanresults(self):
+        ''' Remove all results '''
+        self.results = odict() # Just replace with an empty odict, as at initialization
+        return None
+    
+    
     def addscenlist(self, scenlist): 
         ''' Function to make it slightly easier to add scenarios all in one go -- WARNING, should make this a general feature of add()! '''
         for scen in scenlist: self.addscen(name=scen.name, scen=scen, overwrite=True)
+        return None
+    
+    
+    def save(self, filename=None, saveresults=False):
+        ''' Save the current project, by default using its name, and without results '''
+        if filename is None: filename = self.name+'.prj'
+        if saveresults:
+            saveobj(filename, self)
+        else:
+            tmpproject = dcp(self) # Need to do this so we don't clobber the existing results
+            tmpproject.cleanresults() # Get rid of all results
+            saveobj(filename, tmpproject) # Save it to file
+            del tmpproject # Don't need it hanging around any more
         return None
 
 

--- a/optima/scenarios.py
+++ b/optima/scenarios.py
@@ -109,7 +109,9 @@ def makescenarios(project=None, scenlist=None, verbose=2):
     scenparsets = odict()
     for scenno, scen in enumerate(scenlist):
         
-        try: thisparset = dcp(project.parsets[scen.parsetname])
+        try: 
+            thisparset = dcp(project.parsets[scen.parsetname])
+            thisparset.project = project # Replace copy of project with pointer -- WARNING, hacky
         except: raise OptimaException('Failed to extract parset "%s" from this project:\n%s' % (scen.parsetname, project))
         thisparset.modified = today()
         thisparset.name = scen.name

--- a/optima/utils.py
+++ b/optima/utils.py
@@ -678,6 +678,24 @@ def loadobj(filename, verbose=True):
     return obj
 
 
+def cleanresults(filelist=None):
+    ''' Remove results from one file or many files '''
+    from glob import glob
+    if filelist is None: 
+        filelist = glob('*.prj')
+        ans = raw_input('About to remove results from the following files:\n%s\n\nAre you sure? y/[n]\n' % filelist)
+        if ans!='y': 
+            print('\nResults removal aborted.')
+            return None
+    if isinstance(filelist, (str, unicode)): filelist = [filelist]
+    for filename in filelist:
+        P = loadobj(filename)
+        P.cleanresults()
+        saveobj(filename, P)
+    print('\nDone.')
+    return None
+
+
 def saves(obj):
     ''' Save an object to a string in gzip-compatible way'''
     try: import cPickle as pickle # For Python 2 compatibility


### PR DESCRIPTION
i was more than a little traumatized to see some single project files pushing 300 mb :) this PR introduces a new save() method for projects that by default doesn't save results; it also introduces a cleanresults() utility that acts on a single file or on all files in the current directory; and lastly it makes it so the default projects can actually be loaded from any directory rather than just the optima or tests directories.