### PR TITLE
fix-disappearing-target-population

### DIFF
--- a/client/source/js/modules/programs/program-modal.js
+++ b/client/source/js/modules/programs/program-modal.js
@@ -26,7 +26,7 @@ define(['angular', 'underscore'], function (angular, _) {
       $scope.state = {
         selectAll: false,
         isNew: !program.name,
-        populations: deepCopy(populations), // all possible populations in the program
+        populations: populations, // all possible populations in the program
         parameters: parameters, // all possible parameters
         categories: categories,
         program: program,
@@ -59,25 +59,20 @@ define(['angular', 'underscore'], function (angular, _) {
       console.log('ProgramModalController.init costcov', $scope.state.program.costcov);
       $scope.years = _.range(openProject.startYear, openProject.endYear+1);
 
-      if (isAnyTargetparForTotal) {
-        $scope.state.progPopReadOnly = true;
-        $scope.state.selectAll = true;
-        $scope.clickAllTargetPopulations();
+      console.log('ProgramModalController.init program', $scope.state.program);
+      if (isNonemptyList($scope.state.program.populations)) {
+        _.forEach($scope.state.populations, function(population) {
+          population.active = (
+            $scope.state.program.populations.length === 0)
+            || ($scope.state.program.populations.indexOf(population.short) > -1);
+        });
+        $scope.state.selectAll = !_.find($scope.state.populations, function(population) {
+          return !population.active;
+        })
       } else {
-        console.log('ProgramModalController.init program', $scope.state.program);
-        if (isNonemptyList($scope.state.program.populations)) {
-          _.forEach($scope.state.populations, function(population) {
-            population.active = (
-              $scope.state.program.populations.length === 0)
-               || ($scope.state.program.populations.indexOf(population.short) > -1);
-          });
-          $scope.state.selectAll = !_.find($scope.state.populations, function(population) {
-            return !population.active;
-          })
-        } else {
-          $scope.state.program.populations = [];
-        }
+        $scope.state.program.populations = [];
       }
+
 
       _.forEach($scope.state.program.targetpars, setAttrOfPar);
       console.log('ProgramModalController.init targetpars', $scope.state.program.targetpars);


### PR DESCRIPTION
@robynstuart seems to fix the problem, although i did this by removing a `deepCopy()`, which i assume was there to prevent some _other_ bug, so i am a little concerned about what the consequences might be. haven't found any way to make this break, though.

also removed a pointless FE restriction that programs targeting a `tot` parameter had to target all populations (which isn't true for e.g. OST).

running on sandbox.

cc @gchadder3, maybe spend 10 min looking at `programs-modal.js` and make sure i didn't do anything obviously incompetent by removing the `deepCopy()`. subtly incompetent is fine though.