### PR TITLE
changed messages to report http status codes

### DIFF
--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -72,7 +72,12 @@ define([
                 message = 'Something went wrong. Please try again or contact the support team.';
                 errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
               } else {
-                message = 'Sorry, but our servers feel bad right now. Please, give them some time to recover or contact the support team.';
+                message = 'HTTP status code: ' + rejection.status;
+                if (!rejection.statusText) {
+                  errorText = 'No response from server';
+                } else {
+                  errorText = rejection.statusText;
+                }
               }
               var modalService = $injector.get('modalService');
               modalService.inform(angular.noop, 'Okay', message, 'Server Error', errorText);

--- a/client/source/js/modules/user/edit-ctrl.js
+++ b/client/source/js/modules/user/edit-ctrl.js
@@ -54,7 +54,7 @@ define(['./module', 'sha224/sha224'], function (module, SHA224) {
             case 400:
               break;
             default:
-              $scope.error = 'Server feels bad. Please try again in a bit';
+              $scope.error = 'HTTP status code:' + error.status;
           }
         }
       );

--- a/client/source/js/modules/user/login-ctrl.js
+++ b/client/source/js/modules/user/login-ctrl.js
@@ -30,7 +30,7 @@ define(['./module', 'sha224/sha224'], function (module, SHA224) {
           if (error.status === 401) {
             $scope.error = 'Wrong username or password. Please check credentials and try again';
           } else {
-            $scope.error = 'Server feels bad. Please try again in a bit';
+            $scope.error = 'HTTP status code:' + error.status;
           }
         }
       );

--- a/client/source/js/modules/user/register-ctrl.js
+++ b/client/source/js/modules/user/register-ctrl.js
@@ -42,7 +42,7 @@ define(['./module', 'sha224/sha224'], function (module, SHA224) {
             case 400:
               break;
             default:
-              $scope.error = 'Server feels bad. Please try again in a bit';
+              $scope.error = 'HTTP status code:' + error.status;
           }
         }
       );


### PR DESCRIPTION
issue https://github.com/optimamodel/optima/issues/1502

- if the client encounters HTTP error codes other that 500: internal error, it will display the HTTP error code and the error.statusText
- the stack trace is only sent when the python webserver can capture errors in a high level `try: except` clause and, the webserver is able to catch the exception and convert it into JSON to send to the client in the HTTP error response
- there are a range of other cases beyond this, namely when the webserver itself has died, leading typically to the HTTP error code of 0, and when the wsgi twisted server is still running but has detected an error in the webserver, typically leading to error codes of 5** other than 500