### PR TITLE
Improved auto-calibration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngseed",
   "description": "Neat combination of Angular & Require intended for bulding complex frontend applications",
-  "repository": "git@github.com:StarterSquad/angularjs-requirejs-seed.git",
+  "repository": "http://git@github.com:StarterSquad/angularjs-requirejs-seed.git",
   "version": "0.0.3",
   "devDependencies": {
     "amdefine": "=1.0.0",
@@ -21,7 +21,7 @@
     "gulp-postcss": "=6.0.1",
     "gulp-protractor": "=1.0.0",
     "gulp-replace": "^0.5.4",
-    "gulp-requirejs": "git://github.com/StarterSquad/gulp-requirejs.git",
+    "gulp-requirejs": "=0.1.3",
     "gulp-sass": "=2.0.4",
     "gulp-uglify": "=1.4.1",
     "gulp-util": "=3.0.6",

--- a/client/source/js/modules/programs/cost-coverage/cost-coverage-ctrl.js
+++ b/client/source/js/modules/programs/cost-coverage/cost-coverage-ctrl.js
@@ -17,7 +17,7 @@ define(['./../module', 'underscore'], function (module, _) {
       vm.openProject = activeProject.data;
       console.log('vm.openProject', vm.openProject);
 
-      vm.activeTab = 'outcome';
+      vm.activeTab = 'cost';
       vm.tabs = [
         {
           name: 'Define cost functions',

--- a/client/source/js/modules/programs/cost-coverage/cost/cost-ctrl.js
+++ b/client/source/js/modules/programs/cost-coverage/cost/cost-ctrl.js
@@ -82,14 +82,29 @@ define(['./../../module', 'underscore'], function (module, _) {
         });
     };
 
+    function toNullIfEmpty(val) {
+      if (_.isUndefined(val)) {
+        return null;
+      }
+      if (val == "") {
+        return null;
+      }
+      return val;
+    }
+
     var validateCostcovTable = function(table) {
       var costcov = [];
       table.rows.forEach(function(row, iRow, rows) {
         if (iRow != table.iEditRow) {
-          costcov.push({year: parseInt(row[0]), cost: row[1], coverage: row[2]});
+          costcov.push({
+            year: parseInt(row[0]),
+            cost: toNullIfEmpty(row[1]),
+            coverage: toNullIfEmpty(row[2])
+          });
         }
       });
       $scope.selectedProgram.costcov = costcov;
+      consoleLogJson('save costcov', costcov);
       saveSelectedProgram();
     };
 

--- a/optima/asd.py
+++ b/optima/asd.py
@@ -54,7 +54,7 @@ def asd(function, x, args=None, stepsize=0.1, sinc=2, sdec=2, pinc=2, pdec=2,
     
     Example:
         from asd import asd
-        from pylab import norm
+        from numpy import norm
         x, fval, exitflag, output = asd(norm, [1, 2, 3])
     
     
@@ -62,7 +62,7 @@ def asd(function, x, args=None, stepsize=0.1, sinc=2, sdec=2, pinc=2, pdec=2,
     """
     
     from numpy import array, shape, reshape, ones, zeros, size, mean, cumsum, mod, hstack, floor, flatnonzero, isnan
-    from numpy.random import random, seed # Was pylab.rand
+    from numpy.random import random, seed
     from copy import deepcopy # For arrays, even y = x[:] doesn't copy properly
     from time import time
     seed(randseed)

--- a/optima/batchtools.py
+++ b/optima/batchtools.py
@@ -15,7 +15,7 @@ from optima import loadobj, saveobj, loadbalancer
 
 def batchtest(nprocs=4, nrepeats=3e7, maxload=0.5):
     ''' A simple example of how to run a parallel computation -- use this as a template for making more complex functions'''
-    from pylab import rand
+    from numpy.random import random as rand
     
     def testfunc(obj, ind, outputqueue):
         loadbalancer(maxload=maxload, index=ind)

--- a/optima/colortools.py
+++ b/optima/colortools.py
@@ -123,7 +123,7 @@ def alpinecolormap(gap=0.1,mingreen=0.2,redbluemix=0.5,epsilon=0.01):
    Version: 2014aug06 by Cliff Kerr (cliff@thekerrlab.com)
    """
    from matplotlib.colors import LinearSegmentedColormap as makecolormap
-   from pylab import array
+   from numpy import array
    
    water = array([3,18,59])/256.
    desert = array([194,175,160*0.6])/256.
@@ -159,8 +159,7 @@ def alpinecolormap(gap=0.1,mingreen=0.2,redbluemix=0.5,epsilon=0.01):
 
 ## Show the staggering beauty of the color map's infinite possibilities
 def testalpinecolormap():
-    from pylab import randn, show, convolve, array, seed, linspace, meshgrid, xlabel, ylabel
-    import matplotlib.pyplot as plt
+    from pylab import randn, show, convolve, array, seed, linspace, meshgrid, xlabel, ylabel, figure, pcolor
     from mpl_toolkits.mplot3d import Axes3D # analysis:ignore
     
     maxheight = 3
@@ -177,7 +176,7 @@ def testalpinecolormap():
     data /= data.max()
     data *= maxheight
     
-    fig = plt.figure(figsize=(18,8))
+    fig = figure(figsize=(18,8))
     ax = fig.gca(projection='3d')
     ax.view_init(elev=45, azim=30)
     X = linspace(0,horizontalsize,n)
@@ -189,10 +188,10 @@ def testalpinecolormap():
     ylabel('Position (km)')
     show()
 
-    fig = plt.figure(figsize=(8,6))
+    fig = figure(figsize=(8,6))
     ax = fig.gca()
     X = linspace(0,horizontalsize,n)
-    pcl = plt.pcolor(X, X, data, cmap=alpinecolormap(), linewidth=0, antialiased=False)
+    pcl = pcolor(X, X, data, cmap=alpinecolormap(), linewidth=0, antialiased=False)
     cb2 = fig.colorbar(pcl)
     cb2.set_label('Height (km)',horizontalalignment='right', labelpad=50)
     xlabel('Position (km)')
@@ -227,11 +226,11 @@ def vectocolor(vector,cmap=None):
 
    Version: 1.0 (2012sep13 by cliffk)
    """
-   from pylab import array, zeros
+   from numpy import array, zeros
+   from pylab import cm
 
    if cmap==None:
-      from pylab import cm
-      cmap=cm.jet;
+      cmap=cm.jet
 
    # The vector has elements
    if len(vector):

--- a/optima/misc/convert1to2.py
+++ b/optima/misc/convert1to2.py
@@ -211,7 +211,7 @@ def convert1to2(old=None, infile=None, outfile=None, autofit=True, dosave=True, 
     new.parsets[0].pars[0]['inhomo'].y[:]   = old['F'][0]['inhomo'][:]
 
     ## Run simulation
-    #new.runsim()
+    new.runsim()
 
 
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -869,12 +869,10 @@ def model(simpars=None, settings=None, verbose=None, die=False, debug=False):
                         if not(people[errstate,errpop,t+1]>=0):
                             errormsg = 'WARNING, Non-positive people found!\npeople[%i, %i, %i] = people[%s, %s, %s] = %s' % (errstate, errpop, t+1, settings.statelabels[errstate], popkeys[errpop], tvec[t+1], people[errstate,errpop,t+1])
                             if die: raise OptimaException(errormsg)
-                            else:
+                            else: 
                                 printv(errormsg, 1, verbose=verbose)
                                 people[errstate,errpop,t+1] = 0.0 # Reset
                 
-    # Append final people array to sim output
-    if not (people>=0).all(): raise OptimaException('Non-positive people found!')
     
     raw               = odict()    # Sim output structure
     raw['tvec']       = tvec
@@ -908,6 +906,11 @@ def runmodel(project=None, simpars=None, pars=None, parset=None, progset=None, b
         except: raise OptimaException('Could not get settings from project "%s" supplied to runmodel()' % project)
     try:
         raw = model(simpars=simpars, settings=settings, debug=debug, verbose=verbose) # RUN OPTIMA!!
+        # Append final people array to sim output
+        if not (raw['people']>=0).all(): 
+            printv('Negative people found with runmodel(); rerunning with a smaller timestep...')
+            settings.dt /= 4
+            raw = model(simpars=simpars, settings=settings, debug=debug, verbose=verbose) # RUN OPTIMA!!
     except: 
         printv('Running model failed; running again with debugging...', 1, verbose)
         raw = model(simpars=simpars, settings=settings, debug=True, verbose=verbose) # If it failed, run again, with tests

--- a/optima/pchip.py
+++ b/optima/pchip.py
@@ -8,7 +8,6 @@ Version: 2016feb04
 """
 
 from utils import isnumber
-import matplotlib.pyplot as plt
 from numpy import linspace, array, diff
 from copy import deepcopy as dcp
 import collections
@@ -19,8 +18,9 @@ pchipeps = 1e-8
 #=========================================================
 def pchip(x, y, xnew, deriv = False, method='pchip'):
     
-    xs = [a for a,b in sorted(zip(x,y))]
-    ys = [b for a,b in sorted(zip(x,y))]
+    sortzip = dcp(sorted(zip(x,y)))
+    xs = [a for a,b in sortzip]
+    ys = [b for a,b in sortzip]
     x = dcp(xs)
     y = dcp(ys)
     
@@ -134,7 +134,13 @@ def pchip_eval(x, y, m, xvec, deriv = False):
 
 def plotpchip(x, y, deriv = False, returnplot = False, initbudget = None, optbudget = None):
 
-    xnew = linspace(x[0],x[-1],200)
+    from pylab import figure, plot, show
+
+    sortzip = dcp(sorted(zip(x,y)))
+    xs = [a for a,b in sortzip]
+    ys = [b for a,b in sortzip]
+    x = dcp(xs)
+    y = dcp(ys)
 
     # Process inputs
     if isnumber(initbudget): initbudget = [initbudget] # Plotting expects this to be a list
@@ -151,26 +157,26 @@ def plotpchip(x, y, deriv = False, returnplot = False, initbudget = None, optbud
         xend = max(xend,optbudget[-1])
     xnew = linspace(xstart,xend,200)
     
-    fig = plt.figure(facecolor=(1,1,1))
+    fig = figure(facecolor=(1,1,1))
     ax = fig.add_subplot(111)
 #    print(xnew)
 #    print(pchip(x,y,xnew,deriv))
 #    print(optbudget)
 #    print(pchip(x,y,optbudget,deriv))
-    plt.plot(xnew, pchip(x,y,xnew,deriv), linewidth=2)
+    plot(xnew, pchip(x,y,xnew,deriv), linewidth=2)
     xs = [a+pchipeps for a in x]    # Shift the original points slightly when plotting them, otherwise derivatives become zero-like.
-    plt.plot(xs, pchip(x,y,xs,deriv), 'k+', markeredgewidth=2, markersize=20, label='Budget-objective curve')
+    plot(xs, pchip(x,y,xs,deriv), 'k+', markeredgewidth=2, markersize=20, label='Budget-objective curve')
 #        print(x)
 #        print(pchip(x,y,x,deriv))
     if not initbudget == None:
-        plt.plot(initbudget, pchip(x,y,initbudget,deriv), 'gs', label='Initial')
+        plot(initbudget, pchip(x,y,initbudget,deriv), 'gs', label='Initial')
     if not optbudget == None:
-        plt.plot(optbudget, pchip(x,y,optbudget,deriv), 'ro', label='Optimized')
+        plot(optbudget, pchip(x,y,optbudget,deriv), 'ro', label='Optimized')
     ax.legend(loc='best')
     if returnplot:
         return ax
     else:
-        plt.show()
+        show()
 #    except:
 #        print('Plotting of PCHIP-interpolated data failed!')
     

--- a/optima/portfolio.py
+++ b/optima/portfolio.py
@@ -602,7 +602,7 @@ class GAOptim(object):
     
 #    def superplot(self):
 #        
-#        from matplotlib.pylab import gca, xlabel, tick_params, xlim, figure, subplot, plot, pie, bar, title, legend, xticks, ylabel, show
+#        from pylab import gca, xlabel, tick_params, xlim, figure, subplot, plot, pie, bar, title, legend, xticks, ylabel, show
 #        from gridcolormap import gridcolormap
 #        from matplotlib import gridspec
 #        import numpy

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -7,7 +7,7 @@ Version: 2016feb06
 """
 
 from optima import OptimaException, printv, uuid, today, sigfig, getdate, dcp, smoothinterp, findinds, odict, Settings, sanitize, objrepr, gridcolormap, isnumber, promotetoarray, vec2obj, runmodel
-from numpy import ones, prod, array, zeros, exp, linspace, append, nan, isnan, maximum, minimum, sort, concatenate as cat, transpose
+from numpy import ones, prod, array, zeros, exp, log, linspace, append, nan, isnan, maximum, minimum, sort, concatenate as cat, transpose
 from random import uniform
 import abc
 
@@ -1184,9 +1184,13 @@ class Costcov(CCOF):
 
         nyrs,npts = len(u),len(x)
         eps = array([eps]*npts)
-        if nyrs==npts: return maximum((2*s/(1+exp(-2*x/(popsize*s*u)))-s)*popsize,eps)
-        else: raise OptimaException('coverage vector should be the same length as params.')
-
+        if nyrs==npts: return maximum(-0.5*popsize*s*u*log(maximum(s*popsize-x,0)/(s*popsize+x)),eps)
+        else:
+            y = zeros((nyrs,npts))
+            for yr in range(nyrs):
+                y[yr,:] = maximum(-0.5*popsize[yr]*s[yr]*u[yr]*log(maximum(s[yr]*popsize[yr]-x,0)/(s[yr]*popsize[yr]+x)),eps)
+            return y
+            
 
 ########################################################
 # COVERAGE OUTCOME FUNCTIONS

--- a/optima/project.py
+++ b/optima/project.py
@@ -360,6 +360,10 @@ class Project(object):
         for ind in range(len(simparslist)):
             try:
                 raw = model(simparslist[ind], self.settings, die=die, debug=debug, verbose=verbose) # ACTUALLY RUN THE MODEL
+                if not (raw['people']>=0).all(): # Check for negative people
+                    printv('Negative people found with runsim(); rerunning with a smaller timestep...')
+                    self.settings.dt /= 4
+                    raw = model(simparslist[ind], self.settings, die=die, debug=debug, verbose=verbose) # ACTUALLY RUN THE MODEL
             except:
                 printv('Running model failed; running again with debugging...', 1, verbose)
                 raw = model(simparslist[ind], self.settings, die=die, debug=True, verbose=verbose) # ACTUALLY RUN THE MODEL

--- a/optima/results.py
+++ b/optima/results.py
@@ -4,10 +4,8 @@ This module defines the classes for stores the results of a single simulation ru
 Version: 2016feb04 by cliffk
 """
 
-from optima import OptimaException, Settings, uuid, today, getdate, quantile, printv, odict, dcp, objrepr, defaultrepr, sigfig
+from optima import OptimaException, Settings, uuid, today, getdate, quantile, printv, odict, dcp, objrepr, defaultrepr, sigfig, pchip, plotpchip
 from numpy import array, nan, zeros, arange, shape
-import matplotlib.pyplot as plt
-from optima import pchip, plotpchip
 from numbers import Number
 
 
@@ -388,6 +386,7 @@ class Multiresultset(Resultset):
 
 class BOC(object):
     ''' Structure to hold a budget and outcome array for geospatial analysis'''
+    from pylab import xlabel, ylabel, show
     def __init__(self, name='unspecified', x=None, y=None, objectives=None):
         self.uid = uuid()
         self.created = today()
@@ -417,12 +416,12 @@ class BOC(object):
     def plot(self, deriv = False, returnplot = False, initbudget = None, optbudget = None):
         ''' Plot the budget-outcome curve '''
         ax = plotpchip(self.x, self.y, deriv = deriv, returnplot = True, initbudget = initbudget, optbudget = optbudget)                 # Plot interpolation
-        plt.xlabel('Budget')
-        if not deriv: plt.ylabel('Outcome')
-        else: plt.ylabel('Marginal outcome')
+        xlabel('Budget')
+        if not deriv: ylabel('Outcome')
+        else: ylabel('Marginal outcome')
         
         if returnplot: return ax
-        else: plt.show()
+        else: show()
         return None
 
 

--- a/optima/utils.py
+++ b/optima/utils.py
@@ -639,7 +639,7 @@ def checkmem(origvariable, descend=0, order='n', plot=False, verbose=0):
         print('Variable %s is %s' % (printnames[v], printsizes[v]))
 
     if plot==True:
-        from matplotlib.pylab import pie, array, axes
+        from pylab import pie, array, axes
         axes(aspect=1)
         pie(array(printbytes)[inds], labels=array(printnames)[inds], autopct='%0.2f')
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -62,6 +62,8 @@ def parse_costcovdata(costcovdata):
     if costcovdata is None:
         return None
     result = []
+    print ">> parsing costcovdata"
+    pprint(costcovdata, indent=2)
     costcovdata = normalize_obj(costcovdata)
     n_year = len(costcovdata['t'])
     for i_year in range(n_year):
@@ -76,18 +78,20 @@ def parse_costcovdata(costcovdata):
     return result
 
 
-pluck = lambda l, k: [e[k] if e[k] is not None else nan for e in l]
+pluck = lambda l, k: [e[k] for e in l]
+to_nan = lambda v: v if v is not None and v != "" else nan
 
 
 def revert_costcovdata(costcov):
     result = {}
     if costcov:
+        costcov = normalize_obj(costcov)
         result = {
-            't': pluck(costcov, 'year'),
-            'cost': pluck(costcov, 'cost'),
-            'coverage': pluck(costcov, 'coverage'),
+            't': map(to_nan, pluck(costcov, 'year')),
+            'cost': map(to_nan, pluck(costcov, 'cost')),
+            'coverage': map(to_nan, pluck(costcov, 'coverage')),
         }
-    return normalize_obj(result)
+    return result
 
 
 def revert_ccopars(ccopars):

--- a/tests/testprograms.py
+++ b/tests/testprograms.py
@@ -25,6 +25,7 @@ tests = [
 ##############################################################################
 
 from optima import tic, toc, blank, pd # analysis:ignore
+from numpy.testing import assert_allclose
 
 if 'doplot' not in locals(): doplot = True
 
@@ -39,6 +40,11 @@ for i,test in enumerate(tests): print(('%i.  '+test) % (i+1))
 blank()
 
 T = tic()
+
+# Set tolerance levels
+eps = 1e-2
+atol = 1e-2
+rtol = 1e-2
 
 ##############################################################################
 ## The tests
@@ -202,8 +208,11 @@ if 'makeprograms' in tests:
                        'M 15+': array([ 0.3]),
                        'MSM': [ 0.15]}
     
-    HTC.getcoverage(x=[2e7],t=[2016],parset=P.parsets['default'],total=False)
-    HTC.getbudget(x=linspace(0,1e6,3),t=[2013,2015,2017],parset=P.parsets['default'],proportion=False)
+    # Make sure that getcoverage and getbudget are the reciprocal of each other.
+    a = HTC.getcoverage(x=1e6,t=2016,parset=P.parsets['default'])
+    b = HTC.getbudget(x=a,t=2016,parset=P.parsets['default'])
+    assert_allclose(1e6,b,rtol=rtol)
+    
 
     # NB, if you want to evaluate it for a particular population size, can also do...
     HTC.costcovfn.evaluate(x=[1e6],popsize=[1e5],t=[2015],toplot=False)
@@ -277,7 +286,7 @@ if 'makeprograms' in tests:
     coverage = coverage.sort([p.short for p in R.programs.values()])
 
     defaultbudget = R.getdefaultbudget()
-    defaultcoverage = R.getdefaultcoverage(t=2015, parset=P.parsets['default'])
+    defaultcoverage = R.getdefaultcoverage(t=2016, parset=P.parsets['default'])
 
     R.getprogcoverage(budget=budget,
                       t=[2015,2016,2020],


### PR DESCRIPTION
Note: this depends on PR #865
- merges auto-calibration page with manual calibration page: resolves a massive duplication of code in the webclient, which moving forward would have been a maintenance nightmare
- simplified the webserver API to handle this
- streamlined the celery task server manager to handle autofit tasks robustly
- added a startup cleanup of the part of the DB that talks to celery
- put in the refactored graphing organization code that allows instant showing/hiding of graphs that have been uploaded, this graphing organization code is now used across all the pages instead of being cut-and-pasted for each individual page (another massive duplication of code)
- save autofit parameters to DB. before, only the results of autofit were saved to DB, which was displayed but not actually usable, issue #862
- copies parsets correctly, issue #816 

Warning: autofit saves directly to DB, atm. this will be changed in the future, but at least now, autofit parameters can be edited. before, although autofit is run, there is no way to access the automated parameters in the editing box
