### PR TITLE
small FE tick tweaks

### DIFF
--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -39,6 +39,12 @@ define(
       text = val2str(val, 1E6, 'm')
     } else if (val >= 3E3) {
       text = val2str(val, 1E3, 'k')
+    } else if (val <= -1E9) {
+      text = val2str(val, 1E9, 'b')
+    } else if (val <= -1E6) {
+      text = val2str(val, 1E6, 'm')
+    } else if (val <= -3E3) {
+      text = val2str(val, 1E3, 'k')
     }
     return text;
   }
@@ -50,6 +56,12 @@ define(
     } else if (val >= 1E6) {
       text = val2str(val, 1E6, 'm')
     } else if (val >= 1E3) {
+      text = val2str(val, 1E3, 'k')
+    } else if (val <= -1E9) {
+      text = val2str(val, 1E9, 'b')
+    } else if (val <= -1E6) {
+      text = val2str(val, 1E6, 'm')
+    } else if (val <= -1E3) {
       text = val2str(val, 1E3, 'k')
     }
     return text;

--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -37,13 +37,13 @@ define(
       text = val2str(val, 1E9, 'b')
     } else if (val >= 1E6) {
       text = val2str(val, 1E6, 'm')
-    } else if (val >= 3E3) {
+    } else if (val >= 3E3) {  // 3000 so years like 2022 don't get turned into 2k
       text = val2str(val, 1E3, 'k')
     } else if (val <= -1E9) {
       text = val2str(val, 1E9, 'b')
     } else if (val <= -1E6) {
       text = val2str(val, 1E6, 'm')
-    } else if (val <= -3E3) {
+    } else if (val <= -1E3) {
       text = val2str(val, 1E3, 'k')
     }
     return text;

--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -123,14 +123,14 @@ define(
 
     var useBEylabels = false;
     $.each(ylabels, function (i, ylabel) {
-        var textBE = ylabel.replace(/,/g, '');
+        var textBE = ylabel.replace(/k|m|b|,/g, '');
         if (!isNumeric(textBE)) {   // We choose the BE labels if any one of them is not a number
             useBEylabels = true;
         }
     });
     var useBExlabels = false;
     $.each(xlabels, function (i, xlabel) {
-        var textBE = xlabel.replace(/,/g, '');
+        var textBE = xlabel.replace(/k|m|b|,/g, '');
         if (!isNumeric(textBE)) {   // We choose the BE labels if any one of them is not a number
             useBExlabels = true;
         }

--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -184,6 +184,7 @@ define(
       }
       i = i + 1;
     });
+  }
 
   function changeWidthOfSvg(svg, width) {
     var $svg = $(svg);

--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -176,7 +176,6 @@ define(
             console.log('WARNING: FE has length ' + ($labels.length) + ' xlabels but BE has length ' + (xlabels.length));
             console.log({'FE':$labels,'BE':xlabels})
         }
-        }
       }
       else {
         var textorig = $label.text().replace(/,/g, '');

--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -149,7 +149,7 @@ define(
             newTextBE = reformatYTickStr(textBE);
             $label.text(newTextBE);
         } else {
-            console.log(`WARNING: FE has ${$labels.length} ylabels but BE has ${ylabels.length}`);
+            console.log('WARNING: FE has length ' + ($labels.length) + ' ylabels but BE has length ' + (ylabels.length));
             console.log({'FE':$labels,'BE':ylabels})
         }
       }
@@ -173,7 +173,7 @@ define(
             newTextBE = reformatXTickStr(textBE);
             $label.text(newTextBE);
         } else {
-            console.log(`WARNING: FE has ${$labels.length} xlabels but BE has ${xlabels.length}`);
+            console.log('WARNING: FE has length ' + ($labels.length) + ' xlabels but BE has length ' + (xlabels.length));
             console.log({'FE':$labels,'BE':xlabels})
         }
         }

