### PR TITLE
Diagnosed births

### DIFF
--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -54,6 +54,7 @@ def setmigrations(which='migrations'):
         ('2.6.1', ('2.6.2', '2017-12-19', None,              'New results format')),
         ('2.6.2', ('2.6.3', '2018-01-17', addtimevarying,    'Preliminaries for time-varying optimization')),
         ('2.6.3', ('2.6.4', '2018-01-24', None,              'Changes to how proportions are handled')),
+        ('2.6.4', ('2.6.5', '2018-04-12', None,              'Changes to how HIV+ births are handled')),
         ])
     
     # Define changelog

--- a/optima/model.py
+++ b/optima/model.py
@@ -710,8 +710,10 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
         else:                   calcproppmtct = proppmtct[t] # Else, just use the proportion specified
         calcproppmtct = min(calcproppmtct, 1.)
         
-        undxhivbirths = 0 
-        dxhivbirths = 0 
+        undxhivbirths = zeros(npops) 
+        dxhivbirths = zeros(npops)
+        otherbirths = zeros(npops)
+        popmtct = zeros(npops)
         
         # Calculate actual births, MTCT, and PMTCT
         for p1,p2,birthrates,alleligbirthrate in birthslist:
@@ -724,14 +726,17 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
             mtctdx = (thiseligbirths * (1-calcproppmtct)) * effmtct[t] # MTCT from those diagnosed not receiving PMTCT
             mtctpmtct = (thiseligbirths * calcproppmtct) * pmtcteff[t] # MTCT from those receiving PMTCT
             thisreceivepmtct = thiseligbirths * calcproppmtct
-            popmtct = mtctundx + mtctdx + mtcttx + mtctpmtct # Total MTCT, adding up all components         
+            thispopmtct = mtctundx + mtctdx + mtcttx + mtctpmtct # Total MTCT, adding up all components         
 
-            undxhivbirths += mtctundx                        # Births to add to undx  
-            dxhivbirths   += (mtctdx + mtcttx + mtctpmtct)   # Births add to dx
+            undxhivbirths[p2] = mtctundx                       # Births to add to undx  
+            dxhivbirths[p2]   = (mtctdx + mtcttx + mtctpmtct)   # Births add to dx
+#            import traceback; traceback.print_exc(); import pdb; pdb.set_trace()
+#            otherbirths[p2]   = popbirths - undxhivbirths - dxhivbirths   # Births add to dx
+            popmtct[p2]       = thispopmtct
             
             raw_receivepmtct[p1, t] += thisreceivepmtct * timestepsonpmtct
-            raw_mtct[p2, t] += popmtct/dt
-            raw_mtctfrom[p1, t] += popmtct/dt
+            raw_mtct[p2, t] += thispopmtct/dt
+            raw_mtctfrom[p1, t] += thispopmtct/dt
             raw_births[p2, t] += popbirths/dt
             raw_hivbirths[p1, t] += thisbirthrate * fsums[p1]['allplhiv'] / dt
             
@@ -749,9 +754,12 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
         if t<npts-1:
             
             ## Births 
-            people[undx[0], :, t+1] += undxhivbirths # HIV+ babies born to undiagnosed mothers assigned to undiagnosed compartment 
-            people[dx[0], :, t+1]   += dxhivbirths   # HIV+ babies born to diagnosed mothers assigned to diagnosed compartment
-            people[susreg, :, t+1]  += (raw_births[:,t] - raw_mtct[:, t])*dt  # HIV- babies assigned to uncircumcised compartment
+            people[undx[0], :, t+1] += popmtct # HIV+ babies assigned to undiagnosed compartment -- WARNING, shouldn't use a raw variable in a calculation, that's for output
+            people[susreg, :, t+1] += (raw_births[:,t] - raw_mtct[:, t])*dt  # HIV- babies assigned to uncircumcised compartment
+
+#            people[undx[0], :, t+1] += undxhivbirths # HIV+ babies born to undiagnosed mothers assigned to undiagnosed compartment 
+#            people[dx[0], :, t+1]   += dxhivbirths   # HIV+ babies born to diagnosed mothers assigned to diagnosed compartment
+#            people[susreg, :, t+1]  +=  otherbirths # HIV- babies assigned to uncircumcised compartment
 
             ## Circumcision 
             circppl = minimum(numcirc[:,t+1], people[susreg,:,t+1])

--- a/optima/model.py
+++ b/optima/model.py
@@ -710,9 +710,8 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
         else:                   calcproppmtct = proppmtct[t] # Else, just use the proportion specified
         calcproppmtct = min(calcproppmtct, 1.)
         
-        undxhivbirths = zeros(npops) 
-        dxhivbirths = zeros(npops)
-#        popmtct = zeros(npops)
+        undxhivbirths = zeros(npops) # Store undiagnosed HIV+ births for this timestep
+        dxhivbirths = zeros(npops) # Store diagnosed HIV+ births for this timestep
         
         # Calculate actual births, MTCT, and PMTCT
         for p1,p2,birthrates,alleligbirthrate in birthslist:
@@ -736,7 +735,6 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
             raw_births[p2, t] += popbirths/dt
             raw_hivbirths[p1, t] += thisbirthrate * fsums[p1]['allplhiv'] / dt
             
-#        import traceback; traceback.print_exc(); import pdb; pdb.set_trace()
         raw_inci[:,t] += raw_mtct[:,t] # Update infections acquired based on PMTCT calculation
         raw_incibypop[:,t] += raw_mtctfrom[:,t] # Update infections caused based on PMTCT calculation
 

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,2 +1,2 @@
-version = '2.6.4'
-versiondate = '2018-01-24'
+version = '2.6.5'
+versiondate = '2018-04-12'


### PR DESCRIPTION
Previously, all HIV+ births were being assigned to the undiagnosed compartment, even if the mother was diagnosed. This fixes that.

@cliffckerr if you could review as soon as possible, please, as this is needed for Swaziland (cc @sherriekelly)
