### PR TITLE
wording changes

### DIFF
--- a/optima/results.py
+++ b/optima/results.py
@@ -80,10 +80,10 @@ class Resultset(object):
         self.settings = settings if settings is not None else Settings()
         
         # Main results -- time series, by population
-        self.main['numinci']        = Result('New infections acquired')
-        self.main['numdeath']       = Result('HIV-related deaths')
+        self.main['numinci']        = Result('New HIV infections')
+        self.main['numdeath']       = Result('AIDS-related deaths')
         self.main['numdaly']        = Result('HIV-related DALYs')
-        self.main['numincibypop']   = Result('New infections caused')
+        self.main['numincibypop']   = Result('New HIV infections caused')
         
         self.main['numplhiv']       = Result('PLHIV')
         self.main['numaids']        = Result('People with AIDS')

--- a/optima/results.py
+++ b/optima/results.py
@@ -81,7 +81,7 @@ class Resultset(object):
         
         # Main results -- time series, by population
         self.main['numinci']        = Result('New HIV infections')
-        self.main['numdeath']       = Result('AIDS-related deaths')
+        self.main['numdeath']       = Result('HIV-related deaths')
         self.main['numdaly']        = Result('HIV-related DALYs')
         self.main['numincibypop']   = Result('New HIV infections caused')
         


### PR DESCRIPTION
A couple of changes to the wording on results as requested by @sherriekelly 

@cliffckerr pls review.

NB, I'm a bit uncertain about the CHANGE FROM: HIV-related deaths --> AIDS-related deaths because technically this could include deaths of people who haven't developed AIDS. However, in practice the contribution from these deaths is v small