### PR TITLE
cant use subfolders in tmp since permissions might not work

### DIFF
--- a/server/webapp/utils.py
+++ b/server/webapp/utils.py
@@ -159,7 +159,6 @@ class RequestParser(OrigReqParser):
 
 
 TEMPLATEDIR = "/tmp" # CK: hotfix to prevent ownership issues
-PROJECTDIR = "/tmp"
 
 
 def fullpath(filename, datadir=None):


### PR DESCRIPTION
quick fix to avoid permissions problems in /tmp directory -- current implementation doesn't support multiple users, this does. @critcortex please review.
