### PR TITLE
Bug fixes and addition of fixproppmtct to model

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -23,7 +23,7 @@
     "underscore": "=1.8.2",
     "font-awesome": "=4.7.0",
     "angular-toastr": "~1.7.0",
-    "tooltip": "angular-tooltip#^0.1.1",
+    "tooltip": "kelvinburke/angularjs-tooltip",
     "angularjs-slider": "^5.8.1",
     "angular-loading-bar": "^0.9.0"
   },

--- a/client/source/js/modules/common/icon-directive.js
+++ b/client/source/js/modules/common/icon-directive.js
@@ -113,7 +113,7 @@ define(['angular' ], function (angular) {
             var html =
               '<i'
               + ' class="fa ' + iconTypes[scope.action].iconName + '"'
-              + ' tp-text="' + scope.errormsg + '" '
+              + ' tp-text="{{errormsg}}" '
               + ' tooltip tp-class="tooltip errortooltip" '
               + ' tp-x="-50" tp-y="175" '
               + ' tp-anchor-x="0" tp-anchor-y="0"'

--- a/client/source/js/modules/common/icon-directive.js
+++ b/client/source/js/modules/common/icon-directive.js
@@ -109,30 +109,29 @@ define(['angular' ], function (angular) {
         errormsg: '@'
       },
       link: function(scope, element){
+        var text;
+        var tpclass;
+        var tpy;
         if (scope.action == 'error') {
-            var html =
-              '<i'
-              + ' class="fa ' + iconTypes[scope.action].iconName + '"'
-              + ' tp-text="{{errormsg}}" '
-              + ' tooltip tp-class="tooltip errortooltip" '
-              + ' tp-x="-50" tp-y="175" '
-              + ' tp-anchor-x="0" tp-anchor-y="0"'
-              + ' style="margin-left: 0.5em; font-size: 14px; color: #cc0000;"'
-              + ' ng-click="click()"'
-              + '></i>';
+            text = '{{errormsg}}';
+            tpclass = 'tooltip errortooltip';
+            tpy = 175
         }
         else {
-            var html =
+            text = iconTypes[scope.action].helpText
+            tpclass = 'tooltip';
+            tpy = -150
+        }
+        var html =
               '<i'
               + ' class="fa ' + iconTypes[scope.action].iconName + '"'
-              + ' tp-text="' + iconTypes[scope.action].helpText + '" '
-              + ' tooltip tp-class="tooltip" '
-              + ' tp-x="-50" tp-y="-150" '
+              + ' tp-text="' + text + '" '
+              + ' tooltip tp-class="' + tpclass + '" '
+              + ' tp-x="-50" tp-y="' + tpy + '" '
               + ' tp-anchor-x="0" tp-anchor-y="0"'
               + ' style="margin-left: 0.5em; font-size: 14px"'
               + ' ng-click="click()"'
               + '></i>';
-        }
 
         var el = $compile(html)(scope);
         element.append(el);

--- a/client/source/js/modules/common/icon-directive.js
+++ b/client/source/js/modules/common/icon-directive.js
@@ -97,26 +97,43 @@ define(['angular' ], function (angular) {
       'download': { iconName: 'fa-download', helpText: 'Download'},
       'undo': { iconName: 'fa-undo', helpText: 'Undo'},
       'redo': { iconName: 'fa-repeat', helpText: 'Redo'},
-      'refresh': { iconName: 'fa-refresh', helpText: 'Refresh'}
+      'refresh': { iconName: 'fa-refresh', helpText: 'Refresh'},
+      'error': { iconName: 'fa-exclamation-triangle', helpText: 'Warning'}
     };
 
     return {
       restrict: 'E',
       scope: {
         click: '&',
-        action: '@'
+        action: '@',
+        errormsg: '@'
       },
       link: function(scope, element){
-        var html =
-          '<i'
-          + ' class="fa ' + iconTypes[scope.action].iconName + '"'
-          + ' tp-text="' + iconTypes[scope.action].helpText + '" '
-          + ' tooltip tp-class="tooltip" '
-          + ' tp-x="-50" tp-y="-150" '
-          + ' tp-anchor-x="0" tp-anchor-y="0"'
-          + ' style="margin-left: 0.5em; font-size: 14px"'
-          + ' ng-click="click()"'
-          + '></i>';
+        if (scope.action == 'error') {
+            var html =
+              '<i'
+              + ' class="fa ' + iconTypes[scope.action].iconName + '"'
+              + ' tp-text="' + scope.errormsg + '" '
+              + ' tooltip tp-class="tooltip errortooltip" '
+              + ' tp-x="-50" tp-y="175" '
+              + ' tp-anchor-x="0" tp-anchor-y="0"'
+              + ' style="margin-left: 0.5em; font-size: 14px; color: #cc0000;"'
+              + ' ng-click="click()"'
+              + '></i>';
+        }
+        else {
+            var html =
+              '<i'
+              + ' class="fa ' + iconTypes[scope.action].iconName + '"'
+              + ' tp-text="' + iconTypes[scope.action].helpText + '" '
+              + ' tooltip tp-class="tooltip" '
+              + ' tp-x="-50" tp-y="-150" '
+              + ' tp-anchor-x="0" tp-anchor-y="0"'
+              + ' style="margin-left: 0.5em; font-size: 14px"'
+              + ' ng-click="click()"'
+              + '></i>';
+        }
+
         var el = $compile(html)(scope);
         element.append(el);
       }

--- a/client/source/js/modules/optimization/optimization.html
+++ b/client/source/js/modules/optimization/optimization.html
@@ -34,7 +34,7 @@
               ng-class="{highlighted: optimization.id === state.optimization.id}">
             <td>
               {{optimization.name}}
-              <icon ng-show="optimization.id === state.optimization.id" action="error" errormsg="<p>Custom error message</p><p>This will have which parameters and programs are conflicting...</p>" click="editOptimization(optimization)"/>
+              <icon ng-show="optimization.warning" action="error" errormsg="optimization.warningmessage" click="editOptimization(optimization)"/>
             </td>
             <td>
               <button

--- a/client/source/js/modules/optimization/optimization.html
+++ b/client/source/js/modules/optimization/optimization.html
@@ -34,6 +34,7 @@
               ng-class="{highlighted: optimization.id === state.optimization.id}">
             <td>
               {{optimization.name}}
+              <icon ng-show="optimization.id === state.optimization.id" action="error" errormsg="<p>Custom error message</p><p>This will have which parameters and programs are conflicting...</p>" click="editOptimization(optimization)"/>
             </td>
             <td>
               <button

--- a/client/source/js/modules/optimization/optimization.html
+++ b/client/source/js/modules/optimization/optimization.html
@@ -34,7 +34,7 @@
               ng-class="{highlighted: optimization.id === state.optimization.id}">
             <td>
               {{optimization.name}}
-              <icon ng-show="optimization.warning" action="error" errormsg="{{optimization.warningmessage}}" click="editOptimization(optimization)"/>
+              <icon ng-show="optimization.warning" action="error" errormsg="{{optimization.warningmessage}}" click=""/>
             </td>
             <td>
               <button

--- a/client/source/js/modules/optimization/optimization.html
+++ b/client/source/js/modules/optimization/optimization.html
@@ -34,7 +34,7 @@
               ng-class="{highlighted: optimization.id === state.optimization.id}">
             <td>
               {{optimization.name}}
-              <icon ng-show="optimization.warning" action="error" errormsg="optimization.warningmessage" click="editOptimization(optimization)"/>
+              <icon ng-show="optimization.warning" action="error" errormsg="{{optimization.warningmessage}}}" click="editOptimization(optimization)"/>
             </td>
             <td>
               <button

--- a/client/source/js/modules/optimization/optimization.html
+++ b/client/source/js/modules/optimization/optimization.html
@@ -34,7 +34,7 @@
               ng-class="{highlighted: optimization.id === state.optimization.id}">
             <td>
               {{optimization.name}}
-              <icon ng-show="optimization.warning" action="error" errormsg="{{optimization.warningmessage}}}" click="editOptimization(optimization)"/>
+              <icon ng-show="optimization.warning" action="error" errormsg="{{optimization.warningmessage}}" click="editOptimization(optimization)"/>
             </td>
             <td>
               <button

--- a/client/source/js/modules/scenarios/scenarios.html
+++ b/client/source/js/modules/scenarios/scenarios.html
@@ -41,7 +41,10 @@
                     ng-model="scenario.active"
                     ng-change="saveScenarios(scenarios, 'Saved changes')">
               </td>
-              <td>{{ scenario.name }}</td>
+              <td>
+                {{ scenario.name }}
+                <icon ng-show="scenario.warning" action="error" errormsg="{{scenario.warningmessage}}" click=""/>
+              </td>
               <td>{{ getParsetName(scenario) }}</td>
               <td>{{ getProgramSetName(scenario) }}</td>
               <td>{{ scenario.scenario_type }}</td>

--- a/client/source/sass/main/_shame.scss
+++ b/client/source/sass/main/_shame.scss
@@ -17,7 +17,7 @@
   @include font-height(10px, 12px);
 
   background: #FF4444;
-  color: #53646F;
+  color: #000000;
 
   border-color: #000000;
   border-style: solid;

--- a/client/source/sass/main/_shame.scss
+++ b/client/source/sass/main/_shame.scss
@@ -13,6 +13,25 @@
 
 }
 
+.tooltip.errortooltip {
+  @include font-height(10px, 12px);
+
+  background: #FF4444;
+  color: #53646F;
+
+  border-color: #000000;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 2px;
+
+  padding: 3px;
+}
+
+.errortooltip > p {
+    margin-block-start: 0em;
+    margin-block-end: 0em;
+}
+
 .fa {
   cursor: pointer;
 }

--- a/optima/__init__.py
+++ b/optima/__init__.py
@@ -141,7 +141,7 @@ from . import results as _results; del results
 
 # Define the model parameters -- import before makespreadsheet because makespreadsheet uses partable to make a pre-filled spreadsheet
 from .parameters import Par, Dist, Constant, Metapar, Timepar, Popsizepar, Yearpar, Parameterset # Parameter and Parameterset classes
-from .parameters import makepars, makesimpars, applylimits, comparepars, comparesimpars, sanitycheck
+from .parameters import makepars, makesimpars, applylimits, comparepars, comparesimpars, sanitycheck, checkifparsoverridepars, createwarningforoverride
 from . import parameters as _parameters; del parameters
 
 # Create a blank spreadsheet
@@ -155,7 +155,8 @@ from .loadspreadsheet import loadspreadsheet, loadprogramspreadsheet
 from .model import model
 
 # Define the programs and cost functions
-from .programs import Program, Programset, checkiffixedpropsconflictwithprogset
+from .programs import Program, Programset
+from .programs import checkifparsetoverridesprogset
 from . import programs as _programs; del programs
 
 # Automatic calibration and sensitivity
@@ -163,7 +164,7 @@ from .calibration import autofit
 from . import calibration as _calibration; del calibration
 
 # Scenario analyses
-from .scenarios import Parscen, Budgetscen, Coveragescen, Progscen, runscenarios, makescenarios, baselinescenario, setparscenvalues, defaultscenarios
+from .scenarios import Parscen, Budgetscen, Coveragescen, Progscen, runscenarios, makescenarios, baselinescenario, setparscenvalues, defaultscenarios, checkifparsetoverridesscenario
 from . import scenarios as _scenarios; del scenarios
 
 # Optimization and ICER analyses

--- a/optima/__init__.py
+++ b/optima/__init__.py
@@ -155,7 +155,7 @@ from .loadspreadsheet import loadspreadsheet, loadprogramspreadsheet
 from .model import model
 
 # Define the programs and cost functions
-from .programs import Program, Programset
+from .programs import Program, Programset, checkiffixedpropsconflictwithprogset
 from . import programs as _programs; del programs
 
 # Automatic calibration and sensitivity

--- a/optima/fileio.py
+++ b/optima/fileio.py
@@ -140,9 +140,10 @@ def loadpartable(filename=None, folder=None):
         rawpars.append({})
         for colnum in range(sheet.ncols):
             attr = sheet.cell_value(0,colnum)
-            rawpars[rownum][attr] = sheet.cell_value(rownum+1,colnum) if sheet.cell_value(rownum+1,colnum)!='None' else None
+            cellval = sheet.cell_value(rownum+1,colnum)
+            rawpars[rownum][attr] = cellval if cellval!='None' else None
             if sheet.cell_value(0,colnum) in ['limits']:
-                rawpars[rownum][attr] = eval(sheet.cell_value(rownum+1,colnum)) # Turn into actual values
+                rawpars[rownum][attr] = eval(cellval) # Turn into actual values
     return rawpars
 
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -846,22 +846,23 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
             mtcttx         = thisbirthrate * fsums[p1]['alltx'] * pmtcteff[t] # Births to mothers on treatment
             thiseligbirths = thisbirthrate * fsums[p1]['alldx'] # Births to diagnosed mothers eligible for PMTCT
 
-            mtctdx = (thiseligbirths * (1-calcproppmtct)) * effmtct[t] # MTCT from those diagnosed not receiving PMTCT
-            mtctpmtct = (thiseligbirths * calcproppmtct) * pmtcteff[t] # MTCT from those receiving PMTCT
-            thisreceivepmtct = thiseligbirths * calcproppmtct
+            thisreceivepmtct =  thiseligbirths * calcproppmtct
+            mtctpmtct        = (thiseligbirths * calcproppmtct)     * pmtcteff[t] # MTCT from those receiving PMTCT
+            mtctdx           = (thiseligbirths * (1-calcproppmtct)) * effmtct[t]  # MTCT from those diagnosed not receiving PMTCT
+
             thispopmtct = mtctundx + mtctdx + mtcttx + mtctpmtct # Total MTCT, adding up all components
 
             undxhivbirths[p2] += mtctundx                        # Births to add to undx
             dxhivbirths[p2]   += (mtctdx + mtcttx + mtctpmtct)   # Births add to dx
 
-            raw_receivepmtct[p1, t] += thisreceivepmtct
+            raw_receivepmtct[p1, t] += thisreceivepmtct/dt  # annualise
             raw_mtct[p2, t] += thispopmtct/dt
             state_distribution_plhiv_from = people[:,p1,t] * plhivmap
 
             raw_mtctfrom[:, p1, t] += (thispopmtct/dt) * state_distribution_plhiv_from/(state_distribution_plhiv_from.sum()+eps) #WARNING: not accurate based on differential diagnosis by state potentially, but the best that's feasible
             if advancedtracking:
                 raw_mtcttoandfrom[p2,:,p1,t] += (thispopmtct/dt) * state_distribution_plhiv_from/(state_distribution_plhiv_from.sum()+eps) #WARNING: same warning as above, but I'm not 100% sure this is correct
-            raw_births[p2, t] += popbirths/dt
+            raw_births[p2, t]    += popbirths/dt
             raw_hivbirths[p1, t] += thisbirthrate * fsums[p1]['allplhiv'] / dt
 
         raw_inci[:,t] += raw_mtct[:,t] # Update infections acquired based on PMTCT calculation

--- a/optima/model.py
+++ b/optima/model.py
@@ -1,5 +1,5 @@
 ## Imports
-from numpy import zeros, exp, maximum, minimum, inf, array, isnan, einsum, floor, ones, power as npow, concatenate as cat, interp, nan, squeeze, isinf, isfinite, argsort, take_along_axis, put_along_axis, expand_dims, reshape
+from numpy import zeros, exp, maximum, minimum, inf, array, isnan, einsum, floor, ones, power as npow, concatenate as cat, interp, nan, squeeze, isinf, isfinite, argsort, take_along_axis, put_along_axis, expand_dims
 from optima import OptimaException, printv, dcp, odict, findinds
 
 def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False, debug=False, label=None, startind=None, advancedtracking=False):
@@ -733,7 +733,7 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
                     raw_diag[:,t] += people[fromstate,:,t]*thistransit[fromstate,tostate,:]/dt
 
         # Diagnosed/lost to care
-        if userate(propcare,t):
+        if True: # userate(propcare,t): Put people onto care even if there is propcare set, propcare will adjust after the fact. Otherwise, propcare doesn't link people to care at the rate that people should be (because theres enough in care) and we get too many people diagnosed but not linked.
             careprob = [linktocare[:,t]]*ncd4
             returnprob = [returntocare[:,t]]*ncd4
             for cd4 in range(aidsind, ncd4):
@@ -759,7 +759,7 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
 
 
         # Care/USVL/SVL to lost
-        if userate(propcare,t):
+        if True: # userate(propcare,t): People get lost to care even if there is propcare set, propcare will adjust after the fact.
             lossprob = [leavecare[:,t]]*ncd4
             for cd4 in range(aidsind, ncd4): lossprob[cd4] = minimum(aidsleavecare[t],leavecare[:,t])
         else: lossprob = zeros(ncd4)
@@ -1054,7 +1054,7 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
                                 people[care,:,t+1] += newmoversusvl+newmoverssvl # Add both groups of movers into care
                             else:
                                 people[tostate,:,t+1]    -= newmovers # Shift people out of the more progressed state...
-                                if name == 'propcare': lowerstate = lost  # Note the asymmetry, care moves people from dx and lost, but down into lost
+                                if name == 'propcare': lowerstate = lost  # Note the asymmetry, care moves people from dx and lost, but down into only lost
                                 people[lowerstate,:,t+1] += newmovers # ... and into the less progressed state
                             raw_new[:,t+1]               -= newmovers.sum(axis=0)/dt # Save new movers, inverting again
             if debug: checkfornegativepeople(people, tind=t+1) # If debugging, check for negative people on every timestep

--- a/optima/model.py
+++ b/optima/model.py
@@ -378,7 +378,6 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
             else:   printv(errormsg, 1, verbose)
             treatment = maximum(allinfected, treatment)
 
-        treatment = initnumtx * fractotal # Number of people on 1st-line treatment
         nevertreated = allinfected - treatment
 
         # Set initial distributions for cascade

--- a/optima/model.py
+++ b/optima/model.py
@@ -188,12 +188,12 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
     fixproppmtct   = findfixind('fixproppmtct')
 
 #    # These all have the same format, so we put them in tuples of (proptype, data structure for storing output, state below, state in question, states above (including state in question), numerator, denominator, data structure for storing new movers)
-#    #                    name,       prop,    lower, to,    num,     denom,    raw_new,        fixyear
-    propstruct = odict([('propdx',   [propdx,   undx, dx,    alldx,   allplhiv, raw_diag,       fixpropdx]),
-                        ('propcare', [propcare, dx,   care,  allcare, alldx,    raw_newcare,    fixpropcare]),
-                        ('proptx',   [proptx,   care, alltx, alltx,   allcare,  raw_newtreat,   fixproptx]),
-                        ('propsupp', [propsupp, usvl, svl,   svl,     alltx,    raw_newsupp,    fixpropsupp]),
-                        ('proppmtct',[proppmtct,None, None,  None,    None,     None,           fixproppmtct])])  # Calculation of proppmtct is done in the "Calculate births" section and does not need to be repeated at the end of this file
+#    #                    name,       prop,    lower,       to,    num,     denom,    raw_new,        fixyear
+    propstruct = odict([('propdx',   [propdx,   undx,       dx,    alldx,   allplhiv, raw_diag,       fixpropdx]),
+                        ('propcare', [propcare, dxnotincare,care,  allcare, alldx,    raw_newcare,    fixpropcare]),
+                        ('proptx',   [proptx,   care,       alltx, alltx,   allcare,  raw_newtreat,   fixproptx]),
+                        ('propsupp', [propsupp, usvl,       svl,   svl,     alltx,    raw_newsupp,    fixpropsupp]),
+                        ('proppmtct',[proppmtct,None,       None,  None,    None,     None,           fixproppmtct])])  # Calculation of proppmtct is done in the "Calculate births" section and does not need to be repeated at the end of this file
 
     # Population sizes
     popsize = dcp(simpars['popsize'])

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -859,7 +859,7 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
                 origbudget=None, ccsample='best', randseed=None, mc=3, label=None, die=False, timevarying=None, keepraw=False, stoppingfunc=None, **kwargs):
     ''' Split out minimize outcomes '''
 
-    print(f'!! minoutcomes called with: optim:{optim}, optim:{optim.constraints},tvec:{tvec},origbudget:{origbudget},randseed:{randseed},mc:{mc},timevarying:{timevarying},stoppingfunc:{stoppingfunc}')
+    print(f'!! minoutcomes called with: optim:{optim}, optim.constraints:{optim.constraints}, optim.objectives:{optim.objectives},tvec:{tvec},origbudget:{origbudget},randseed:{randseed},mc:{mc},timevarying:{timevarying},stoppingfunc:{stoppingfunc}')
 
     ## Handle budget and remove fixed costs
     if project is None or optim is None: raise OptimaException('An optimization requires both a project and an optimization object to run')
@@ -871,7 +871,12 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
     else:
         try: origbudget = dcp(progset.getdefaultbudget())
         except: raise OptimaException('Could not get default budget for optimization')
-    
+
+    print(f'!! progset::{progset}')
+    print(f'!! origtotalbudget::{origtotalbudget}')
+    print(f'!! origbudget::{origbudget}')
+    print(f'!! optim.constraints:{optim.constraints}')
+
     optimizable = array(progset.optimizable())
     optiminds = findinds(optimizable)
     nonoptiminds = findinds(optimizable==False)
@@ -891,6 +896,8 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
         raise op.CancelException
 
     # Calculate original things
+    # here: origbudget: #7: HTS, budgettvec[7]: HTS, BUT: optim.constraints: has HTS in 5th position
+    # so origbudget = budgettvec, but diff from optim.constraints
     print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{origtotalbudget},budgetlims:{optim.constraints},optiminds:{optiminds},outputtype:"full"')
     constrainedbudgetorig, constrainedbudgetvecorig, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvec, totalbudget=origtotalbudget, budgetlims=optim.constraints, optiminds=optiminds, outputtype='full')
     print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetorig}, constrainedbudgetvecorig:{constrainedbudgetvecorig},lowerlim:{lowerlim},upperlim:{upperlim}')

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -217,10 +217,8 @@ def calcoptimindsoptimkeys(functionname, prognamelist=None, progset=None, optimi
             progset.reorderprograms(prognamelist)
         optimizable = array(progset.optimizable())
         optiminds = findinds(optimizable)
-        print('!!!! optiminds',optiminds, type(optiminds))
-        a = progset.programs.keys()
-        print('!!!! a', a, type(a))
-        optimkeys = a[optiminds]
+        progkeys = array(progset.programs.keys())
+        optimkeys = progkeys[optiminds]
 
     elif prognamelist is not None:
         if optimkeys is not None:

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -859,6 +859,8 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
                 origbudget=None, ccsample='best', randseed=None, mc=3, label=None, die=False, timevarying=None, keepraw=False, stoppingfunc=None, **kwargs):
     ''' Split out minimize outcomes '''
 
