### PR TITLE
Remove 'estimated population' column from cost functions page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,7 @@
     "underscore": "=1.8.3"
   },
   "scripts": {
-    "postinstall": "node_modules/bower/bin/bower install"
+    "postinstall": "bower install"
   },
   "dependencies": {
     "gulp": "^3.9.1"

--- a/client/source/js/modules/costfunction/cost-function.html
+++ b/client/source/js/modules/costfunction/cost-function.html
@@ -127,7 +127,6 @@
                   class="section table table-bordered">
                 <tr>
                   <td>Year</td>
-                  <td>Estimated<br>population</td>
                   <td>Saturation %</td>
                   <td>Unit cost</td>
                   <td></td>
@@ -139,11 +138,6 @@
                         ng-change="vm.setEstPopulationForCcopar()"
                         ng-options="year for year in vm.state.yearSelector"
                         class="txbox"/>
-                  </td>
-                  <td valign="center">
-                    <div class="txbox">
-                      {{row[1]}}
-                    </div>
                   </td>
                   <td>
                     <ng-form name="saturationForm">


### PR DESCRIPTION
Removed the 'estimated population' column from cost functions page and updated the package.json file so that 'npm install' works on Windows.