### PR TITLE
Remove years from plotcascade function call

### DIFF
--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -215,7 +215,7 @@ def makeplots(results=None, toplot=None, die=False, verbose=2, plotstartyear=Non
     ## Add cascade plot(s) with bars
     if 'cascadebars' in toplot:
         toplot.remove('cascadebars') # Because everything else is passed to plotepi()
-        cascadebarplots = plotcascade(results, die=die, plotstartyear=plotstartyear, plotendyear=plotendyear, fig=fig, asbars=True, **kwargs)
+        cascadebarplots = plotcascade(results, die=die, fig=fig, asbars=True, **kwargs)
         allplots.update(cascadebarplots)
     
     ## Add deaths by CD4 plot -- WARNING, only available if results includes raw


### PR DESCRIPTION
The cascade bars should not be plotted between the simulation years, the function already handles the default values for years depending on the data and the simulation (lines 894 to 903).

Solves Trello card: https://trello.com/c/X9mdsMTE/966-cascade-plots-are-broken-on-fe.