+    print(f'!! minoutcomes called with: optim:{optim}, optim:{optim.constraints},tvec:{tvec},origbudget:{origbudget},randseed:{randseed},mc:{mc},timevarying:{timevarying},stoppingfunc:{stoppingfunc}')
+
     ## Handle budget and remove fixed costs
     if project is None or optim is None: raise OptimaException('An optimization requires both a project and an optimization object to run')
     parset  = project.parsets[optim.parsetname] # Link to the original parameter set
@@ -889,7 +891,9 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
         raise op.CancelException
 
     # Calculate original things
+    print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{origtotalbudget},budgetlims:{optim.constraints},optiminds:{optiminds},outputtype:"full"')
     constrainedbudgetorig, constrainedbudgetvecorig, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvec, totalbudget=origtotalbudget, budgetlims=optim.constraints, optiminds=optiminds, outputtype='full')
+    print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetorig}, constrainedbudgetvecorig:{constrainedbudgetvecorig},lowerlim:{lowerlim},upperlim:{upperlim}')
 
     # Set up arguments which are shared between outcomecalc and asd
     args = {'which':      'outcomes', 
@@ -1019,9 +1023,16 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
                 else: thislabel = '"'+key+'"'
                 origoutcomes = outcomecalc(outputresults=True, **args) # Calculate the initial outcome and pass it back in
                 args['origoutcomes'] = origoutcomes
+                print(f'!! About to call asd with allbudgetvecs[key]:{allbudgetvecs[key]}, args:{args}, xmin:{xmin}, maxtime:{maxtime}, maxiters:{maxiters}, verbose:{verbose}, randseed:{allseeds[k]}, label:{thislabel}, stoppingfunc:{stoppingfunc}, **kwargs:{kwargs}')
                 res = asd(outcomecalc, allbudgetvecs[key], args=args, xmin=xmin, maxtime=maxtime, maxiters=maxiters, verbose=verbose, randseed=allseeds[k], label=thislabel, stoppingfunc=stoppingfunc, **kwargs)
+                print(f'!! asd returned res:{res}')
                 budgetvecnew, fvals = res.x, res.details.fvals
+                print(f'!! budgetvecnew:{budgetvecnew}, fvals:{fvals}')
+
+                print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{totalbudget},budgetlims:{optim.constraints},optiminds:{optiminds},outputtype:"full"')
                 constrainedbudgetnew, constrainedbudgetvecnew, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvecnew, totalbudget=totalbudget, budgetlims=optim.constraints, optiminds=optiminds, outputtype='full')