--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -150,7 +150,7 @@ define(
             $label.text(newTextBE);
         } else {
             console.log('WARNING: FE has length ' + ($labels.length) + ' ylabels but BE has length ' + (ylabels.length));
-            console.log({'FE':$labels,'BE':ylabels})
+            console.log({'FE':$labels,'BE':ylabels});
         }
       }
       else {
@@ -158,7 +158,7 @@ define(
         newTextorig = reformatYTickStr(textorig);
         $label.text(newTextorig);
       }
-      i = i + 1
+      i = i + 1;
     });
 
     // reformat x-ticks
@@ -174,7 +174,7 @@ define(
             $label.text(newTextBE);
         } else {
             console.log('WARNING: FE has length ' + ($labels.length) + ' xlabels but BE has length ' + (xlabels.length));
-            console.log({'FE':$labels,'BE':xlabels})
+            console.log({'FE':$labels,'BE':xlabels});
         }
       }
       else {
@@ -182,7 +182,7 @@ define(
         newTextorig = reformatXTickStr(textorig);
         $label.text(newTextorig);
       }
-      i = i + 1
+      i = i + 1;
     });
 
   function changeWidthOfSvg(svg, width) {

--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -121,30 +121,44 @@ define(
              !isNaN(parseFloat(a)) // ...and ensure strings of whitespace fail
     }
 
+    var useBEylabels = false;
+    $.each(ylabels, function (i, ylabel) {
+        var textBE = ylabel.replace(/,/g, '');
+        if (!isNumeric(textBE)) {   // We choose the BE labels if any one of them is not a number
+            useBEylabels = true;
+        }
+    });
+    var useBExlabels = false;
+    $.each(xlabels, function (i, xlabel) {
+        var textBE = xlabel.replace(/,/g, '');
+        if (!isNumeric(textBE)) {   // We choose the BE labels if any one of them is not a number
+            useBExlabels = true;
+        }
+    });
+
     // reformat y-ticks
     var $yaxis = $element.find('.mpld3-yaxis');
     var $labels = $yaxis.find('g.tick > text');
+
     var i = 0;
     $labels.each(function () {
       var $label = $(this);
-      var textorig = $label.text().replace(/,/g, '');
-
-      // We try to perform a hacky replacement of the ylabels that got lost in the translation in the BE (see comments !~! in the BE)
-      var usedBE = false;
-      if (i < ylabels.length) {
-        var textBE = ylabels[i].replace(/,/g, '');
-        if (!isNumeric(textBE)) {   // We don't include numbers because sometimes the FE has chosen different points
+      if (useBEylabels) {
+        if (i < ylabels.length) {
+            var textBE = ylabels[i].replace(/,/g, '');
             newTextBE = reformatYTickStr(textBE);
             $label.text(newTextBE);
-            usedBE = true;
+        } else {
+            console.log(`WARNING: FE has ${$labels.length} ylabels but BE has ${ylabels.length}`);
+            console.log({'FE':$labels,'BE':ylabels})
         }
       }
-      if (!usedBE) {
+      else {
+        var textorig = $label.text().replace(/,/g, '');
         newTextorig = reformatYTickStr(textorig);
         $label.text(newTextorig);
       }
-
-      i = i + 1;
+      i = i + 1
     });
 
     // reformat x-ticks
@@ -153,26 +167,24 @@ define(
     var i = 0;
     $labels.each(function () {
       var $label = $(this);
-      var textorig = $label.text().replace(/,/g, '');
-
-      // We try to perform a hacky replacement of the ylabels that got lost in the translation in the BE (see comments !~! in the BE)
-      var usedBE = false;
-      if (i < xlabels.length) {
-        var textBE = xlabels[i].replace(/,/g, '');
-        if (!isNumeric(textBE)) {   // We don't include numbers because sometimes the FE has chosen different points
+      if (useBExlabels) {
+        if (i < xlabels.length) {
+            var textBE = xlabels[i].replace(/,/g, '');
             newTextBE = reformatXTickStr(textBE);
             $label.text(newTextBE);
-            usedBE = true;
+        } else {
+            console.log(`WARNING: FE has ${$labels.length} xlabels but BE has ${xlabels.length}`);
+            console.log({'FE':$labels,'BE':xlabels})
+        }
         }
       }
-      if (!usedBE) {
+      else {
+        var textorig = $label.text().replace(/,/g, '');
         newTextorig = reformatXTickStr(textorig);
         $label.text(newTextorig);
       }
-
-      i = i + 1;
+      i = i + 1
     });
-  }
 
   function changeWidthOfSvg(svg, width) {
     var $svg = $(svg);

--- a/client/source/js/modules/charts/charts.js
+++ b/client/source/js/modules/charts/charts.js
@@ -149,11 +149,12 @@ define(
             newTextBE = reformatYTickStr(textBE);
             $label.text(newTextBE);
         } else {
+            useBEylabels = false
             console.log('WARNING: FE has length ' + ($labels.length) + ' ylabels but BE has length ' + (ylabels.length));
             console.log({'FE':$labels,'BE':ylabels});
         }
       }
-      else {
+      if (!useBEylabels) {
         var textorig = $label.text().replace(/,/g, '');
         newTextorig = reformatYTickStr(textorig);
         $label.text(newTextorig);
@@ -173,11 +174,12 @@ define(
             newTextBE = reformatXTickStr(textBE);
             $label.text(newTextBE);
         } else {
+            useBExlabels = false
             console.log('WARNING: FE has length ' + ($labels.length) + ' xlabels but BE has length ' + (xlabels.length));
             console.log({'FE':$labels,'BE':xlabels});
         }
       }
-      else {
+      if (!useBExlabels) {
         var textorig = $label.text().replace(/,/g, '');
         newTextorig = reformatXTickStr(textorig);
         $label.text(newTextorig);

--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -919,8 +919,8 @@ def plotcoverage(multires=None, die=True, figsize=globalfigsize, legendsize=glob
     
     for plt in range(nallocs):
         
-        fig,naxes = makefigure(figsize=figsize, interactive=interactive, fig=fig)
-        ax.append(fig.add_subplot(naxes, 1, naxes))
+        currfig, naxes = makefigure(figsize=figsize, interactive=interactive, fig=fig)
+        ax.append(currfig.add_subplot(naxes, 1, naxes))
         setposition(ax[-1], position, interactive)
         
         nprogs = nprogslist[plt]
@@ -950,7 +950,7 @@ def plotcoverage(multires=None, die=True, figsize=globalfigsize, legendsize=glob
         ax[-1].set_xticklabels('')
         ax[-1].set_xlim(0,nprogs+1)
         
-        ylabel = 'Coverage (%)'
+        ylabel = 'Coverage'
         ax[-1].set_ylabel(ylabel)
          
         if nallocs>1: thistitle = 'Coverage - %s' % alloclabels[plt]
@@ -966,7 +966,8 @@ def plotcoverage(multires=None, die=True, figsize=globalfigsize, legendsize=glob
         
         # Tidy up
         SIticks(ax=ax)
-        coverageplots[thistitle] = fig
+        coverageplots[thistitle] = currfig  # if fig=None, like it normally is (except gui),
+                                            # then coverageplots is an odict of figures, each with only one subplot
     
     for thisax in ax: thisax.set_ylim(ymin,ymax) # So they all have the same scale
     
@@ -2089,7 +2090,7 @@ def plotcostcov(program=None, year=None, parset=None, results=None, plotoptions=
         plotdata['xlinedata'] = linspace(0,xupperlim,npts)
     else:
         plotdata['xlinedata'] = xlinedata
-    
+
     fig,naxes = makefigure(figsize=None, interactive=interactive, fig=existingFigure)
     ax = fig.add_subplot(111)
     


### PR DESCRIPTION
The FE uses the BE tick labels if any one of them is not a number - ie ['default','1','2'] will be labelled correctly but ['4','5','6'] will be labelled incorrectly since it will use the FE labels
Also fixed a bug where it incorrectly used the BE labels when they were all numbers - wasn't removing k,m,b