### PR TITLE
Improve odict repr

### DIFF
--- a/optima/utils.py
+++ b/optima/utils.py
@@ -1242,7 +1242,7 @@ class odict(OrderedDict):
         
         # Set primitives for display.
         toolong = ' [...]' # String to display at end of line when maximum value character length is overrun.
-        dividerstr = '\n'+'#'*60+'\n' # String to use as an inter-item divider.
+        dividerstr = '*'*40+'\n' # String to use as an inter-item divider.
         indentstr = '    ' # Create string to use to indent.
         
         # Only if we are in the root call, indent by the number of indents.
@@ -1269,7 +1269,7 @@ class odict(OrderedDict):
                     thisvalstr = str(thisval.__repr__(maxlen=maxlen, showmultilines=showmultilines, divider=divider, 
                         dividerthresh=dividerthresh, numindents=numindents, recurselevel=recurselevel+1))
                 else: # Otherwise, do the normal __repr__() read.
-                    thisvalstr = str(thisval.__repr__())
+                    thisvalstr = thisval.__repr__()
 
                 # Add information to the lists to retrace afterwards.
                 keystrs.append(thiskeystr)
@@ -1283,7 +1283,7 @@ class odict(OrderedDict):
                 vallinecount = vallinecounts[i]
                 
                 if (divider or (maxvallinecounts>dividerthresh)) and \
-                    showmultilines and recurselevel == 0 and i!=0: # Add a divider line if we should.
+                    showmultilines and recurselevel==0 and i!=0: # Add a divider line if we should.
                     newoutput = indent(prefix=theprefix, text=dividerstr, width=80)
                     if newoutput[-1] == '\n':
                         newoutput = newoutput[:-1]


### PR DESCRIPTION
Hierarchical display of odicts is much improved.  To test:

import optima as op
P = op.demo(0)
toydict = op.odict()
toydict['author'] = 'George Chadderdon'
toydict['title'] = 'Emancipation'
toydict['copyright'] = 2017
toydict['publisher'] = 'Who Knows Publications'
toydict2 = op.odict()
toydict2['minime'] = toydict
toydict2['author'] = 'George Chadderdon'
toydict2['title'] = 'Emancipation'
toydict2['copyright'] = 2017
toydict2['publisher'] = 'Who Knows Publications'
toydict3 = op.odict()
toydict3['minime'] = toydict2
toydict3['author'] = 'George Chadderdon'
toydict3['title'] = 'Emancipation'
toydict3['copyright'] = 2017
toydict3['publisher'] = 'Who Knows Publications'

Try and verify good output for:
toydict3
P.parsets
P.data
