### PR TITLE
Widen unit cost box

### DIFF
--- a/client/source/js/modules/costfunction/cost-function.html
+++ b/client/source/js/modules/costfunction/cost-function.html
@@ -114,7 +114,7 @@
                   width: 100%;
                   margin-top: 10px">
 
-            <div style="flex: 0 0 510px;">
+            <div style="flex: 0 0 540px;">
 
               <h3>Define cost function
                 <help ref="define-cost-function"/>
@@ -182,7 +182,7 @@
                           min="0"
                           type="number"
                           step="any"
-                          style="width: 70px"
+                          style="width: 85px"
                           class="txbox __inline"
                           required/>
                       -
@@ -193,7 +193,7 @@
                           min="0"
                           type="number"
                           step="any"
-                          style="width: 70px"
+                          style="width: 85px"
                           class="txbox __inline"
                           required/>
                       <div class="error-hint" ng-show="unitForm.$invalid">


### PR DESCRIPTION
It should now be possible to enter as a Unit cost, values of size xxxxx.xx.

To test:
* Open a project where you can adjust the cost functions.
* Go to the Cost functions tab.
* Enter larger values in Unit cost textboxes.