### PR TITLE
dont show improvement graph by default

### DIFF
--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -22,7 +22,7 @@ epiformatsdict = odict([('tot',epiformatslist[0]), ('per',epiformatslist[1]), ('
 datacolor = (0,0,0) # Define color for data point -- WARNING, should this be in settings.py?
 defaultepiplots = ['prev-tot', 'prev-per', 'numplhiv-sta', 'numinci-sta', 'numdeath-sta', 'numdiag-sta', 'numtreat-sta', 'popsize-sta'] # Default epidemiological plots
 #defaultplots = ['improvement', 'budget', 'cascade'] + defaultepiplots # Define the default plots available
-defaultplots = ['improvement', 'budget'] + defaultepiplots # Define the default plots available # WARNING, TEMP
+defaultplots = ['budget'] + defaultepiplots # Define the default plots available # WARNING, TEMP
 
 # Define global font sizes
 globaltitlesize = 10


### PR DESCRIPTION
@critcortex this was requested by david you said, the option is still available, just not selected by default
