### PR TITLE
Respect selected plots

### DIFF
--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -402,20 +402,21 @@ define(
             });
         };
 
-        scope.switchGraphs = function() {
+        scope.toggleAdvanced = function() {
           scope.graphs.advanced = !scope.graphs.advanced;
           var resultId = scope.graphs.resultId;
           if (_.isUndefined(resultId)) {
             return;
           }
-          console.log('switchGraphs', scope.graphs.advanced, 'reusltId', scope.graphs.resultId);
-          var which = ["default"];
+          console.log('toggleAdvanced', scope.graphs.advanced, 'resultId', scope.graphs.resultId);
+          var which = scope.getSelectors();
+          var zoom = scope.state.slider2.currentValue;
           if (scope.graphs.advanced) {
             which.push("advanced");
           }
           rpcService
             .rpcRun('load_result_mpld3_graphs',
-              [resultId, which])
+              [resultId, which, zoom])
             .then(function(response) {
               scope.graphs = response.data.graphs;
               toastr.success('Graphs updated');
@@ -474,9 +475,9 @@ define(
         );
 
         // WARNING -- do we need this!?
-        scope.toggleAdvanced = function() {
+        /*scope.toggleAdvanced = function() {
           scope.switchGraphs();
-        };
+        };*/
 
         // Or this?
         scope.defaultSelectors = function() {

--- a/server/webapp/plot.py
+++ b/server/webapp/plot.py
@@ -129,7 +129,7 @@ def make_mpld3_graph_dict(result=None, which=None, zoom=None, startYear=None, en
         n = len(graph_selectors['keys'])
         for i in range(n):
             key = graph_selectors['keys'][i]
-            if key.startswith(normal_default_keys) and ('total' in key or 'stacked' in key):
+            if key.startswith(normal_default_keys) and ('stacked' in key) and ('numincibypop' not in key):
                 graph_selectors['defaults'][i] = True
     selectors = convert_to_selectors(graph_selectors)
 

--- a/server/webapp/plot.py
+++ b/server/webapp/plot.py
@@ -109,8 +109,15 @@ def make_mpld3_graph_dict(result=None, which=None, zoom=None, startYear=None, en
         else:
             which = ["default"]
     else:
-        advanced = False
-        if 'advanced' in which:
+        if 'advanced' not in which:
+            advanced = False
+            which = [w.split("-")[0] for w in which]
+            def remove_duplicates(seq):
+                seen = set()
+                seen_add = seen.add
+                return [x for x in seq if not (x in seen or seen_add(x))]
+            which = remove_duplicates(which)
+        else:
             advanced = True
             which.remove('advanced')
 
@@ -125,12 +132,16 @@ def make_mpld3_graph_dict(result=None, which=None, zoom=None, startYear=None, en
             if normal_graph_selectors["defaults"][i]:
                 normal_default_keys.append(normal_graph_selectors["keys"][i])
         normal_default_keys = tuple(normal_default_keys)
-        # rough and dirty defaults for missing defaults in advanced
+        # rough and dirty defaults for missing defaults in advanced - convert 'numinci' to 'numinci-stacked', for example
         n = len(graph_selectors['keys'])
         for i in range(n):
             key = graph_selectors['keys'][i]
             if key.startswith(normal_default_keys) and ('stacked' in key) and ('numincibypop' not in key):
                 graph_selectors['defaults'][i] = True
+            if (key.split("-")[0] in which) and (('stacked' in key) and ('prev' not in key)):
+                which[which.index(key.split("-")[0])] = key
+        if 'prev' in which:
+            which[which.index('prev')] = 'prev-population'
     selectors = convert_to_selectors(graph_selectors)
 
     default_which = []


### PR DESCRIPTION
Change default plots for "Advanced options": remove "xxx - total" and "New HIV infections caused - xxx" and respect selection of graphs and zoom when toggling between "Normal options" and "Advanced options", as well as when switching tabs ('Calibration', 'Projects', 'Programs', etc). Previous behaviour was to reload default graphs for each each time the options or tabs were toggled.

Solves Trello card: https://trello.com/c/ISDj8EBn/1033-calibration-advanced-display-options-update-default-maintain.