+                print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetnew}, constrainedbudgetvecorig:{constrainedbudgetvecnew},lowerlim:{lowerlim},upperlim:{upperlim}')
+
                 asdresults[key] = {'budget':constrainedbudgetnew, 'fvals':fvals}
                 if fvals[-1]<bestfval: 
                     bestkey = key # Reset key

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -217,6 +217,7 @@ def calcoptimindsoptimkeys(functionname, prognamelist=None, progset=None, optimi
             progset.reorderprograms(prognamelist)
         optimizable = array(progset.optimizable())
         optiminds = findinds(optimizable)
+        print('!!!! optiminds',optiminds, type(optiminds))
         optimkeys = progset.programs.keys()[optiminds]
 
     elif prognamelist is not None:

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -251,7 +251,7 @@ def calcoptimindsoptimkeys(functionname, prognamelist=None, progset=None, optimi
 
 def constrainbudget(origbudget=None, budgetvec=None, totalbudget=None, budgetlims=None, optiminds=None, optimkeys=None, tolerance=1e-2, overalltolerance=1.0, outputtype=None, verbose=2, tvsettings=None):
     """ Take an unnormalized/unconstrained budgetvec and normalize and constrain it """
-    
+    print(f'!?! constrainbudget called with \norigbudget: {origbudget},\nbudgetvec: {budgetvec},\nbudgetlims: {budgetlims},\noptiminds: {optiminds},\noptimkeys: {optimkeys},')
     # Prepare this budget for later scaling and the like
     constrainedbudget = dcp(origbudget)
     
@@ -356,7 +356,9 @@ def constrainbudget(origbudget=None, budgetvec=None, totalbudget=None, budgetlim
     if abs(sum(constrainedbudget[:])-totalbudget)>overalltolerance:
         errormsg = 'final budget amounts differ (%f != %f)' % (sum(constrainedbudget[:]), totalbudget)
         raise OptimaException(errormsg)
-    
+
+    print(f'!?! constrainbudget returning \nconstrainedbudget: {constrainedbudget},\nconstrainedbudgetvec: {constrainedbudgetvec},\nlowerlim: {lowerlim},\nupperlim: {upperlim}')
+
     # Optionally return the calculated upper and lower limits as well as the original budget and vector
     constrainedbudgetvec = dcp(constrainedbudget[optimkeys])
     if outputtype=='odict':
@@ -977,9 +979,9 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
     # Calculate original things
     # here: origbudget: #7: HTS, budgettvec[7]: HTS, BUT: optim.constraints: has HTS in 5th position
     # so origbudget = budgettvec, but diff from optim.constraints
-    print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{origtotalbudget},budgetlims:{optim.constraints},optimkeys:{optimkeys},outputtype:"full"')
+    # print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{origtotalbudget},budgetlims:{optim.constraints},optimkeys:{optimkeys},outputtype:"full"')
     constrainedbudgetorig, constrainedbudgetvecorig, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvec, totalbudget=origtotalbudget, budgetlims=optim.constraints, optimkeys=optimkeys, outputtype='full', verbose=verbose)
-    print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetorig}, constrainedbudgetvecorig:{constrainedbudgetvecorig},lowerlim:{lowerlim},upperlim:{upperlim}')
+    # print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetorig}, constrainedbudgetvecorig:{constrainedbudgetvecorig},lowerlim:{lowerlim},upperlim:{upperlim}')
 
     # Set up arguments which are shared between outcomecalc and asd
     args = {'which':      'outcomes', 
@@ -1115,9 +1117,9 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
                 budgetvecnew, fvals = res.x, res.details.fvals
                 print(f'!! budgetvecnew:{budgetvecnew}, fvals:{fvals}')
 
-                print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{totalbudget},budgetlims:{optim.constraints},optimkeys:{optimkeys},outputtype:"full"')
+                # print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{totalbudget},budgetlims:{optim.constraints},optimkeys:{optimkeys},outputtype:"full"')
                 constrainedbudgetnew, constrainedbudgetvecnew, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvecnew, totalbudget=totalbudget, budgetlims=optim.constraints, optimkeys=optimkeys, outputtype='full')
-                print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetnew}, constrainedbudgetvecorig:{constrainedbudgetvecnew},lowerlim:{lowerlim},upperlim:{upperlim}')
+                # print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetnew}, constrainedbudgetvecorig:{constrainedbudgetvecnew},lowerlim:{lowerlim},upperlim:{upperlim}')
 
                 asdresults[key] = {'budget':constrainedbudgetnew, 'fvals':fvals}
                 if fvals[-1]<bestfval: 

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -251,7 +251,8 @@ def calcoptimindsoptimkeys(functionname, prognamelist=None, progset=None, optimi
 
 def constrainbudget(origbudget=None, budgetvec=None, totalbudget=None, budgetlims=None, optiminds=None, optimkeys=None, tolerance=1e-2, overalltolerance=1.0, outputtype=None, verbose=2, tvsettings=None):
     """ Take an unnormalized/unconstrained budgetvec and normalize and constrain it """
-    print(f'!?! constrainbudget called with \norigbudget: {origbudget},\nbudgetvec: {budgetvec},\nbudgetlims: {budgetlims},\noptiminds: {optiminds},\noptimkeys: {optimkeys},')
+    print(f'!?! constrainbudget called with \norigbudget={origbudget},\nbudgetvec={budgetvec},\ntotalbudget={totalbudget},\nbudgetlims={budgetlims},\noptiminds={optiminds},\noptimkeys={optimkeys},'
+                                                                                                  f'\ntolerance={tolerance},\noveralltolerance={overalltolerance},\noutputtype={outputtype},\nverbose={verbose},\ntvsettings={tvsettings}')
     # Prepare this budget for later scaling and the like
     constrainedbudget = dcp(origbudget)
     

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -893,8 +893,8 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
     optimizable = array(progset.optimizable())
     optiminds = findinds(optimizable)
     nonoptiminds = findinds(optimizable==False)
-    optimkeys    = np.array([key for k,key in enumerate(origbudget.keys()) if optimizable[k]])
-    nonoptimkeys = np.array([key for k,key in enumerate(origbudget.keys()) if not optimizable[k]])
+    optimkeys    = array([key for k,key in enumerate(origbudget.keys()) if optimizable[k]])
+    nonoptimkeys = array([key for k,key in enumerate(origbudget.keys()) if not optimizable[k]])
     budgetvec = origbudget[optimkeys] # Get the original budget
     budgetvec2 = origbudget[:][optiminds]  # Get the original budget
     print('!?!!! budgetvec==budgetvec2',budgetvec==budgetvec2, budgetvec, budgetvec2)

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -664,7 +664,7 @@ def optimize(optim=None, maxiters=None, maxtime=None, verbose=2, stoppingfunc=No
         optim.constraints = defaultconstraints(project=project, progsetname=optim.progsetname, verbose=verbose)
 
     # Reorder the programs to match the order of the constraints
-    progset.reorderprograms(optim.constraints)
+    progset.reorderprograms(optim.constraints['name'].keys())
 
     # Process inputs
     if not optim.objectives['budget']: # Handle 0 or None 

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -311,7 +311,7 @@ def constrainbudget(origbudget=None, budgetvec=None, totalbudget=None, budgetlim
         return constrainedbudgetvec
     elif outputtype=='full':
         lowerlim = dcp(abslimits['min'][optiminds])
-        upperlim = dcp(abslimits['min'][optiminds])
+        upperlim = dcp(abslimits['max'][optiminds])
         return constrainedbudget, constrainedbudgetvec, lowerlim, upperlim
     else:
         raise OptimaException('Must specify an output type of "odict", "vec", or "full"; you specified "%s"' % outputtype)
@@ -866,7 +866,7 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
     parset  = project.parsets[optim.parsetname] # Link to the original parameter set
     progset = project.progsets[optim.progsetname] # Link to the original program set
     print(f"optim.constraints['name'].keys():{optim.constraints['name'].keys()}")
-    progset.reorderprograms(optim.constraints['name'].keys())
+    progset.reorderprograms(optim.constraints['name'].keys()) # I am not 100% sure that optim.constraints will have ALL the programs in it
     origtotalbudget = dcp(optim.objectives['budget']) # Should be a float, but dcp just in case
     if origbudget is not None:
         origbudget = dcp(origbudget)

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -360,7 +360,11 @@ def constrainbudget(origbudget=None, budgetvec=None, totalbudget=None, budgetlim
 
     # Optionally return the calculated upper and lower limits as well as the original budget and vector
     constrainedbudgetvec = dcp(constrainedbudget[optimkeys])
+    #tmp
+    lowerlim = dcp(abslimits['min'][optimkeys])
+    upperlim = dcp(abslimits['max'][optimkeys])
     print(f'!?! constrainbudget returning \nconstrainedbudget: {constrainedbudget},\nconstrainedbudgetvec: {constrainedbudgetvec},\nlowerlim: {lowerlim},\nupperlim: {upperlim}')
+    #tmp
     if outputtype=='odict':
         return constrainedbudget
     elif outputtype=='vec':

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -218,7 +218,9 @@ def calcoptimindsoptimkeys(functionname, prognamelist=None, progset=None, optimi
         optimizable = array(progset.optimizable())
         optiminds = findinds(optimizable)
         print('!!!! optiminds',optiminds, type(optiminds))
-        optimkeys = progset.programs.keys()[optiminds]
+        a = progset.programs.keys()
+        print('!!!! a', a, type(a))
+        optimkeys = a[optiminds]
 
     elif prognamelist is not None:
         if optimkeys is not None:

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -357,10 +357,10 @@ def constrainbudget(origbudget=None, budgetvec=None, totalbudget=None, budgetlim
         errormsg = 'final budget amounts differ (%f != %f)' % (sum(constrainedbudget[:]), totalbudget)
         raise OptimaException(errormsg)
 
-    print(f'!?! constrainbudget returning \nconstrainedbudget: {constrainedbudget},\nconstrainedbudgetvec: {constrainedbudgetvec},\nlowerlim: {lowerlim},\nupperlim: {upperlim}')
 
     # Optionally return the calculated upper and lower limits as well as the original budget and vector
     constrainedbudgetvec = dcp(constrainedbudget[optimkeys])
+    print(f'!?! constrainbudget returning \nconstrainedbudget: {constrainedbudget},\nconstrainedbudgetvec: {constrainedbudgetvec},\nlowerlim: {lowerlim},\nupperlim: {upperlim}')
     if outputtype=='odict':
         return constrainedbudget
     elif outputtype=='vec':

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -893,8 +893,11 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
     optimizable = array(progset.optimizable())
     optiminds = findinds(optimizable)
     nonoptiminds = findinds(optimizable==False)
-    optimkeys = [key for k,key in enumerate(origbudget.keys()) if optimizable[k]]
-    budgetvec = origbudget[:][optiminds] # Get the original budget vector
+    optimkeys    = np.array([key for k,key in enumerate(origbudget.keys()) if optimizable[k]])
+    nonoptimkeys = np.array([key for k,key in enumerate(origbudget.keys()) if not optimizable[k]])
+    budgetvec = origbudget[optimkeys] # Get the original budget
+    budgetvec2 = origbudget[:][optiminds]  # Get the original budget
+    print('!?!!! budgetvec==budgetvec2',budgetvec==budgetvec2, budgetvec, budgetvec2)
     nprogs = len(origbudget[:]) # Number of programs total
     noptimprogs = len(budgetvec) # Number of optimizable programs
     xmin = zeros(noptimprogs)
@@ -911,8 +914,8 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
     # Calculate original things
     # here: origbudget: #7: HTS, budgettvec[7]: HTS, BUT: optim.constraints: has HTS in 5th position
     # so origbudget = budgettvec, but diff from optim.constraints
-    print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{origtotalbudget},budgetlims:{optim.constraints},optiminds:{optiminds},outputtype:"full"')
-    constrainedbudgetorig, constrainedbudgetvecorig, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvec, totalbudget=origtotalbudget, budgetlims=optim.constraints, optiminds=optiminds, outputtype='full', verbose=verbose)
+    print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{origtotalbudget},budgetlims:{optim.constraints},optimkeys:{optimkeys},outputtype:"full"')
+    constrainedbudgetorig, constrainedbudgetvecorig, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvec, totalbudget=origtotalbudget, budgetlims=optim.constraints, optimkeys=optimkeys, outputtype='full', verbose=verbose)
     print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetorig}, constrainedbudgetvecorig:{constrainedbudgetvecorig},lowerlim:{lowerlim},upperlim:{upperlim}')
 
     # Set up arguments which are shared between outcomecalc and asd
@@ -923,7 +926,7 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
             'objectives': optim.objectives, 
             'constraints':optim.constraints, 
             'totalbudget':origtotalbudget, # Complicated, see below
-            'optiminds':  optiminds, 
+            'optiminds':  optiminds, # WARNING should replace with optimkeys eventually
             'origbudget': origbudget, 
             'tvec':       tvec, 
             'ccsample':   ccsample, 
@@ -1002,7 +1005,7 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
 
         # Get the total budget & constrain it 
         totalbudget = origtotalbudget*scalefactor
-        constrainedbudget, constrainedbudgetvec, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvec, totalbudget=totalbudget, budgetlims=optim.constraints, optiminds=optiminds, outputtype='full')
+        constrainedbudget, constrainedbudgetvec, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvec, totalbudget=totalbudget, budgetlims=optim.constraints, optimkeys=optimkeys, outputtype='full')
         args['totalbudget'] = totalbudget
         args['initpeople'] = initpeople # Reset initpeople
         
@@ -1049,8 +1052,8 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
                 budgetvecnew, fvals = res.x, res.details.fvals
                 print(f'!! budgetvecnew:{budgetvecnew}, fvals:{fvals}')
 
-                print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{totalbudget},budgetlims:{optim.constraints},optiminds:{optiminds},outputtype:"full"')
-                constrainedbudgetnew, constrainedbudgetvecnew, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvecnew, totalbudget=totalbudget, budgetlims=optim.constraints, optiminds=optiminds, outputtype='full')
+                print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{totalbudget},budgetlims:{optim.constraints},optimkeys:{optimkeys},outputtype:"full"')
+                constrainedbudgetnew, constrainedbudgetvecnew, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvecnew, totalbudget=totalbudget, budgetlims=optim.constraints, optimkeys=optimkeys, outputtype='full')
                 print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetnew}, constrainedbudgetvecorig:{constrainedbudgetvecnew},lowerlim:{lowerlim},upperlim:{upperlim}')
 
                 asdresults[key] = {'budget':constrainedbudgetnew, 'fvals':fvals}

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -202,15 +202,20 @@ def defaulttvsettings(**kwargs):
 
 def calcoptimindsoptimkeys(functionname, prognamelist=None, progset=None, optiminds = None, optimkeys=None, reorderprograms=True, verbose=2):
     """
-
     A helper function that calculates the optiminds and optimkeys from the progset if it is given.
     It also copies the order of the programs from the keys of the prognamelist to the progset if reorderprograms=True.
 
     If no progset is given, it ensures the optimkeys and the optiminds are referring to the same programs from the
-    prognamelist, choosing to use the optimkeys if they are given.
+    prognamelist, preferring to use the optimkeys if they are given.
 
     Making sure the optiminds match up to the proper location in the dictionary as the optimkeys helps avoid tricky to
     diagnose errors.
+
+    Example usage: (constraints['name'] is an odict with short program names as the keys)
+    constraintskeys = constraints['name'].keys() if (constraints is not None) else None
+    optiminds, optimkeys = calcoptimindsoptimkeys('thisfunctionsname', prognamelist=constraintskeys, progset=progset,
+                                                  optiminds=optiminds, optimkeys=optimkeys, reorderprograms=True, verbose=verbose)
+    note in this example optimkeys and optiminds are overriden and progset is reordered to match the order of prognamelist
     """
     if progset is not None:
         if prognamelist is not None and reorderprograms:
