### PR TITLE
Labels and title in bold and larger with the "for_report" kwarg, titles can be specified using "popmapping"

### DIFF
--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -312,6 +312,12 @@ def plotepi(results, toplot=None, uncertainty=True, die=True, showdata=True, ver
         
         # Remove failed ones
         toplot = [thisplot for thisplot in toplot if None not in thisplot] # Remove a plot if datatype or plotformat is None
+
+        # Check if the figure will be saved to insert into a presentation or report
+        if  kwargs["for_report"]:
+            forreport = True
+            titlesize = 16
+            labelsize = 14
         
 
         ################################################################################################################
@@ -484,8 +490,6 @@ def plotepi(results, toplot=None, uncertainty=True, die=True, showdata=True, ver
                 
                 # General configuration
                 boxoff(ax)
-                ax.title.set_fontsize(titlesize)
-                ax.xaxis.label.set_fontsize(labelsize)
                 ax.yaxis.label.set_fontsize(labelsize)
                 for item in ax.get_xticklabels() + ax.get_yticklabels(): item.set_fontsize(ticksize)
     
@@ -494,9 +498,14 @@ def plotepi(results, toplot=None, uncertainty=True, die=True, showdata=True, ver
                 plottitle = results.main[datatype].name
                 if isperpop:  
                     plotylabel = plottitle
-                    plottitle  = results.popkeys[i] # Add extra information to plot if by population
                     ax.set_ylabel(plotylabel)
+                    try: plottitle = kwargs["popmapping"][results.popkeys[i]] # if popmapping was passed in as kwarg, use the title specified there for this population instead
+                    except: plottitle = results.popkeys[i] # Add extra information to plot if by population
+                    if forreport: ax.set_ylabel(plotylabel, fontweight="bold", fontsize=labelsize) # overwrites previously set ylabel
                 ax.set_title(plottitle)
+                if forreport:
+                    ax.set_xlabel('Year', fontweight="bold", fontsize=labelsize)
+                    ax.set_title(plottitle, fontweight="bold", fontsize=titlesize) # overwrites previously set title
                 setylim(allydata, ax=ax)
                 ax.set_xlim((results.tvec[startind], results.tvec[endind]))
                 if not ismultisim:


### PR DESCRIPTION
For example, calling saveplots(..., **{"for_report": True, "popmapping": popmapping}), with:
popmapping = {
    'Clients': 'Clients',
    'F0-14': u'Girls 0\u201414 years',
    'F15-19': u'Females 15\u201419 years',
    'F20-24': u'Females 20\u201424 years',
    'F15-24': u'Females 15\u201424 years',
    'F25-34': u'Females 25\u201434 years',
    'F35-49': u'Females 35\u201449 years',
    'F50+': 'Females 50+ years',
    'FSW': 'Female sex workers',
    'M0-14': u'Boys 0\u201414 years',
    'M15-19': u'Males 15\u201419 years',
    'M20-24': u'Males 20\u201424 years',
    'M15-24': u'Males 15\u201424 years',
    'M25-34': u'Males 25\u201434 years',
    'M35-49': u'Males 35\u201449 years',
    'M50+': 'Males 50+ years',
    'MSM': 'Men who have sex with men',
    'Prisoners': 'Prisoners',
}
makes plots as in attached file.

Addresses Trello card: https://trello.com/c/UQrT5pJt/1037-calibration-figure-axis-labels, although to solve it, extra code would need to be written to call saveplots with those kwargs for plots when downloaded.
[Zimbabwe calibration figures.pptx](https://github.com/optimamodel/optima/files/2252653/Zimbabwe.calibration.figures.pptx)
