### PR TITLE
added an extra sanity check to the initialization

### DIFF
--- a/optima/model.py
+++ b/optima/model.py
@@ -849,8 +849,6 @@ def model(simpars=None, settings=None, verbose=None, die=False, debug=False):
             
             # Reconcile population sizes for populations with no inflows
             thissusreg = people[susreg,noinflows,t+1] # WARNING, will break if susreg is not a scalar index!
-            if any(thissusreg<0) or any(thissusreg>1e8):
-                import traceback; traceback.print_exc(); import pdb; pdb.set_trace()
             thisprogcirc = people[progcirc,noinflows,t+1]
             allsus = thissusreg+thisprogcirc
             newpeople = popsize[noinflows,t+1] - people[:,:,t+1][:,noinflows].sum(axis=0) # Number of people to add according to simpars['popsize'] (can be negative)


### PR DESCRIPTION
@robyn please review, should now work to run dumb scenarios like:

```
from optima import Budgetscen, defaults, dcp, pygui
P = defaults.defaultproject('best')
defaultbudget = P.progsets['default'].getdefaultbudget()
maxbudget = dcp(defaultbudget)
for key in maxbudget: maxbudget[key] += 1e14
scenlist = [
    Budgetscen(name='Current conditions', parsetname='default', progsetname='default', t=[2000], budget=defaultbudget),
    Budgetscen(name='Unlimited spending', parsetname='default', progsetname='default', t=[2000], budget=maxbudget),
    ]
P.addscenlist(scenlist)
P.runscenarios() 
pygui(P.results[-1], toplot='default')
```
