### PR TITLE
Allow addccopar to give an empty list

### DIFF
--- a/optima/programs.py
+++ b/optima/programs.py
@@ -1075,7 +1075,7 @@ class CCOF(object):
         else:
             if (not self.ccopars['t']) or (ccopar['t'] not in self.ccopars['t']):
                 for ccopartype in self.ccopars.keys():
-                    if ccopartype in ccopar.keys():
+                    if ccopartype in ccopar.keys() and ccopar[ccopartype] is not None: #Treatment progs can have an empty list for saturation
                         self.ccopars[ccopartype].append(ccopar[ccopartype])
                 printv('\nAdded CCO parameters "%s". \nCCO parameters are: %s' % (ccopar, self.ccopars), 4, verbose)
             else:


### PR DESCRIPTION
Adding with an empty list resulted in [[]], adding with None resulted in
[None], unless there is some other way of calling this that didn't occur
to me and this change isn't necessary (seems likely)?