@@ -963,11 +968,6 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
     else:
         try: origbudget = dcp(progset.getdefaultbudget())
         except: raise OptimaException('Could not get default budget for optimization')
-
-    # print(f'!! progset::{progset}')
-    # print(f'!! origtotalbudget::{origtotalbudget}')
-    # print(f'!! origbudget::{origbudget}')
-    # print(f'!! optim.constraints:{optim.constraints}')
 
     budgetvec = origbudget[optimkeys] # Get the original budget
     nprogs = len(origbudget[:]) # Number of programs total

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -1413,6 +1413,7 @@ def minmoney(project=None, optim=None, tvec=None, verbose=None, maxtime=None, ma
             while r <= n_refine and still_choices:
                 r += 1
                 trial_vec = op.dcp(budgetvec)
+                trial_vec = trial_vec.astype('float')   # this should fix dividing by zero giving an error
                 choices = op.findinds(logical_and(refine_vec, trial_vec)) # It's not a choice if either is zero
                 if not len(choices):
                     still_choices = False
@@ -1423,7 +1424,7 @@ def minmoney(project=None, optim=None, tvec=None, verbose=None, maxtime=None, ma
                     trial_vec[ind] = 0 # Set to zero temporarily
                     new_prog = this_prog*refine_step
                     reallocate = this_prog*(1-refine_step)*refine_keep
-                    reallocate_vec = trial_vec / trial_vec.sum() * reallocate
+                    reallocate_vec = trial_vec / trial_vec.sum() * reallocate   # this line throws an error if the dtype of trial_vec is not float
                     reallocate_vec = op.sanitize(reallocate_vec, replacenans=0) # Ensure in the corner case that 0/0 is replaced with 0
                     trial_vec += reallocate_vec
                     trial_vec[ind] = new_prog

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -865,6 +865,8 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
     if project is None or optim is None: raise OptimaException('An optimization requires both a project and an optimization object to run')
     parset  = project.parsets[optim.parsetname] # Link to the original parameter set
     progset = project.progsets[optim.progsetname] # Link to the original program set
+    print(f"optim.constraints['name'].keys():{optim.constraints['name'].keys()}")
+    progset.reorderprograms(optim.constraints['name'].keys())
     origtotalbudget = dcp(optim.objectives['budget']) # Should be a float, but dcp just in case
     if origbudget is not None:
         origbudget = dcp(origbudget)

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -217,7 +217,7 @@ def calcoptimindsoptimkeys(functionname, prognamelist=None, progset=None, optimi
             progset.reorderprograms(prognamelist)
         optimizable = array(progset.optimizable())
         optiminds = findinds(optimizable)
-        optimkeys = progset.programs[optiminds]
+        optimkeys = progset.programs.keys()[optiminds]
 
     elif prognamelist is not None:
         if optimkeys is not None:

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -251,8 +251,10 @@ def calcoptimindsoptimkeys(functionname, prognamelist=None, progset=None, optimi
 
 def constrainbudget(origbudget=None, budgetvec=None, totalbudget=None, budgetlims=None, optiminds=None, optimkeys=None, tolerance=1e-2, overalltolerance=1.0, outputtype=None, verbose=2, tvsettings=None):
     """ Take an unnormalized/unconstrained budgetvec and normalize and constrain it """
-    print(f'!?! constrainbudget called with \norigbudget={origbudget},\nbudgetvec={budgetvec},\ntotalbudget={totalbudget},\nbudgetlims={budgetlims},\noptiminds={optiminds},\noptimkeys={optimkeys},'
-                                                                                                  f'\ntolerance={tolerance},\noveralltolerance={overalltolerance},\noutputtype={outputtype},\nverbose={verbose},\ntvsettings={tvsettings}')
+    # Optional printing for debugging
+    # print(f'!?! constrainbudget called with \norigbudget={origbudget},\nbudgetvec={budgetvec},\ntotalbudget={totalbudget},\nbudgetlims={budgetlims},\noptiminds={optiminds},\noptimkeys={optimkeys},'
+    #                                                                                               f'\ntolerance={tolerance},\noveralltolerance={overalltolerance},\noutputtype={outputtype},\nverbose={verbose},\ntvsettings={tvsettings}')
+
     # Prepare this budget for later scaling and the like
     constrainedbudget = dcp(origbudget)
     
@@ -279,7 +281,7 @@ def constrainbudget(origbudget=None, budgetvec=None, totalbudget=None, budgetlim
                                                   optiminds=optiminds, optimkeys=optimkeys, reorderprograms=False, verbose=verbose)
 
     progkeys = array(origbudget.keys())  # Array of all allowable keys
-    fixedkeys = array([p for p in progkeys if p not in optimkeys]) # Get the complement of progkeys
+    fixedkeys = array([p for p in progkeys if p not in optimkeys]) # Get the complement of optimkeys
     minfixed = 0.0
     for key in fixedkeys:
         rescaledminfixed[key] = rescaledbudget[key]*budgetlims['min'][key]
@@ -361,11 +363,12 @@ def constrainbudget(origbudget=None, budgetvec=None, totalbudget=None, budgetlim
 
     # Optionally return the calculated upper and lower limits as well as the original budget and vector
     constrainedbudgetvec = dcp(constrainedbudget[optimkeys])
-    #tmp
-    lowerlim = dcp(abslimits['min'][optimkeys])
-    upperlim = dcp(abslimits['max'][optimkeys])
-    print(f'!?! constrainbudget returning \nconstrainedbudget: {constrainedbudget},\nconstrainedbudgetvec: {constrainedbudgetvec},\nlowerlim: {lowerlim},\nupperlim: {upperlim}')
-    #tmp
+
+    # Optional printing for debugging
+    # lowerlim = dcp(abslimits['min'][optimkeys])
+    # upperlim = dcp(abslimits['max'][optimkeys])
+    # print(f'!?! constrainbudget returning \nconstrainedbudget: {constrainedbudget},\nconstrainedbudgetvec: {constrainedbudgetvec},\nlowerlim: {lowerlim},\nupperlim: {upperlim}')
+
     if outputtype=='odict':
         return constrainedbudget
     elif outputtype=='vec':
@@ -440,8 +443,6 @@ def separatetv(inputvec=None, optiminds=None, optimkeys=None):
         errormsg = 'Budget vector must be either length %i or length %i, not %i' % (noptimprogs, ndims*noptimprogs, len(inputvec))
         raise OptimaException(errormsg)
     return (budgetvec, tvcontrolvec)
-
-
 
 
 
@@ -856,7 +857,7 @@ def tvoptimize(project=None, optim=None, tvec=None, verbose=None, maxtime=None, 
             'objectives':optim.objectives, 
             'constraints':optim.constraints, 
             'totalbudget':origtotalbudget, # Complicated, see below
-            'optiminds':optiminds, # Redundant, could be removed because optimkeys is given
+            'optiminds':optiminds, # Redundant, could probably be removed because optimkeys is given
             'optimkeys':optimkeys,
             'origbudget':origbudget, 
             'tvec':tvec, 
@@ -941,7 +942,8 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
                 origbudget=None, ccsample='best', randseed=None, mc=3, label=None, die=False, timevarying=None, keepraw=False, stoppingfunc=None, **kwargs):
     ''' Split out minimize outcomes '''
 
-    print(f'!! minoutcomes called with: optim:{optim}, optim.constraints:{optim.constraints}, optim.objectives:{optim.objectives},tvec:{tvec},origbudget:{origbudget},randseed:{randseed},mc:{mc},timevarying:{timevarying},stoppingfunc:{stoppingfunc}')
+    # Optional printing for debugging
+    # print(f'!! minoutcomes called with: optim:{optim}, optim.constraints:{optim.constraints}, optim.objectives:{optim.objectives},tvec:{tvec},origbudget:{origbudget},randseed:{randseed},mc:{mc},timevarying:{timevarying},stoppingfunc:{stoppingfunc}')
 
     ## Handle budget and remove fixed costs
     if project is None or optim is None: raise OptimaException('An optimization requires both a project and an optimization object to run')
@@ -962,10 +964,10 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
         try: origbudget = dcp(progset.getdefaultbudget())
         except: raise OptimaException('Could not get default budget for optimization')
 
-    print(f'!! progset::{progset}')
-    print(f'!! origtotalbudget::{origtotalbudget}')
-    print(f'!! origbudget::{origbudget}')
-    print(f'!! optim.constraints:{optim.constraints}')
+    # print(f'!! progset::{progset}')
+    # print(f'!! origtotalbudget::{origtotalbudget}')
+    # print(f'!! origbudget::{origbudget}')
+    # print(f'!! optim.constraints:{optim.constraints}')
 
     budgetvec = origbudget[optimkeys] # Get the original budget
     nprogs = len(origbudget[:]) # Number of programs total
@@ -982,11 +984,7 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
         raise op.CancelException
 
     # Calculate original things
-    # here: origbudget: #7: HTS, budgettvec[7]: HTS, BUT: optim.constraints: has HTS in 5th position
-    # so origbudget = budgettvec, but diff from optim.constraints
-    # print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{origtotalbudget},budgetlims:{optim.constraints},optimkeys:{optimkeys},outputtype:"full"')
     constrainedbudgetorig, constrainedbudgetvecorig, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvec, totalbudget=origtotalbudget, budgetlims=optim.constraints, optimkeys=optimkeys, outputtype='full', verbose=verbose)
-    # print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetorig}, constrainedbudgetvecorig:{constrainedbudgetvecorig},lowerlim:{lowerlim},upperlim:{upperlim}')
 
     # Set up arguments which are shared between outcomecalc and asd
     args = {'which':      'outcomes', 
@@ -1116,16 +1114,9 @@ def minoutcomes(project=None, optim=None, tvec=None, verbose=None, maxtime=None,
                 else: thislabel = '"'+key+'"'
                 origoutcomes = outcomecalc(outputresults=True, **args) # Calculate the initial outcome and pass it back in
                 args['origoutcomes'] = origoutcomes
-                print(f'!! About to call asd with allbudgetvecs[key]:{allbudgetvecs[key]}, args:{args}, xmin:{xmin}, maxtime:{maxtime}, maxiters:{maxiters}, verbose:{verbose}, randseed:{allseeds[k]}, label:{thislabel}, stoppingfunc:{stoppingfunc}, **kwargs:{kwargs}')
                 res = asd(outcomecalc, allbudgetvecs[key], args=args, xmin=xmin, maxtime=maxtime, maxiters=maxiters, verbose=verbose, randseed=allseeds[k], label=thislabel, stoppingfunc=stoppingfunc, **kwargs)
-                print(f'!! asd returned res:{res}')
                 budgetvecnew, fvals = res.x, res.details.fvals
-                print(f'!! budgetvecnew:{budgetvecnew}, fvals:{fvals}')
-
-                # print(f'!! constrainbudget called with: origbudget:{origbudget}, budgetvec:{budgetvec},totalbudget:{totalbudget},budgetlims:{optim.constraints},optimkeys:{optimkeys},outputtype:"full"')
                 constrainedbudgetnew, constrainedbudgetvecnew, lowerlim, upperlim = constrainbudget(origbudget=origbudget, budgetvec=budgetvecnew, totalbudget=totalbudget, budgetlims=optim.constraints, optimkeys=optimkeys, outputtype='full')
-                # print(f'!! constrainbudget returned: constrainedbudgetorig:{constrainedbudgetnew}, constrainedbudgetvecorig:{constrainedbudgetvecnew},lowerlim:{lowerlim},upperlim:{upperlim}')
-
                 asdresults[key] = {'budget':constrainedbudgetnew, 'fvals':fvals}
                 if fvals[-1]<bestfval: 
                     bestkey = key # Reset key

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -6,7 +6,7 @@ parameters, the Parameterset class.
 Version: 2.1 (2017apr04)
 """
 
-from numpy import array, nan, isnan, isfinite, zeros, ones, argmax, mean, log, polyfit, exp, maximum, minimum, Inf, linspace, median, shape, append
+from numpy import array, nan, isnan, isfinite, zeros, ones, argmax, mean, log, polyfit, exp, maximum, minimum, Inf, linspace, median, shape, append, logical_and
 from numpy.random import uniform, normal, seed
 from optima import OptimaException, Link, odict, dataframe, printv, sanitize, uuid, today, getdate, makefilepath, smoothinterp, dcp, defaultrepr, isnumber, findinds, findnearest, getvaliddata, promotetoarray, promotetolist, inclusiverange # Utilities 
 from optima import Settings, getresults, convertlimits, gettvecdt, loadpartable, loadtranstable # Heftier functions
@@ -15,6 +15,19 @@ import optima as op
 defaultsmoothness = 1.0 # The number of years of smoothing to do by default
 generalkeys = ['male', 'female', 'popkeys', 'injects', 'fromto', 'transmatrix'] # General parameter keys that are just copied
 staticmatrixkeys = ['birthtransit','agetransit','risktransit'] # Static keys that are also copied, but differently :)
+
+# WARNING: the parameters that override one another are hardcoded here.
+# If more parameters are added that override others or if model.py is changed, they should be added here
+overridingpars = odict([('propdx',['hivtest','aidstest']),
+                        ('propcare',['linktocare','aidslinktocare','leavecare','aidsleavecare','returntocare','aidstest']),
+                        ('proptx',['numtx']),
+                        ('propsupp',['treatfail','regainvs','numvlmon']),
+                        ('proppmtct',['numpmtct']),
+                        ('fixpropdx',['hivtest','aidstest']),
+                        ('fixpropcare',['linktocare','aidslinktocare','leavecare','aidsleavecare','returntocare','aidstest']),
+                        ('fixproptx',['numtx']),
+                        ('fixpropsupp',['treatfail','regainvs','numvlmon']),
+                        ('fixproppmtct',['numpmtct']) ])
 
 
 #################################################################################################################################
@@ -1539,14 +1552,123 @@ def sanitycheck(simpars=None, showdiff=True, threshold=0.1, eps=1e-6):
     print(outstr)
     return outstr
 
+def checkifparsoverridepars(origpars, targetpars, progstartyear=None, progendyear=None):
+    '''
+    Checks if the original parset has parameters that override parameters that
+    are being targeted.
+    Args:
+        origpars: odict of Par objects from the parset being used
+        targetpars: list of short names of pars that are being changed or targeted (by a progset)
+        progendyear: list that the programs or optimization finishes (ignores origpars at or after this year)
+    Returns:
+        An odict with keys that are the overriding parameters in origpars,
+        and the values are the list of targetpars that each par overrides.
+        eg: origpars['fixpropcare'] = 2022, targetpars = ['linktocare','returntocare','numpmtct'], progendyear = 2030
+        returns: warning=True, outdict = {'fixpropdx':['linktocare','returntocare']}, times = {'fixpropdx':2022.}
+    '''
+    if progendyear is None: progendyear = 2100
+    if progstartyear is None: progstartyear = progendyear # the function should still work with this set.
+    warning = False
+    outdict, times, vals = odict(), odict(), odict()
+    targetparsset = set(targetpars)
+    for overriding, affectedpars in overridingpars.items():
+        overridingpar = origpars[overriding]  # (overriding)pars, progendyear, (overriden)targetpartypes
+        willoverride = False
+        if isinstance(overridingpar, Timepar):
+            tvals = array(overridingpar.t['tot'])
+            yvals = array(overridingpar.y['tot'])
+            timesset = tvals[~isnan(yvals)]
+            timesnan = tvals[isnan(yvals)]
+            if len(timesset) == 0: continue
+            maxtimesetbefore = max(append(timesset[timesset<progstartyear], -1))
+            mintimesetafter  = min(append(timesset[timesset>=progendyear], Inf))
+            if logical_and(timesset>=progstartyear, timesset<progendyear).any(): # proportion is set during the programs
+                willoverride = True
+            elif maxtimesetbefore>=0 or isfinite(mintimesetafter): # the prop is set either before or after programs
+                if not logical_and(maxtimesetbefore < timesnan, timesnan < mintimesetafter).any(): # need a nan after prop set before, or nan before prop set after
+                    willoverride = True
+        elif isinstance(overridingpar, Yearpar):
+            tvals = overridingpar.t
+            yvals = '"Fixed"' ### WARNING not really a value
+            willoverride = overridingpar.t < progendyear
+
+        if willoverride:  # the proportion is actually set so now we check if the programset targets any of the overriden parameters
+            targetparsaffected = list(filter(lambda par: par in targetparsset, affectedpars))
+            if len(targetparsaffected) > 0:
+                warning = True
+                outdict[overriding] = targetparsaffected
+                times[overriding] = tvals
+                vals[overriding] = yvals
+    return warning, outdict, times, vals
 
 
+def createwarningforoverride(origpars, warning, parsoverridingparsdict, overridetimes, overridevals, fortype='Progscen',
+                             progsetname=None, parsetname=None, progsbytargetpartype=None, progendyear=2100,
+                             formatfor='console', warningmessage=None, warningmessageplural=None,
+                             recommendmessagefixed=None,recommendmessageprop=None):
+    """
+    A helper function that checks whether there are any parameters in the parset that would make a program in
+    the progset not have an effect. This can be run for optimizations and scenarios, as long as the progset is
+    provided.
+    Args:
+        progset:
+        parset:
+        progendyear:
+        formatfor: 'html' or 'console': html uses <p> ... </p> to format the warning message, console uses \n
 
+    Returns:
+        warning:
+        combinedwarningmsg:
+        warningmessages:
 
+    """
+    if not warning: return warning, '', []
 
+    if formatfor == 'html': sep = '</p><p>'
+    else: sep = '\n'
 
+    warningmessages = []
+    if warningmessage is None:
+        if fortype == 'Parscen': warningmessage = 'Warning: This scenario trying to set "{affectedparname}" but the parameter set "{parsetname}" has "{overridingparname}" set to {valstr}'
+        else:                    warningmessage = 'Warning: The program \'{programsnames}\' in program set "{progsetname}" targets the "{affectedparname}" but the parameter set "{parsetname}" has "{overridingparname}" set to {valstr} which is before the program ends in {progendyear} so this program will likely have no affect.'
 
+    if warningmessageplural is None:  warningmessageplural  = 'Warning: The programs {programsnames} in program set "{progsetname}" target the "{affectedparname}" but the parameter set "{parsetname}" has "{overridingparname}" set to {valstr} which is before the programs end in {progendyear} so these programs will likely have no effect.'
+    if recommendmessagefixed is None: recommendmessagefixed = 'It is recommended to make another parameter set that has "{overridingparname}" set to 2100.'
+    if recommendmessageprop is None:  recommendmessageprop  = 'It is recommended to make another parameter set that doesn\'t have "{overridingparname}" set.'
 
+    for overriding, affectedpars in parsoverridingparsdict.items():
+        overridingpar = origpars[overriding]
+        if isinstance(overridingpar, Yearpar):
+            valstr = f"{overridetimes[overriding]}"
+            recommendmessage = recommendmessagefixed
+        elif isinstance(overridingpar, Timepar):
+            tvals = overridingpar.t['tot']
+            yvals = array(overridingpar.y['tot'])
+            valstr = f"{yvals} in {tvals}"
+            recommendmessage = recommendmessageprop
+        for affected in affectedpars:
+            if fortype == 'Parscen':
+                warningmessages.append(warningmessage)
+                progsaffectednames = ['Not a program'] # Kludgy, so that later doesn't produce an error, but this won't be used anyway
+            else:
+                progsaffectednames = [prog.short for prog in progsbytargetpartype[affected]]
+                warningmessages.append(warningmessage if len(progsaffectednames) == 1 else warningmessageplural)
+            warningmessages[-1] = warningmessages[-1] + sep + recommendmessage
+            warningmessages[-1] = warningmessages[-1].format(programsnames=progsaffectednames if len(progsaffectednames)>1 else progsaffectednames[0],
+                                                       progsetname=progsetname,
+                                                       affectedparname=origpars[affected].name,
+                                                       parsetname=parsetname,
+                                                       overridingparname=overridingpar.name,
+                                                       valstr=valstr,
+                                                       progendyear=progendyear)
+
+    if formatfor == 'html':
+        warningmessages = ['<p>' + msg.replace('"','&quot;') + '</p>' for msg in warningmessages]
+        combinedwarningmsg = '<br>'.join(warningmessages)  # Note that this defaults to '' if warningmessages is empty
+    else:
+        combinedwarningmsg = (sep+sep).join(warningmessages)  # Note that this defaults to '' if warningmessages is empty
+
+    return warning, combinedwarningmsg, warningmessages
 
 
 

--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -1081,8 +1081,8 @@ def plotcascade(results=None, aspercentage=False, cascadecolors=None, figsize=gl
     for plt in range(nsims): # WARNING, copied from plotallocs()
     
         # Create the figure and axes
-        fig,naxes = makefigure(figsize=figsize, interactive=interactive, fig=fig, newfig=newfig)
-        ax = fig.add_subplot(naxes, 1, naxes)
+        currfig,naxes = makefigure(figsize=figsize, interactive=interactive, fig=fig, newfig=newfig)
+        ax = currfig.add_subplot(naxes, 1, naxes)
         setposition(ax, position, interactive)
             
         if asbars:
@@ -1169,7 +1169,7 @@ def plotcascade(results=None, aspercentage=False, cascadecolors=None, figsize=gl
         ax.legend(**legendsettings) # Multiple entries, all populations
             
         ax.set_title(thistitle)
-        cascadeplots[thistitle] = fig
+        cascadeplots[thistitle] = currfig
         
     return cascadeplots
 

--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -114,11 +114,14 @@ def getplotselections(results, advanced=False, includeadvancedtracking=False):
     ## Cascade plot is always available, since epi is always available
     plotselections['keys'].append('cascade')
     plotselections['names'].append('Care cascade')
-    plotselections['keys'].append('cascadebars')
-    plotselections['names'].append('Care cascade (bars)')
     if advanced:
+        plotselections['keys'].append('cascadebars')
+        plotselections['names'].append('Care cascade (bars) 95-95-95 targets')
         plotselections['keys'].append('cascadebars90')
-        plotselections['names'].append('Care cascade (bars) - 90-90-90 targets')
+        plotselections['names'].append('Care cascade (bars) 90-90-90 targets')
+    else:
+        plotselections['keys'].append('cascadebars')
+        plotselections['names'].append('Care cascade (bars)')
     
 #    ## Deaths by CD4 -- broken because no results.raw
 #    if advanced:
@@ -273,18 +276,21 @@ def makeplots(results=None, toplot=None, die=False, verbose=2, plotstartyear=Non
         toplot.remove('cascade') # Because everything else is passed to plotepi()
         cascadeplots = plotcascade(results, die=die, plotstartyear=plotstartyear, plotendyear=plotendyear, fig=fig, newfig=newfig, **kwargs)
         allplots.update(cascadeplots)
-    
+
+    bothcascadebars = ('cascadebars' in toplot) and ('cascadebars90' in toplot)
     ## Add cascade plot(s) with bars
     if 'cascadebars' in toplot:
         toplot.remove('cascadebars') # Because everything else is passed to plotepi()
-        cascadebarplots = plotcascade(results, die=die, fig=fig, asbars=True, newfig=newfig, **kwargs)
+        titlesuffix = ' (95-95-95 targets)' if bothcascadebars else None
+        cascadebarplots = plotcascade(results, die=die, fig=fig, asbars=True, newfig=newfig,titlesuffix=titlesuffix, **kwargs)
         allplots.update(cascadebarplots)
 
     ## Add cascade plot(s) with bars
     if 'cascadebars90' in toplot:
         toplot.remove('cascadebars90')  # Because everything else is passed to plotepi()
-        cascadebarplots = plotcascade(results, targets=90, die=die, fig=fig, asbars=True, newfig=newfig, **kwargs)
-        allplots.update(cascadebarplots)
+        titlesuffix = ' (90-90-90 targets)' if bothcascadebars else None
+        cascadebarplots90 = plotcascade(results, targets=90, die=die, fig=fig, asbars=True, newfig=newfig,titlesuffix=titlesuffix, **kwargs)
+        allplots.update(cascadebarplots90)
     
     ## Add deaths by CD4 plot -- WARNING, only available if results includes raw
     if 'deathbycd4' in toplot:
@@ -998,7 +1004,7 @@ def plotcoverage(multires=None, die=True, figsize=globalfigsize, legendsize=glob
 def plotcascade(results=None, aspercentage=False, cascadecolors=None, figsize=globalfigsize, lw=2, titlesize=globaltitlesize, 
                 labelsize=globallabelsize, ticksize=globalticksize, legendsize=globallegendsize, position=None, useSIticks=True, 
                 showdata=True, dotsize=50, plotstartyear=None, plotendyear=None, die=False, verbose=2, interactive=False, fig=None,
-                asbars=False, allbars=True, blhind=None, newfig=None, targets=None, **kwargs):
+                asbars=False, allbars=True, blhind=None, newfig=None, targets=None, titlesuffix=None, **kwargs):
 
     ''' 
     Plot the treatment cascade.
@@ -1147,8 +1153,9 @@ def plotcascade(results=None, aspercentage=False, cascadecolors=None, figsize=gl
             ax.spines['right'].set_visible(False)
             ax.yaxis.set_ticks_position('left')
             ax.xaxis.set_ticks_position('bottom')
-            if ismultisim: thistitle = 'Care cascade - %s' % titles[plt]
-            else:          thistitle = 'Care cascade'
+            if titlesuffix is None: titlesuffix = ''
+            if ismultisim: thistitle = 'Care cascade - %s' % titles[plt] + titlesuffix
+            else:          thistitle = 'Care cascade' + titlesuffix
         
         else: # Not bars
             bottom = 0*results.tvec # Easy way of setting to 0...

--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -116,6 +116,9 @@ def getplotselections(results, advanced=False, includeadvancedtracking=False):
     plotselections['names'].append('Care cascade')
     plotselections['keys'].append('cascadebars')
     plotselections['names'].append('Care cascade (bars)')
+    if advanced:
+        plotselections['keys'].append('cascadebars90')
+        plotselections['names'].append('Care cascade (bars) - 90-90-90 targets')
     
 #    ## Deaths by CD4 -- broken because no results.raw
 #    if advanced:
@@ -275,6 +278,12 @@ def makeplots(results=None, toplot=None, die=False, verbose=2, plotstartyear=Non
     if 'cascadebars' in toplot:
         toplot.remove('cascadebars') # Because everything else is passed to plotepi()
         cascadebarplots = plotcascade(results, die=die, fig=fig, asbars=True, newfig=newfig, **kwargs)
+        allplots.update(cascadebarplots)
+
+    ## Add cascade plot(s) with bars
+    if 'cascadebars90' in toplot:
+        toplot.remove('cascadebars90')  # Because everything else is passed to plotepi()
+        cascadebarplots = plotcascade(results, targets=90, die=die, fig=fig, asbars=True, newfig=newfig, **kwargs)
         allplots.update(cascadebarplots)
     
     ## Add deaths by CD4 plot -- WARNING, only available if results includes raw

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -156,31 +156,23 @@ class Programset(object):
 
     def reorderprograms(self,desiredorder,verbose=2):
         ''' Reorder the odict of programs. Expects desiredorder to be a list of Program or list of str'''
-
         if not (len(desiredorder) == len(self.programs)):
-            errormsg = f'You have asked to reorder the programs {[thisprog for thisprog in self.programs]} of programset {self.name} into order {desiredorder}, but the desired order only has {len(desiredorder)} programs not {len(self.programs)}.'
-            raise OptimaException(errormsg)
+            raise OptimaException(f'You have asked to reorder the programs {[thisprog for thisprog in self.programs]} of programset {self.name} into order {desiredorder}, but the desired order only has {len(desiredorder)} programs not {len(self.programs)}.')
 
         for i,program in enumerate(desiredorder):
-            if not type(program) == str: desiredorder[i] = program.short  # If not str, assume Program
+            if not type(program) == str: desiredorder[i] = program.short  # If not str, assume Program and get it's short name
 
-        if desiredorder == list(self.programs.keys()):  # Same order so don't need to continue
-            return
-
+        if desiredorder == list(self.programs.keys()): return # Same order so don't need to continue
         if not (set(desiredorder) == set(self.programs.keys())):   # desiredorder is a list of str, self.programs is an odict
-            errormsg = f'You have asked to reorder the programs {[thisprog for thisprog in self.programs]} of programset {self.name} into order {desiredorder}, but the desired order does not have all of the programs.'
-            raise OptimaException(errormsg)
+            raise OptimaException(f'You have asked to reorder the programs {[thisprog for thisprog in self.programs]} of programset {self.name} into order {desiredorder}, but the desired order does not have all of the programs.')
 
         originalprograms = dcp(self.programs)
         self.programs = odict()
-
         for i,program in enumerate(desiredorder):
             if program not in originalprograms:
-                errormsg = f'You have asked to reorder the program "{program}" to position {i} in programset {self.name}, but there is no program by this name. Available programs are {[thisprog for thisprog in self.programs]}'
-                raise OptimaException(errormsg)
+                raise OptimaException(f'You have asked to reorder the program "{program}" to position {i} in programset {self.name}, but there is no program by this name. Available programs are {[thisprog for thisprog in self.programs]}')
             else:
                 self.programs[program] = originalprograms[program]  # ordering an odict is done by the order of insertion
-
         self.updateprogset()
         printv(f'\nReordered the programs in programset: {self.name}.\nThe old order was: {[key for key in originalprograms.keys()]} and the new order is {[key for key in self.programs.keys()]}.')
 

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -837,6 +837,9 @@ def checkiffixedpropsconflictwithprogset(progset=None,parset=None, progendyear=2
         formatfor: 'html' or 'console': html uses <p> ... </p> to format the warning message, console uses \n
 
     Returns:
+        warning:
+        combinedwarningmsg:
+        warningmessages:
 
     """
     if progset is None or parset is None or parset.pars is None:
@@ -888,9 +891,9 @@ def checkiffixedpropsconflictwithprogset(progset=None,parset=None, progendyear=2
                                                                starttime=starttime)
     if formatfor == 'html':
         warningmessages = ['<p>' + msg + '</p>' for msg in warningmessages]
-        combinedwarningmsg = '<br>'.join(warningmessages)
+        combinedwarningmsg = '<br>'.join(warningmessages)  # Note that this defaults to '' if warningmessages is empty
     else:
-        combinedwarningmsg = (sep+sep).join(warningmessages)
+        combinedwarningmsg = (sep+sep).join(warningmessages)  # Note that this defaults to '' if warningmessages is empty
 
     return warning, combinedwarningmsg, warningmessages
 

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -6,7 +6,7 @@ set of programs, respectively.
 Version: 2019jan09
 """
 
-from optima import OptimaException, Link, printv, uuid, today, sigfig, getdate, dcp, smoothinterp, findinds, odict, Settings, sanitize, defaultrepr, isnumber, promotetoarray, vec2obj, asd, convertlimits
+from optima import OptimaException, Link, printv, uuid, today, sigfig, getdate, dcp, smoothinterp, findinds, odict, Settings, sanitize, defaultrepr, isnumber, promotetoarray, vec2obj, asd, convertlimits, Timepar, Yearpar
 from numpy import ones, prod, array, zeros, exp, log, append, nan, isnan, maximum, minimum, sort, concatenate as cat, transpose, mean, argsort
 from random import uniform
 import six
@@ -637,7 +637,7 @@ class Programset(object):
             last_y = thispar.interp(tvec=last_t, dt=settings.dt, asarray=False, usemeta=False) # Find what the model would get for this value
             
             for pop in outcomes[outcome].keys(): # WARNING, 'pop' should be renamed 'key' or something for e.g. partnerships
-                
+
                 # Validate outcome
                 thisoutcome = outcomes[outcome][pop] # Shorten
                 lower = float(thispar.limits[0]) # Lower limit, cast to float just to be sure (is probably int)
@@ -814,6 +814,85 @@ def costfuncobjectivecalc(parmeans=None, pardict=None, progset=None, parset=None
         printv('%45s | %30s | par: %s | budget: %s | mismatch: %s' % ((budgetparpair[0],budgetparpair[1])+sigfig([parval,budgetval,thismismatch],4)), 3, verbose)
     return mismatch
 
+overridingpars = odict([('propdx',['hivtest','aidstest']),
+                        ('propcare',['linktocare','aidslinktocare','leavecare','aidsleavecare','returntocare','aidstest']),
+                        ('proptx',['numtx']),
+                        ('propsupp',['treatfail','regainvs','numvlmon']),
+                        ('proppmtct',['numpmtct']),
+                        ('fixpropdx',['hivtest','aidstest']),
+                        ('fixpropcare',['linktocare','aidslinktocare','leavecare','aidsleavecare','returntocare','aidstest']),
+                        ('fixproptx',['numtx']),
+                        ('fixpropsupp',['treatfail','regainvs','numvlmon']),
+                        ('fixproppmtct',['numpmtct']) ])
+
+def checkiffixedpropsconflictwithprogset(progset=None,parset=None, progendyear=2100, formatfor='console'):
+    """
+    A helper function that checks whether there are any parameters in the parset that would make a program in
+    the progset not have an effect. This can be run for optimizations and scenarios, as long as the progset is
+    provided.
+    Args:
+        progset:
+        parset:
+        progendyear:
+        formatfor: 'html' or 'console': html uses <p> ... </p> to format the warning message, console uses \n
+
+    Returns:
+
+    """
+    if progset is None or parset is None or parset.pars is None:
+        raise OptimaException('checkiffixedpropsconflictwithprogset() must be provided with both a progset and a parset, but at least one of them was none.')
+
+    if formatfor == 'html': sep = '</p><p>'
+    else: sep = '\n'
+
+    progset.gettargetpartypes()
+    progtargetpartypes = progset.targetpartypes
+    pars = parset.pars
+    progsbytargetpartype = None
+    warning = False
+    warningmessages = []
+    warningmessage =       'Warning: The program \'{programsnames}\' in program set "{progsetname}" targets the "{affectedparname}" but the parameter set "{parsetname}" has "{overridingparname}" set to {valstr} which is before the program ends in {progendyear} so this program will have no effect after {starttime}.'
+    warningmessageplural = 'Warning: The programs {programsnames} in program set "{progsetname}" target the "{affectedparname}" but the parameter set "{parsetname}" has "{overridingparname}" set to {valstr} which is before the programs ends in {progendyear} so these programs will have no effect after {starttime}.'
+    recommendmessagefix = 'It is recommended to make another parameter set that has "{overridingparname}" set to 2100.'
+    recommendmessageprop = 'It is recommended to make another parameter set that doesn\'t have "{overridingparname}" set.'
+
+    for overriding, affectedpars in overridingpars.items():
+        overridingpar = pars[overriding]
+        if isinstance(overridingpar, Timepar):
+            tvals = array(overridingpar.t['tot'])
+            yvals = array(overridingpar.y['tot'])
+            timesset = tvals[~isnan(yvals)]
+            if len(timesset) == 0: continue
+            starttime = min(timesset)
+            valstr = f"{yvals[tvals==starttime][0]} in {starttime}"
+        elif isinstance(overridingpar, Yearpar):
+            starttime = overridingpar.t
+            valstr = f"{starttime}"
+        print('??', overridingpar.short, overridingpar.t, starttime)
+        if starttime is not None and starttime < progendyear: # the proportion is actually set so now we check if the programset targets any of the overriden parameters
+            for affected in affectedpars:
+                print('affected',overriding,affected, affected in progtargetpartypes)
+                if affected in progtargetpartypes:
+                    warning = True
+                    if progsbytargetpartype is None: progsbytargetpartype = progset.progs_by_targetpartype()
+                    progsaffectednames = [prog.short for prog in progsbytargetpartype[affected]]
+                    warningmessages.append(warningmessage if len(progsaffectednames) == 1 else warningmessageplural)
+                    warningmessages[-1] = warningmessages[-1] + sep + recommendmessagefix if isinstance(overridingpar, Yearpar) else warningmessages[-1] + sep + recommendmessageprop
+                    warningmessages[-1] = warningmessages[-1].format(programsnames=progsaffectednames if len(progsaffectednames)>1 else progsaffectednames[0],
+                                                               progsetname=progset.name,
+                                                               affectedparname=pars[affected].name,
+                                                               parsetname=parset.name,
+                                                               overridingparname=overridingpar.name,
+                                                               valstr=valstr,
+                                                               progendyear=progendyear,
+                                                               starttime=starttime)
+    if formatfor == 'html':
+        warningmessages = ['<p>' + msg + '</p>' for msg in warningmessages]
+        combinedwarningmsg = '<br>'.join(warningmessages)
+    else:
+        combinedwarningmsg = (sep+sep).join(warningmessages)
+
+    return warning, combinedwarningmsg, warningmessages
 
 
 class Program(object):

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -890,7 +890,7 @@ def checkiffixedpropsconflictwithprogset(progset=None,parset=None, progendyear=2
                                                                progendyear=progendyear,
                                                                starttime=starttime)
     if formatfor == 'html':
-        warningmessages = ['<p>' + msg + '</p>' for msg in warningmessages]
+        warningmessages = ['<p>' + msg.replace('"','&quot;') + '</p>' for msg in warningmessages]
         combinedwarningmsg = '<br>'.join(warningmessages)  # Note that this defaults to '' if warningmessages is empty
     else:
         combinedwarningmsg = (sep+sep).join(warningmessages)  # Note that this defaults to '' if warningmessages is empty

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -162,7 +162,10 @@ class Programset(object):
             raise OptimaException(errormsg)
 
         for i,program in enumerate(desiredorder):
-            if not type(program) == str: desiredorder[i] = program.short
+            if not type(program) == str: desiredorder[i] = program.short  # If not str, assume Program
+
+        if desiredorder == list(self.programs.keys()):  # Same order so don't need to continue
+            return
 
         if not (set(desiredorder) == set(self.programs.keys())):   # desiredorder is a list of str, self.programs is an odict
             errormsg = f'You have asked to reorder the programs {[thisprog for thisprog in self.programs]} of programset {self.name} into order {desiredorder}, but the desired order does not have all of the programs.'

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -154,6 +154,33 @@ class Programset(object):
             self.updateprogset()
             printv('\nRemoved program "%s" from programset "%s". \nPrograms in this programset are: %s' % (program, self.name, [thisprog.short for thisprog in self.programs.values()]), 4, verbose)
 
+    def reorderprograms(self,desiredorder,verbose=2):
+        ''' Reorder the odict of programs. Expects desiredorder to be a list of Program or list of str'''
+
+        if not (len(desiredorder) == len(self.programs)):
+            errormsg = f'You have asked to reorder the programs {[thisprog for thisprog in self.programs]} of programset {self.name} into order {desiredorder}, but the desired order only has {len(desiredorder)} programs not {len(self.programs)}.'
+            raise OptimaException(errormsg)
+
+        for i,program in enumerate(desiredorder):
+            if not type(program) == str: desiredorder[i] = program.short
+
+        if not (set(desiredorder) == set(self.programs.keys())):   # desiredorder is a list of str, self.programs is an odict
+            errormsg = f'You have asked to reorder the programs {[thisprog for thisprog in self.programs]} of programset {self.name} into order {desiredorder}, but the desired order does not have all of the programs.'
+            raise OptimaException(errormsg)
+
+        originalprograms = dcp(self.programs)
+        self.programs = odict()
+
+        for i,program in enumerate(desiredorder):
+            if program not in originalprograms:
+                errormsg = f'You have asked to reorder the program "{program}" to position {i} in programset {self.name}, but there is no program by this name. Available programs are {[thisprog for thisprog in self.programs]}'
+                raise OptimaException(errormsg)
+            else:
+                self.programs[program] = originalprograms[program]  # ordering an odict is done by the order of insertion
+
+        self.updateprogset()
+        printv(f'\nReordered the programs in programset: {self.name}.\nThe old order was: {[key for key in originalprograms.keys()]} and the new order is {[key for key in self.programs.keys()]}.')
+
     def optimizable(self):
         return [True if prog.optimizable() else False for prog in self.programs.values()]
 

--- a/optima/results.py
+++ b/optima/results.py
@@ -361,6 +361,9 @@ class Resultset(object):
 
         self.main['numpmtct'].pops = process(allpmtct[:,:,indices])
         self.main['numpmtct'].tot  = process(allpmtct[:,:,indices].sum(axis=1))
+        if data is not None:
+            self.main['numpmtct'].datatot = processdata(data['numpmtct'], uncertainty=False)
+            self.main['numpmtct'].estimate = False # It's real data, not just an estimate
 
         self.main['numnewdiag'].pops = process(alldiag[:,:,indices])
         self.main['numnewdiag'].tot  = process(alldiag[:,:,indices].sum(axis=1)) # Axis 1 is populations

--- a/optima/results.py
+++ b/optima/results.py
@@ -105,6 +105,7 @@ class Resultset(object):
         self.main['propincare']         = Result('Diagnosed PLHIV retained in care (%)',     ispercentage=True, defaultplot='total')
         self.main['proptreat']          = Result('Diagnosed PLHIV on treatment (%)',         ispercentage=True, defaultplot='total')
         self.main['propsuppressed']     = Result('Treated PLHIV with viral suppression (%)', ispercentage=True, defaultplot='total')
+        self.main['proppmtct']          = Result('HIV+ women receiving PMTCT (%)',           ispercentage=True, defaultplot='total')
         
         self.main['prev']               = Result('HIV prevalence (%)',       ispercentage=True, defaultplot='population')
         self.main['force']              = Result('HIV incidence (per 100 p.y.)', ispercentage=True, defaultplot='population')
@@ -426,6 +427,9 @@ class Resultset(object):
 
         self.main['propplhivsupp'].pops = process(allpeople[:,svl,:,:][:,:,:,indices].sum(axis=1)/maximum(allpeople[:,allplhiv,:,:][:,:,:,indices].sum(axis=1),eps), percent=True) 
         self.main['propplhivsupp'].tot = process(allpeople[:,svl,:,:][:,:,:,indices].sum(axis=(1,2))/maximum(allpeople[:,allplhiv,:,:][:,:,:,indices].sum(axis=(1,2)),eps), percent=True) # Axis 1 is populations
+
+        self.main['proppmtct'].pops = process(allpmtct[:,:,indices]/maximum(allhivbirths[:,:,indices],eps), percent=True)
+        self.main['proppmtct'].tot  = process(allpmtct[:,:,indices].sum(axis=1)/maximum(allhivbirths[:,:,indices].sum(axis=1),eps), percent=True) # Axis 1 is populations
 
         self.main['popsize'].pops = process(allpeople[:,:,:,indices].sum(axis=1))
         self.main['popsize'].tot = process(allpeople[:,:,:,indices].sum(axis=(1,2)))

--- a/optima/scenarios.py
+++ b/optima/scenarios.py
@@ -8,6 +8,7 @@ Version: 2017jun03
 from numpy import append, array, inf
 from optima import OptimaException, Link, Multiresultset # Core classes/functions
 from optima import dcp, today, odict, printv, findinds, defaultrepr, getresults, vec2obj, isnumber, uuid, promotetoarray # Utilities
+from optima import checkifparsetoverridesprogset, checkifparsoverridepars, createwarningforoverride # From programs.py and parameters.py for warning
 
 class Scen(object):
     ''' The scenario base class -- not to be used directly, instead use Parscen or Progscen '''
@@ -388,3 +389,47 @@ def defaultscenarios(project=None, which=None, startyear=2020, endyear=2025, par
         from optima import pygui
         pygui(project)
     return None # Can get it from project.scens
+
+
+def checkifparsetoverridesscenario(project, parset, scen, progendyear=None, formatfor='console', createmessages=True, die=False, verbose=2):
+    if isinstance(scen, Progscen):
+        progstartyear = scen.t
+
+        try: progset = project.progsets[scen.progsetname]
+        except:
+            errmsg = f'Warning could not get progset with name "{scen.progsetname}" for scenario "{scen.name}" from project "{project.name}" to check if any parameters override it.'
+            if die: raise OptimaException(errmsg)
+            else:
+                printv(errmsg, 2, verbose=verbose)
+                # warning, parsoverridingparsdict, overridetimes, overridevals, combinedwarningmsg, warningmessages
+                return False, odict(), odict(), odict(), '', []
+
+        # warning, parsoverridingparsdict, overridetimes, overridevals, combinedwarningmsg, warningmessages = \
+        return checkifparsetoverridesprogset(progset=progset, parset=parset, progendyear=progendyear, progstartyear=progstartyear, formatfor=formatfor, createmessages=createmessages)
+    elif isinstance(scen, Parscen):
+        origpars = parset.pars
+        targetpars = scen.pars
+        if len(targetpars) == 0: return False, odict(), odict(), odict(), '', []
+
+        targetparsnames = [par['name'] for par in targetpars]
+        targetparsstart = [par['startyear'] for par in targetpars]
+        targetparsend = [par['endyear'] for par in targetpars]
+
+        warning, parsoverridingparsdict, overridetimes, overridevals = \
+            checkifparsoverridepars(origpars,
+                                    targetparsnames,
+                                    progstartyear=min(targetparsstart),
+                                    progendyear=max(targetparsend)) # note that assumes that all Pars are set starting in the same year, and ending in the same year but this is good enough? for a warning
+
+        combinedwarningmsg, warningmessages = None, None
+        if createmessages:
+            warning, combinedwarningmsg, warningmessages = createwarningforoverride(origpars, warning,
+                                                                                    parsoverridingparsdict,
+                                                                                    overridetimes, overridevals,
+                                                                                    fortype='Parscen',
+                                                                                    parsetname=parset.name,
+                                                                                    progendyear=progendyear,
+                                                                                    formatfor=formatfor)
+        # warning, parsoverridingparsdict, overridetimes, overridevals, combinedwarningmsg, warningmessages
+        return warning, parsoverridingparsdict, overridetimes, overridevals, combinedwarningmsg, warningmessages
+

--- a/optima/scenarios.py
+++ b/optima/scenarios.py
@@ -391,18 +391,19 @@ def defaultscenarios(project=None, which=None, startyear=2020, endyear=2025, par
     return None # Can get it from project.scens
 
 
-def checkifparsetoverridesscenario(project, parset, scen, progendyear=None, formatfor='console', createmessages=True, die=False, verbose=2):
+def checkifparsetoverridesscenario(project, parset, scen, progset=None, progendyear=None, formatfor='console', createmessages=True, die=False, verbose=2):
     if isinstance(scen, Progscen):
-        progstartyear = scen.t
+        if progset is None:
+            try: progset = project.progsets[scen.progsetname]
+            except:
+                errmsg = f'Warning could not get progset with name "{scen.progsetname}" for scenario "{scen.name}" from project "{project.name}" to check if any parameters override it.'
+                if die: raise OptimaException(errmsg)
+                else:
+                    printv(errmsg, 2, verbose=verbose)
+                    # warning, parsoverridingparsdict, overridetimes, overridevals, combinedwarningmsg, warningmessages
+                    return False, odict(), odict(), odict(), '', []
 
-        try: progset = project.progsets[scen.progsetname]
-        except:
-            errmsg = f'Warning could not get progset with name "{scen.progsetname}" for scenario "{scen.name}" from project "{project.name}" to check if any parameters override it.'
-            if die: raise OptimaException(errmsg)
-            else:
-                printv(errmsg, 2, verbose=verbose)
-                # warning, parsoverridingparsdict, overridetimes, overridevals, combinedwarningmsg, warningmessages
-                return False, odict(), odict(), odict(), '', []
+        progstartyear = scen.t
 
         # warning, parsoverridingparsdict, overridetimes, overridevals, combinedwarningmsg, warningmessages = \
         return checkifparsetoverridesprogset(progset=progset, parset=parset, progendyear=progendyear, progstartyear=progstartyear, formatfor=formatfor, createmessages=createmessages)

--- a/optima/utils.py
+++ b/optima/utils.py
@@ -1666,7 +1666,7 @@ class odict(OrderedDict):
         except:
             output = items # If that fails, just give up and return the list
         return output
-        
+
 
 
     def __getitem__(self, key):
@@ -1676,9 +1676,12 @@ class odict(OrderedDict):
                 output = OrderedDict.__getitem__(self, key)
                 return output
             except Exception as E: # WARNING, should be KeyError, but this can't print newlines!!!
+                class KeyErrorMessage(str): # This str version makes KeyError able to print new lines
+                    def __repr__(self): return str(self)
+
                 if len(list(self.keys())): errormsg = '%s\nodict key "%s" not found; available keys are:\n%s' % (repr(E), flexstr(key), '\n'.join([flexstr(k) for k in self.keys()]))
                 else:                errormsg = 'Key "%s" not found since odict is empty'% key
-                raise Exception(errormsg)
+                raise KeyError(KeyErrorMessage(errormsg))
         elif isinstance(key, Number): # Convert automatically from float...dangerous?
             thiskey = list(self.keys())[int(key)]
             return OrderedDict.__getitem__(self,thiskey)

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -1505,7 +1505,15 @@ def load_reconcile_summary(project_id, progset_id, parset_id, t):
 
     budgets = progset.getdefaultbudget()
     if progset.readytooptimize():
-        pars = progset.compareoutcomes(parset=parset, year=t)
+        errmsg = None
+        try:
+            pars = progset.compareoutcomes(parset=parset, year=t)
+        except KeyError as e:
+            errmsg = 'One of the partnerships has changed, please refresh the programs by opening each one in the Programs tab and clicking Save.'
+            errmsg = str(e) + '\n\n' +  errmsg + '\n'
+        finally:
+            if errmsg is not None:  # Raise the error here so that the error message isn't too long
+                raise op.OptimaException(errmsg)
     else:
         msg = progset.readytooptimize(detail=True)
         pars = [[msg, '', 0, 0]]

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -1025,17 +1025,24 @@ def update_or_create_result_record_by_id(
 
 
 def delete_result_by_parset_id(
-        project_id, parset_id, calculation_type=None, db_session=None):
+        project_id, parset_id=None, calculation_type=None, db_session=None):
+    ''' Deletes the results filtering by parset_id, calculation_type, or both.
+        At least one of parset_id or calculation_type should not be None.     '''
     if db_session is None:
         db_session = db.session
     if calculation_type is None:
         records = db_session.query(ResultsDb).filter_by(
             project_id=project_id, parset_id=parset_id)
+    elif parset_id is None:
+        records = db_session.query(ResultsDb).filter_by(
+            project_id=project_id, calculation_type=calculation_type)
     else:
         records = db_session.query(ResultsDb).filter_by(
             project_id=project_id, parset_id=parset_id,
             calculation_type=calculation_type)
     for record in records:
+        print(f'>> delete_result_by_parset_id deleting results record '
+              f'project_id: {record.project_id}, parset_id: {record.parset_id}, calculation_type: {record.calculation_type}')
         record.cleanup()
     records.delete()
     db_session.commit()
@@ -1550,18 +1557,19 @@ def make_scenarios_graphs(project_id, which=None, is_run=False, zoom=None, start
             which = result.which
     if is_run:
         project = load_project(project_id)
+        if result is not None:
+            delete_result_by_parset_id(project_id, parset_id=None, calculation_type='scenarios')
+            save_project(project)
         if len(project.scens) == 0:
             print(">> make_scenarios_graphs no scenarios")
             return {}
-        print(">> make_scenarios_graphs project '%s' from %s to %s" % (
-            project_id, startYear, endYear))
+        print(">> make_scenarios_graphs project '%s' from %s to %s" % (project_id, startYear, endYear))
         # start=None, end=None -> does nothing
         project.runscenarios(end=endYear) # Only change end year from default
         result = project.results[-1]
         if which:
             result.which = which
-        record = update_or_create_result_record_by_id(
-            result, project.uid, None, 'scenarios')
+        record = update_or_create_result_record_by_id(result, project.uid, None, 'scenarios')
         db.session.add(record)
         db.session.commit()
     return make_mpld3_graph_dict(result=result, which=which, zoom=zoom, startYear=startYear, endYear=endYear)

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1232,7 +1232,7 @@ def get_scenario_summary(project, scenario):
     except:
         print('>> Warning, scenario parset "%s" not in project parsets: %s; reverting to default "%s"' % (scenario.parsetname, project.parsets.keys(), project.parset().name))
         parset_id = project.parset().uid
-    if hasattr(scenario, "progsetname"):
+    if hasattr(scenario, "progsetname") and not isinstance(scenario, op.Parscen):
         try:
             progset_id = project.progsets[scenario.progsetname].uid
         except:

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1462,9 +1462,9 @@ def get_optimization_summaries(project):
 
         optim_summary["parset_id"]   = parset_id
         optim_summary["progset_id"] = progset_id
-
-        warning, combinedwarningmsg, warningmessages = \
-            op.checkiffixedpropsconflictwithprogset(progset,parset,progendyear=optim.objectives['end'],formatfor='html')
+        warning, _, _, _, combinedwarningmsg, warningmessages = \
+            checkifparsetoverridesprogset(progset=progset, parset=parset, progendyear=optim.objectives['end'],
+                                          progstartyear=optim.objectives['start'], formatfor='html', createmessages=True)
         optim_summary["warning"] = warning
         optim_summary["warningmessage"] = combinedwarningmsg
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1229,17 +1229,22 @@ def get_scenario_summary(project, scenario):
 
     try:
         parset_id = project.parsets[scenario.parsetname].uid
+        parset    = project.parsets[scenario.parsetname]
     except:
         print('>> Warning, scenario parset "%s" not in project parsets: %s; reverting to default "%s"' % (scenario.parsetname, project.parsets.keys(), project.parset().name))
         parset_id = project.parset().uid
+        parset    = project.parset()
     if hasattr(scenario, "progsetname") and not isinstance(scenario, op.Parscen):
         try:
             progset_id = project.progsets[scenario.progsetname].uid
+            progset    = project.progsets[scenario.progsetname]
         except:
             print('>> Warning, scenario progset "%s" not in project progset: %s; reverting to default "%s"' % (scenario.progsetname, project.progsets.keys(), project.progset().name))
             progset_id = project.progset().uid
+            progset    = project.progset()
     else:
         progset_id = None
+        progset = None
 
     if hasattr(scenario, "uid"):
         scenario_id = scenario.uid
@@ -1247,6 +1252,9 @@ def get_scenario_summary(project, scenario):
         scenario_id = scenario.uuid
     else:
         scenario_id = op.uuid()
+
+    warning, _,_,_, combinedwarningmsg, warningmessages = \
+        op.checkifparsetoverridesscenario(project=project, parset=parset,progset=progset, scen=scenario, formatfor='html', createmessages=True)
 
     result = {
         'id': scenario_id,
@@ -1256,6 +1264,8 @@ def get_scenario_summary(project, scenario):
         'name': scenario.name,
         'years': scenario.t,
         'parset_id': parset_id,
+        'warning': warning,
+        'warningmessage': combinedwarningmsg,
     }
     result.update(variant_data)
     return result

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -457,7 +457,7 @@ def get_parameters_for_scenarios(project):
         pars = []
         result[parset_id] = pars
         for par in parset.pars.values():
-            if isinstance(par, op.Timepar): # Targetable parameters are timepars
+            if isinstance(par, op.Timepar) and par.short not in get_disallowed_parameters_for_program(): # Targetable parameters are timepars
                 for pop in par.keys():
                     pars.append({
                         'name': par.name,
@@ -509,7 +509,8 @@ def get_parameters_for_edit_program(project):
     return parameters
 
 def get_disallowed_parameters_for_program():
-    ''' Returns a list of short names of parameters that programs cannot affect (hardcoded here)'''
+    ''' Returns a list of short names of parameters that programs and parameter scenarios cannot affect
+        WARNING used by the FE and hardcoded here.'''
     return ['agerate']
 
 def get_parameters_for_outcomes(project, progset_id, parset_id):
@@ -522,7 +523,7 @@ def get_parameters_for_outcomes(project, progset_id, parset_id):
     progset.gettargetpars()
     progset.gettargetpartypes()
 
-    target_par_shorts = set([p['param'] for p in progset.targetpars]) #!!HERE targetpars is the one we want to compare with
+    target_par_shorts = set([p['param'] for p in progset.targetpars])
     pars = parset.pars
     parameters = [ # Note the loop!
         {
@@ -1389,7 +1390,7 @@ def get_optimization_from_project(project, optim_id):
     raise ValueError(errormsg)
 
 
-def get_optimization_summaries(project): #!!!HERE IS WHAT I WANT TO EDIT
+def get_optimization_summaries(project):
     '''
     Returns a list of dictionaries:
         -

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -522,7 +522,7 @@ def get_parameters_for_outcomes(project, progset_id, parset_id):
     progset.gettargetpars()
     progset.gettargetpartypes()
 
-    target_par_shorts = set([p['param'] for p in progset.targetpars])
+    target_par_shorts = set([p['param'] for p in progset.targetpars]) #!!HERE targetpars is the one we want to compare with
     pars = parset.pars
     parameters = [ # Note the loop!
         {
@@ -546,7 +546,7 @@ def get_parameters_for_outcomes(project, progset_id, parset_id):
         }
         for par_short in target_par_shorts
     ]
-
+    print(f'!!! parameters:{parameters}')
     return {'parameters': parameters}
 
 
@@ -1389,7 +1389,7 @@ def get_optimization_from_project(project, optim_id):
     raise ValueError(errormsg)
 
 
-def get_optimization_summaries(project):
+def get_optimization_summaries(project): #!!!HERE IS WHAT I WANT TO EDIT
     '''
     Returns a list of dictionaries:
         -
@@ -1457,6 +1457,8 @@ def get_optimization_summaries(project):
 
         optim_summary["parset_id"]   = parset_id
         optim_summary["progset_id"] = progset_id
+
+
 
         optim_summaries.append(optim_summary)
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -489,9 +489,10 @@ def get_startval_for_parameter(project, parset_id, par_short, pop, year):
     return None
 
 def get_parameters_for_edit_program(project):
+    disallowed_parameters = get_disallowed_parameters_for_program()
     parameters = []
     added_par_keys = set()
-    default_par_keys = [par['short'] for par in op.loadpartable()]
+    default_par_keys = [par['short'] for par in op.loadpartable() if par['short'] not in disallowed_parameters]
     for parset in project.parsets.values():
         pars = parset.pars
         for par_key in default_par_keys:
@@ -507,6 +508,9 @@ def get_parameters_for_edit_program(project):
                     added_par_keys.add(par_key)
     return parameters
 
+def get_disallowed_parameters_for_program():
+    ''' Returns a list of short names of parameters that programs cannot affect (hardcoded here)'''
+    return ['agerate']
 
 def get_parameters_for_outcomes(project, progset_id, parset_id):
     progset = get_progset_from_project(project, progset_id)

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1233,9 +1233,9 @@ def get_scenario_summary(project, scenario):
         parset_id = project.parset().uid
     if hasattr(scenario, "progsetname"):
         try:
-            print('>> Warning, scenario progset "%s" not in project progset: %s; reverting to default "%s"' % (scenario.progsetname, project.progsets.keys(), project.progset().name))
             progset_id = project.progsets[scenario.progsetname].uid
         except:
+            print('>> Warning, scenario progset "%s" not in project progset: %s; reverting to default "%s"' % (scenario.progsetname, project.progsets.keys(), project.progset().name))
             progset_id = project.progset().uid
     else:
         progset_id = None

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1445,20 +1445,27 @@ def get_optimization_summaries(project): #!!!HERE IS WHAT I WANT TO EDIT
 
         try:
             parset_id = project.parsets[optim.parsetname].uid # Try to extract the
+            parset    = project.parsets[optim.parsetname]
         except:
             print('>> Warning, optimization parset "%s" not in project parsets: %s; reverting to default "%s"' % (optim.parsetname, project.parsets.keys(), project.parset().name))
             parset_id = project.parset().uid # Just get the default
+            parset    = project.parset()
 
         try:
             progset_id = project.progsets[optim.progsetname].uid # Try to extract the
+            progset    = project.progsets[optim.progsetname]
         except:
             print('>> Warning, optimization progset "%s" not in project progsets: %s; reverting to default "%s"' % (optim.progsetname, project.progsets.keys(), project.progset().name))
             progset_id = project.progset().uid # Just get the default
+            progset    = project.progset()
 
         optim_summary["parset_id"]   = parset_id
         optim_summary["progset_id"] = progset_id
 
-
+        warning, combinedwarningmsg, warningmessages = \
+            op.checkiffixedpropsconflictwithprogset(progset,parset,progendyear=optim.objectives.end,formatfor='html')
+        optim_summary["warning"] = warning
+        optim_summary["warningmessage"] = combinedwarningmsg
 
         optim_summaries.append(optim_summary)
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1473,7 +1473,7 @@ def get_optimization_summaries(project):
         optim_summary["parset_id"]   = parset_id
         optim_summary["progset_id"] = progset_id
         warning, _, _, _, combinedwarningmsg, warningmessages = \
-            checkifparsetoverridesprogset(progset=progset, parset=parset, progendyear=optim.objectives['end'],
+            op.checkifparsetoverridesprogset(progset=progset, parset=parset, progendyear=optim.objectives['end'],
                                           progstartyear=optim.objectives['start'], formatfor='html', createmessages=True)
         optim_summary["warning"] = warning
         optim_summary["warningmessage"] = combinedwarningmsg

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1463,7 +1463,7 @@ def get_optimization_summaries(project): #!!!HERE IS WHAT I WANT TO EDIT
         optim_summary["progset_id"] = progset_id
 
         warning, combinedwarningmsg, warningmessages = \
-            op.checkiffixedpropsconflictwithprogset(progset,parset,progendyear=optim.objectives.end,formatfor='html')
+            op.checkiffixedpropsconflictwithprogset(progset,parset,progendyear=optim.objectives['end'],formatfor='html')
         optim_summary["warning"] = warning
         optim_summary["warningmessage"] = combinedwarningmsg
 

--- a/server/webapp/tasks.py
+++ b/server/webapp/tasks.py
@@ -103,14 +103,14 @@ def init_db_session():
     Create scoped_session, eventually bound to engine
     """
     out =  scoped_session(sessionmaker(db.engine))
-    print(f"!! init_db_session called from:{inspect.currentframe().f_back.f_code.co_name}. Returning:{out}, status of out.bind:{out.bind.status()}")
+    print(f"!! init_db_session called from:{inspect.currentframe().f_back.f_code.co_name}. Returning:{out}, status of out.bind.pool:{out.bind.pool.status()}")
     return out
 
 
 def close_db_session(db_session):
     # this line might be redundant (not 100% sure - not clearly described)
 
-    print(f"!! close_db_session called with db_session:{db_session}, from:{inspect.currentframe().f_back.f_code.co_name}, status of db_session.bind:{db_session.bind.status()}")
+    print(f"!! close_db_session called with db_session:{db_session}, from:{inspect.currentframe().f_back.f_code.co_name}, status of db_session.bind.pool:{db_session.bind.pool.status()}")
     db_session.connection().close() # pylint: disable=E1101
     db_session.remove()
     # black magic to actually close the connection by forcing the engine to dispose of garbage (I assume)

--- a/server/webapp/tasks.py
+++ b/server/webapp/tasks.py
@@ -4,7 +4,7 @@ from celery import Celery
 from celery.contrib.abortable import AbortableTask, AbortableAsyncResult
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import sessionmaker, scoped_session
-import inspect
+# import inspect # Use for debugging "too many clients already" FE error
 import optima as op
 
 
@@ -102,15 +102,16 @@ def init_db_session():
     """
     Create scoped_session, eventually bound to engine
     """
-    out =  scoped_session(sessionmaker(db.engine))
-    print(f"!! init_db_session called from:{inspect.currentframe().f_back.f_code.co_name}. Returning:{out}, status of out.bind.pool:{out.bind.pool.status()}")
-    return out
+    # Use for debugging "too many clients already" FE error
+    # print(f"!! init_db_session called from:{inspect.currentframe().f_back.f_code.co_name}. Returning:{out}, status of out.bind.pool:{out.bind.pool.status()}")
+    return scoped_session(sessionmaker(db.engine))
 
 
 def close_db_session(db_session):
     # this line might be redundant (not 100% sure - not clearly described)
 
-    print(f"!! close_db_session called with db_session:{db_session}, from:{inspect.currentframe().f_back.f_code.co_name}, status of db_session.bind.pool:{db_session.bind.pool.status()}")
+    # Use for debugging "too many clients already" FE error
+    # print(f"!! close_db_session called with db_session:{db_session}, from:{inspect.currentframe().f_back.f_code.co_name}, status of db_session.bind.pool:{db_session.bind.pool.status()}")
     db_session.connection().close() # pylint: disable=E1101
     db_session.remove()
     # black magic to actually close the connection by forcing the engine to dispose of garbage (I assume)

--- a/server/webapp/tasks.py
+++ b/server/webapp/tasks.py
@@ -4,6 +4,7 @@ from celery import Celery
 from celery.contrib.abortable import AbortableTask, AbortableAsyncResult
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import sessionmaker, scoped_session
+import inspect
 import optima as op
 
 
@@ -101,11 +102,15 @@ def init_db_session():
     """
     Create scoped_session, eventually bound to engine
     """
-    return scoped_session(sessionmaker(db.engine))
+    out =  scoped_session(sessionmaker(db.engine))
+    print(f"!! init_db_session called from:{inspect.currentframe().f_back.f_code.co_name}. Returning:{out}, status of out.bind:{out.bind.status()}")
+    return out
 
 
 def close_db_session(db_session):
     # this line might be redundant (not 100% sure - not clearly described)
+
+    print(f"!! close_db_session called with db_session:{db_session}, from:{inspect.currentframe().f_back.f_code.co_name}, status of db_session.bind:{db_session.bind.status()}")
     db_session.connection().close() # pylint: disable=E1101
     db_session.remove()
     # black magic to actually close the connection by forcing the engine to dispose of garbage (I assume)


### PR DESCRIPTION
This hasn't changed the behaviour of the optimizations or model, just simply fixed bugs and added additional outputs

 - Fix 'cascade' plot labels overlapping when downloaded from FE
 - Fix 0/0 error in money optimization
 - Ensure programset and optimization constraints are in the same order by reordering the progamset to match optim.constraints
 - Make optimization more bug-proof by using program keys eg "ART" instead of optiminds [0,1,2...] (maintained backwards compatibility)
 - when optiminds are used, calcoptimindsoptimkeys() ensures they match the optimkeys

 - Add fixproppmtct to the model so it is actually used
 - Note that fixproppmtct is based off calcproppmtct which is: number of mothers on PMTCT / number of mothers who know their status  - This may need to be changed...
- note that there is no targetted testing of pregnant women, so the number on PMTCT may be too low if not enough women know their status. 
 - Fix bug where 'numpmtct' wasn't annualised in the results, giving "HIV+ women receiving PMTCT" plot was 5 times too low
 - Add data points to "HIV+ women receiving PMTCT" (note that the model may not have as many mothers on PMTCT see above)
 - Add proppmtct to the results.main: the proportion of HIV+ mothers that are on PMTCT. Again, if you fixproppmtct, this might not stay constant because fixproppmtct fixes: num on PMTCT / num of mothers who know their status

- Remove 'ageing rate' from the list of parameters that programs can affect
- Improve error message in the FE Cost Functions tab when partnerships change
- Propcare now brings people from both dx (and not in care) and lost into care, puts them down into lost if too many in care. (previously brought up only from dx, down back dx if too many in care)
- Fixed when propcare was set, people weren't getting linked to care because there were enough in care.

Unfinished:
 - Warning when optimization and budget scenario is  run with parset that has fixed proportions
 - PMTCT currently has proppmtct = numpmtct / hiv+dxmothers, which is less intuitive than numpmtct / allhiv+mothers

Questions:
 - Should 'ageing rate' be removed from parameter scenarios as well?
 - Removing ageing rate from programs was done with a list in the code for the backend - other option is to make a new column in model-inputs.xlsx but that seems a little bit overkill for just one or two parameters. Is the current fix ok
 - Should clicking the FE warning do anything in particular? eg. the help buttons take you to a location in the User Guide