### PR TITLE
Python3 website

### DIFF
--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -790,7 +790,6 @@ def plotcoverage(multires=None, die=True, figsize=globalfigsize, legendsize=glob
         fig,naxes = makefigure(figsize=figsize, interactive=interactive, fig=fig)
         ax.append(fig.add_subplot(naxes, 1, naxes))
         setposition(ax[-1], position, interactive)
-        ax[-1].hold(True)
         
         nprogs = nprogslist[plt]
         proglabels = progkeylists[plt]
@@ -1080,7 +1079,6 @@ def plotallocations(project=None, budgets=None, colors=None, factor=1e6, compare
     nplt = len(budgets)
     for plt in range(nplt):
         ax.append(fig.add_subplot(naxes+len(budgets)-1,1,naxes+plt))
-        ax[-1].hold(True)
         for p,ind in enumerate(indices):
             ax[-1].bar([xbardata[p]], [budgets[plt][ind]/factor], color=colors[p], linewidth=0)
             if plt==1 and compare:
@@ -1320,7 +1318,6 @@ def plotcostcov(program=None, year=None, parset=None, results=None, plotoptions=
         plotdata['xlinedata'] = xlinedata
     
     fig,naxes = makefigure(figsize=None, interactive=interactive, fig=existingFigure)
-    fig.hold(True)
     ax = fig.add_subplot(111)
     
     ax.set_position((0.1, 0.35, .8, .6)) # to make a bit of room for extra text

--- a/server/config.example.py
+++ b/server/config.example.py
@@ -15,10 +15,12 @@ SQLALCHEMY_TRACK_MODIFICATIONS = bool(os.getenv('SQLALCHEMY_TRACK_MODIFICATIONS'
 MATPLOTLIB_BACKEND = os.getenv('MATPLOTLIB_BACKEND',"agg")
 SERVER_PORT = int(os.getenv('PORT', 8080))
 WORKERS = int(os.getenv('WORKERS',min(math.ceil(multiprocessing.cpu_count()/2.0),8))) # By default use half the CPUs, up to a maximum of 8
+BIND_IP = os.getenv('BIND_IP',"0.0.0.0")  # Bind address for gunicorn. '0.0.0.0' allows external connections e.g. from a remote nginx, while '127.0.0.1' allows only local access (e.g., a locally running nginx)
 
-# GUNICORN VARIABLES
-bind = '0.0.0.0:%d' % (SERVER_PORT) # Bind to 0.0.0.0 so apollo can talk to athena. The port should generally be publicly firewalled
+# GUNICORN VARIABLES - the variable names below are special and recognized by `gunicorn`
+bind = '%s:%d' % (BIND_IP,SERVER_PORT)
 workers = WORKERS
-timeout = 60 # Increase BE timeout for long running RPCs
+timeout = 60  # Increase BE timeout for long running RPCs
+
 # To use gunicorn, run 'gunicorn --config config.py server.api:app' 
 # Unfortunately, the WSGI app 'server.api:app' cannot be set in this file

--- a/server/config.example.py
+++ b/server/config.example.py
@@ -1,10 +1,24 @@
 # Copy this file to config.py
-SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://optima:optima@localhost:5432/optima'
-SECRET_KEY = 'F12Zr47j\3yX R~X@H!jmM]Lwf/,?KT'
-UPLOAD_FOLDER = '/tmp/uploads'
-CELERY_BROKER_URL = 'redis://localhost:6379'
-CELERY_RESULT_BACKEND = 'redis://localhost:6379'
-CELERY_ACCEPT_CONTENT = ['pickle', 'json', 'msgpack', 'yaml']
-SQLALCHEMY_TRACK_MODIFICATIONS = False
-REDIS_URL = CELERY_BROKER_URL
-MATPLOTLIB_BACKEND = "agg"
+
+import os
+import multiprocessing
+import math
+
+SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI','postgresql+psycopg2://optima:optima@localhost:5432/optima')
+SECRET_KEY = os.getenv('SECRET_KEY','F12Zr47j\3yX R~X@H!jmM]Lwf/,?KT')
+UPLOAD_FOLDER = os.getenv('UPLOAD_FOLDER','/tmp/uploads')
+REDIS_URL = os.getenv('REDIS_URL', 'redis://127.0.0.1:6379/4') # Shortcut for setting both the celery broker and result backend cache
+CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL',REDIS_URL)
+CELERY_RESULT_BACKEND = os.getenv('CELERY_RESULT_BACKEND',REDIS_URL)
+CELERY_ACCEPT_CONTENT = os.getenv('CELERY_ACCEPT_CONTENT','pickle,json,msgpack,yaml').split(',') # Comma separated list
+SQLALCHEMY_TRACK_MODIFICATIONS = bool(os.getenv('SQLALCHEMY_TRACK_MODIFICATIONS',False))
+MATPLOTLIB_BACKEND = os.getenv('MATPLOTLIB_BACKEND',"agg")
+SERVER_PORT = int(os.getenv('PORT', 8080))
+WORKERS = int(os.getenv('WORKERS',min(math.ceil(multiprocessing.cpu_count()/2.0),8))) # By default use half the CPUs, up to a maximum of 8
+
+# GUNICORN VARIABLES
+bind = '0.0.0.0:%d' % (SERVER_PORT) # Bind to 0.0.0.0 so apollo can talk to athena. The port should generally be publicly firewalled
+workers = WORKERS
+timeout = 60 # Increase BE timeout for long running RPCs
+# To use gunicorn, run 'gunicorn --config config.py server.api:app' 
+# Unfortunately, the WSGI app 'server.api:app' cannot be set in this file

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -37,6 +37,9 @@ from .exceptions import ProjectDoesNotExist, ParsetAlreadyExists, \
 from .dbmodels import UserDb, ProjectDb, ResultsDb, PyObjectDb, UndoStackDb
 from .plot import make_mpld3_graph_dict, convert_to_mpld3
 
+import six
+if six.PY3: # Python 3
+    basestring = str
 
 TEMPLATEDIR = "/tmp"  # CK: hotfix to prevent ownership issues
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -20,6 +20,9 @@ import optima as op
 
 from .exceptions import ParsetDoesNotExist, ProgramDoesNotExist, ProgsetDoesNotExist
 
+import six
+if six.PY3: # Python 3
+    unicode = str
 
 #############################################################################################
 ### UTILITIES
@@ -100,6 +103,9 @@ def normalize_obj(obj):
         else:
             return float(obj)
 
+    if isinstance(obj, np.int64):
+        return int(obj)
+
     if isinstance(obj, unicode):
         try:    string = str(obj) # Try to convert it to ascii
         except: string = obj # Give up and use original
@@ -110,6 +116,12 @@ def normalize_obj(obj):
 
     if isinstance(obj, UUID):
         return str(obj)
+
+    if isinstance(obj, map):
+        return list(obj)
+
+    if isinstance(obj, range):
+        return list(obj)
 
     return obj
 


### PR DESCRIPTION
Enable Python 3 compatibility for the FE. Should be backwards compatible but need to double check it's OK on athena with Python 2. Note that the python versions cannot be changed without migrating the database pickles (so this PR can be merged at any point but athena should not be changed to python 3 yet)