### PR TITLE
Include saturation

### DIFF
--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -54,6 +54,7 @@ def setmigrations(which='migrations'):
         ('2.6.1', ('2.6.2', '2017-12-19', None,              'New results format')),
         ('2.6.2', ('2.6.3', '2018-01-17', addtimevarying,    'Preliminaries for time-varying optimization')),
         ('2.6.3', ('2.6.4', '2018-01-24', None,              'Changes to how proportions are handled')),
+        ('2.6.4', ('2.6.5', '2018-01-24', None,              'Updates interactions between programs')),
         ])
     
     # Define changelog

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -385,10 +385,10 @@ class Programset(object):
         return thisbudget
 
 
-    def getdefaultcoverage(self, t=None, parset=None, results=None, verbose=2, sample='best'):
+    def getdefaultcoverage(self, t=None, parset=None, results=None, verbose=2, sample='best', proportion=False):
         ''' Extract the coverage levels corresponding to the default budget'''
         defaultbudget = self.getdefaultbudget()
-        defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, sample=sample)
+        defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
         for progno in range(len(defaultcoverage)):
             defaultcoverage[progno] = defaultcoverage[progno][0] if defaultcoverage[progno] else nan    
         return defaultcoverage

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -548,7 +548,8 @@ class Programset(object):
                             if not self.covout[thispartype][thispop].ccopars[thisprog.short]:
                                 print('WARNING: no coverage-outcome parameters defined for program  "%s", population "%s" and parameter "%s". Skipping over... ' % (thisprog.short, thispop, thispartype))
                                 outcomes[thispartype][thispop] = None
-                            else: outcomes[thispartype][thispop] += thiscov[thisprog.short]*delta[thisprog.short]
+                            else: 
+                                outcomes[thispartype][thispop] += thiscov[thisprog.short]*delta[thisprog.short] * self.programs[thisprog.short].costcovfn.ccopars['saturation']
                             
                     # NESTED CALCULATION
                     elif self.covout[thispartype][thispop].interaction == 'nested':

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,2 +1,2 @@
-version = '2.6.4'
-versiondate = '2018-01-24'
+version = '2.6.5'
+versiondate = '2018-04-02'

--- a/tests/benchmark.txt
+++ b/tests/benchmark.txt
@@ -97,3 +97,5 @@
 0.868 2017-Oct-30_18:14:10 49e8971 time-varying-optimization (benchmark:18.94m)
 0.552 2017-Oct-30_18:27:40 2f93690 time-varying-optimization (benchmark:18.64m)
 0.505 2017-Oct-30_18:50:53 2035162 time-varying-optimization (benchmark:18.87m)
+0.890 2018-Mar-29_17:21:06 b586b1b develop (benchmark:16.89m)
+0.818 2018-Mar-29_17:22:42 b586b1b develop (benchmark:17.63m)


### PR DESCRIPTION
@robynstuart i think there was a bug so that saturation wasn't being counted in program interactions -- i.e., if you set saturation to 10% and the budget was enough to cover 10% of the population, then for the sake of the covout function, coverage was being counted as 100% (instead of 10%). i think this fixes it. pls test and review. related to card https://trello.com/b/CSqYTPJf/optima-hiv-development