### PR TITLE
Add diagnosis by CD4 count

### DIFF
--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -95,7 +95,8 @@ def setmigrations(which='migrations'):
         ('2.10.14',('2.10.15','2022-09-13',fixmoremanfitsettings,'Fix more manual fit settings (which impact on FE display)')),
         ('2.10.15',('2.10.16','2022-09-15',clearuntrackedresults,'Clear results if they did not have tracking')),
         ('2.10.16',('2.11.0', '2022-09-17', None,            'Version update for updated GUI launch')),
-        ('2.11.0', ('2.11.1', '2022-10-06',addcd4lt200indssetting,'Add cd4lt200inds to settings. Lots of other changes in this update that do not need a migration')),
+        ('2.11.0', ('2.11.1', '2022-10-06', None,            'Major bug fixes, FE updates, fixproppmtct now fixes proportion of diagnosed women on PMTCT and propcare brings people from dx and lost')),
+        ('2.11.1', ('2.11.2', '2022-10-10', None,            'Big model speed ups (about 25%) and split diagnoses by CD4 count')),
         ])
     
     
@@ -1449,22 +1450,6 @@ def clearuntrackedresults(project=None, **kwargs):
             if not hasattr(res, 'advancedtracking'): #if anything wasn't migrated previously just clear the result and user will rerun, migration is complex otherwise
                 project.results = op.odict()
                 break
-    return None
-
-def addcd4lt200indssetting(project=None, **kwargs):
-    '''
-    Migration between Optima 2.11.0 and 2.11.1
-    - Adds cd4lt200inds (the indices of the cd4 states <200) to settings
-    '''
-    if project is not None:
-        if project.settings is not None:
-            if not hasattr(project.settings, 'cd4lt200inds'):
-                base_settings = op.Settings()
-                project.settings.cd4lt200inds = base_settings.cd4lt200inds
-        for res in project.results.values():
-            if not hasattr(res.settings, 'cd4lt200inds'):
-                settings = project.settings if project.settings is not None else op.Settings()
-                res.settings.cd4lt200inds = settings.cd4lt200inds
     return None
 
 ##########################################################################################

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -95,7 +95,7 @@ def setmigrations(which='migrations'):
         ('2.10.14',('2.10.15','2022-09-13',fixmoremanfitsettings,'Fix more manual fit settings (which impact on FE display)')),
         ('2.10.15',('2.10.16','2022-09-15',clearuntrackedresults,'Clear results if they did not have tracking')),
         ('2.10.16',('2.11.0', '2022-09-17', None,            'Version update for updated GUI launch')),
-        ('2.11.0', ('2.11.1', '2022-10-06', None,            'Major bug fixes, FE updates, fixproppmtct now fixes proportion of diagnosed women on PMTCT and propcare brings people from dx and lost')),
+        ('2.11.0', ('2.11.1', '2022-10-06',addcd4lt200indssetting,'Add cd4lt200inds to settings. Lots of other changes in this update that do not need a migration')),
         ])
     
     
@@ -1449,6 +1449,22 @@ def clearuntrackedresults(project=None, **kwargs):
             if not hasattr(res, 'advancedtracking'): #if anything wasn't migrated previously just clear the result and user will rerun, migration is complex otherwise
                 project.results = op.odict()
                 break
+    return None
+
+def addcd4lt200indssetting(project=None, **kwargs):
+    '''
+    Migration between Optima 2.11.0 and 2.11.1
+    - Adds cd4lt200inds (the indices of the cd4 states <200) to settings
+    '''
+    if project is not None:
+        if project.settings is not None:
+            if not hasattr(project.settings, 'cd4lt200inds'):
+                base_settings = op.Settings()
+                project.settings.cd4lt200inds = base_settings.cd4lt200inds
+        for res in project.results.values():
+            if not hasattr(res.settings, 'cd4lt200inds'):
+                settings = project.settings if project.settings is not None else op.Settings()
+                res.settings.cd4lt200inds = settings.cd4lt200inds
     return None
 
 ##########################################################################################

--- a/optima/model.py
+++ b/optima/model.py
@@ -27,9 +27,9 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
         print('WARNING, due to parameter interpolation, results are unreliable if initpeople is not None!')
 
     # PMTCT behaviour
-    useoldpmtct = compareversions(version,"2.12.0") < 0 # Remove new pmtct behaviour from 2.11.x versions and before
-    if useoldpmtct: diagnosemothersforpmtct = False  # Don't diagnose mothers
-    else:           diagnosemothersforpmtct = True
+    oldbehaviour = compareversions(version,"2.12.0") < 0 # Remove new pmtct behaviour from 2.11.x versions and before
+    if oldbehaviour: diagnosemothersforpmtct = False  # Don't diagnose mothers
+    else:            diagnosemothersforpmtct = False
     putinstantlyontopmtct = True  # Should be True, since we are only considering mothers to be preg when they are giving birth - otherwise we get too many diagnosed by ANC
     printpmtctinformation = False
 
@@ -147,6 +147,14 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
     immipropdiag    = simpars['immipropdiag']       #Proportion of immigrants with HIV who are already diagnosed (will be assumed linked to care but not on treatment)
 
     # Shorten to lists of key tuples so don't have to iterate over every population twice for every timestep
+    if oldbehaviour:
+        risktransitlist,agetransitlist = [],[]
+        for p1 in range(npops):
+            for p2 in range(npops):
+                if agetransit[p1,p2]:
+                    agetransitlist.append((p1,p2, (1.-exp(-dt/agetransit[p1,p2]))))
+                if risktransit[p1,p2]:  risktransitlist.append((p1,p2, (1.-exp(-dt/risktransit[p1,p2]))))
+
     with errstate(divide='ignore'): # If risktransit[p1,p2] = 0 then -dt/risktransit[:,:] is inf, but it is ok, we sanitize
         risktransit = array(risktransit, dtype=float)
         risktransitarr = 1.-exp(-dt/risktransit[:,:])
@@ -540,6 +548,15 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
     ### Age precalculation
     ##############################################################################################################
 
+    if oldbehaviour:
+        agelist = dict()
+        for p1 in range(npops):
+            agelist[p1] = dict()
+            # allagerate = einsum('i,j->j',agetransit[p1, :],agerate[p1, :])
+            for p2 in range(npops):
+                agerates = agetransit[p1, p2] * agerate[p1, :]
+                agelist[p1][p2] = agerates
+
     agearr = zeros((npops, npops, npts))
     agearr = einsum('ij,ik->ijk', agetransit, agerate) # shape: (frompop, topop, time)
 
@@ -836,7 +853,7 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
         numdxhivpospregwomen   = numpotmothers[:,_alldx]    * totalbirthrate
         numundxhivpospregwomen = numpotmothers[:, _undx]    * totalbirthrate
 
-        if useoldpmtct:  # old behaviour is calcproppmtct = numpmtct / dxpregwomen, and proppmtct = numpmtct / dxpregwomen
+        if oldbehaviour:  # old behaviour is calcproppmtct = numpmtct / dxpregwomen, and proppmtct = numpmtct / dxpregwomen
             if isnan(proppmtct[t]): thisnumpmtct = numpmtct[t] / timestepsonpmtct
             else:                   thisnumpmtct = proppmtct[t]*(eps*dt+numdxhivpospregwomen.sum())
         else:            # New behaviour calcproppmtct = numpmtct / dxpregwomen, whereas proppmtct = numpmtct / allhiv+pregwomen
@@ -891,7 +908,7 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
         # New behaviour calcproppmtct = numpmtct / dxpregwomen, whereas thisproppmtct = numpmtct /  allhiv+pregwomen
         calcproppmtct = thisnumpmtct / (eps*dt+numdxhivpospregwomen.sum()) # eps*dt to make sure that backwards compatible
         calcproppmtct = minimum(calcproppmtct,1)
-        if useoldpmtct: thisproppmtct = calcproppmtct  # old behaviour is calcproppmtct = numpmtct / dxpregwomen, and thisproppmtct = numpmtct / dxpregwomen
+        if oldbehaviour: thisproppmtct = calcproppmtct  # old behaviour is calcproppmtct = numpmtct / dxpregwomen, and thisproppmtct = numpmtct / dxpregwomen
         else:           thisproppmtct = thisnumpmtct / (eps+numhivpospregwomen.sum())
         thisproppmtct = minimum(calcproppmtct, 1)
 
@@ -958,24 +975,56 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
             people[susreg,:,t+1]   -= circppl
             people[progcirc,:,t+1] += circppl
 
-            ## Age-related transitions
-            peoplefromto = einsum('ki,ij->kij', people[:,:,t+1], agearr[:,:,t])
-            people[:,:,t+1] -= peoplefromto.sum(axis=2)  # sum over popto    # Ageing from a population
-            people[:,:,t+1] += peoplefromto.sum(axis=1)  # sum over popfrom  # Ageing to a population
-            if advancedtracking:
-                raw_transitpopbypop[:,allplhiv,:,t+1] += swapaxes(peoplefromto[allplhiv,:,:],1,2) / dt  # annualize
+            if oldbehaviour:
+                ## Age-related transitions
+                for p1,p2,thisagetransprob in agetransitlist:
+                    thisagerate = agelist[p1][p2][t]
+                    peopleleaving = people[:, p1, t+1] * thisagerate #thisagetransprob
+                    if debug and (peopleleaving > people[:, p1, t+1]).any():
+                        errormsg = label + 'Age transitions between pops %s and %s at time %i are too high: the age transitions you specified say that %f%% of the population should age in a single time-step.' % (popkeys[p1], popkeys[p2], t+1, agetransit[p1, p2]*100.)
+                        if die: raise OptimaException(errormsg)
+                        else:   printv(errormsg, 1, verbose)
+                        peopleleaving = minimum(peopleleaving, people[:, p1, t]) # Ensure positive
 
-            # ## Risk-related transitions
-            # peoplefromto1: statetofrom, popfrom, popto
-            peoplefromto1 = einsum('ki,ij->kij', people[:,:,t+1], risktransitarr[:,:]) # Number of other people who are moving pop1 -> pop2
-            peoplefromto2 = einsum('kj,ij,i,j->kij', people[:,:,t+1], risktransitarr[:,:], people[:,:,t+1].sum(axis=0), 1/people[:,:,t+1].sum(axis=0)) # Number of people who moving pop2 -> pop1, correcting for population size
-            people[:,:,t+1] -= peoplefromto1.sum(axis=2)
-            people[:,:,t+1] += peoplefromto1.sum(axis=1) # Symmetric flow in totality, but the state distribution will ideally change.
-            people[:,:,t+1] -= swapaxes(peoplefromto2,1,2).sum(axis=2)
-            people[:,:,t+1] += swapaxes(peoplefromto2,1,2).sum(axis=1)
-            if advancedtracking:
-                raw_transitpopbypop[:,allplhiv,:,t+1] += swapaxes(peoplefromto1[allplhiv,:,:],1,2)/dt #annualize
-                raw_transitpopbypop[:,allplhiv,:,t+1] += swapaxes(peoplefromto2[allplhiv,:,:],1,2)/dt #annualize
+
+                    people[:, p1, t+1] -= peopleleaving # Take away from pop1...
+                    people[:, p2, t+1] += peopleleaving # ... then add to pop2
+
+                    if advancedtracking:
+                        raw_transitpopbypop[p2,allplhiv,p1, t+1] += peopleleaving[allplhiv]/dt #annualize
+
+
+                ## Risk-related transitions
+                for p1,p2,thisrisktransprob in risktransitlist:
+                    peoplemoving1 = people[:, p1, t+1] * thisrisktransprob  # Number of other people who are moving pop1 -> pop2
+                    peoplemoving2 = people[:, p2, t+1] * thisrisktransprob * (sum(people[:, p1, t+1])/sum(people[:, p2, t+1])) # Number of people who moving pop2 -> pop1, correcting for population size
+                    # Symmetric flow in totality, but the state distribution will ideally change.
+                    people[:, p1, t+1] += peoplemoving2 - peoplemoving1 # NOTE: this should not cause negative people; peoplemoving1 is guaranteed to be strictly greater than 0 and strictly less that people[:, p1, t+1]
+                    people[:, p2, t+1] += peoplemoving1 - peoplemoving2 # NOTE: this should not cause negative people; peoplemoving2 is guaranteed to be strictly greater than 0 and strictly less that people[:, p2, t+1]
+
+                    if advancedtracking:
+                        raw_transitpopbypop[p2,allplhiv,p1, t+1] += peoplemoving1[allplhiv]/dt #annualize
+                        raw_transitpopbypop[p1,allplhiv,p2, t+1] += peoplemoving2[allplhiv]/dt #annualize
+            else:
+                ## Age-related transitions
+                peoplefromto = einsum('ki,ij->kij', people[:,:,t+1], agearr[:,:,t])
+                people[:,:,t+1] -= peoplefromto.sum(axis=2)  # sum over popto    # Ageing from a population
+                people[:,:,t+1] += peoplefromto.sum(axis=1)  # sum over popfrom  # Ageing to a population
+                if advancedtracking:
+                    raw_transitpopbypop[:,allplhiv,:,t+1] += swapaxes(peoplefromto[allplhiv,:,:],1,2) / dt  # annualize
+
+                # ## Risk-related transitions
+                # peoplefromto1: statetofrom, popfrom, popto
+                peoplefromto1 = einsum('ki,ij->kij', people[:,:,t+1], risktransitarr[:,:]) # Number of other people who are moving pop1 -> pop2
+                peoplefromto2 = einsum('kj,ij,i,j->kij', people[:,:,t+1], risktransitarr[:,:], people[:,:,t+1].sum(axis=0), 1/people[:,:,t+1].sum(axis=0)) # Number of people who moving pop2 -> pop1, correcting for population size
+                people[:,:,t+1] -= peoplefromto1.sum(axis=2)
+                people[:,:,t+1] += peoplefromto1.sum(axis=1) # Symmetric flow in totality, but the state distribution will ideally change.
+                people[:,:,t+1] -= swapaxes(peoplefromto2,1,2).sum(axis=2)
+                people[:,:,t+1] += swapaxes(peoplefromto2,1,2).sum(axis=1)
+                if advancedtracking:
+                    raw_transitpopbypop[:,allplhiv,:,t+1] += swapaxes(peoplefromto1[allplhiv,:,:],1,2)/dt #annualize
+                    raw_transitpopbypop[:,allplhiv,:,t+1] += swapaxes(peoplefromto2[allplhiv,:,:],1,2)/dt #annualize
+
 
             ###############################################################################
             ## Reconcile population sizes

--- a/optima/model.py
+++ b/optima/model.py
@@ -1183,14 +1183,14 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
     raw['hivbirths']      = raw_hivbirths
     raw['immi']           = raw_immi
     raw['pmtct']          = raw_receivepmtct
-    raw['diag']           = raw_diagcd4.sum(axis=0) # sum over cd4 count
-    raw['diagcd4']        = raw_diagcd4
+    raw['diag']           = raw_diagcd4.sum(axis=0) # Sum over cd4 count
     raw['diagpmtct']      = raw_dxforpmtct
     raw['newtreat']       = raw_newtreat
     raw['death']          = raw_death
     raw['otherdeath']     = raw_otherdeath
     if advancedtracking:
-        raw['incionpopbypop'] = raw_incionpopbypopmethods.sum(axis=0) # removes the method of transmission
+        raw['diagcd4']        = raw_diagcd4
+        raw['incionpopbypop'] = raw_incionpopbypopmethods.sum(axis=0) # Removes the method of transmission
         raw['incimethods']    = raw_incionpopbypopmethods
         raw['transitpopbypop']= raw_transitpopbypop
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -776,12 +776,10 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
 
         # SVL to USVL
         usvlprob = treatfail[t] if userate(propsupp,t) else 0.
-        for fromstate in svl:
-            for tostate in fromto[fromstate]:
-                if tostate in svl: # Probability of remaining suppressed
-                    thistransit[fromstate,tostate,:] *= (1.-usvlprob)
-                elif tostate in usvl: # Probability of becoming unsuppressed
-                    thistransit[fromstate,tostate,:] *= usvlprob
+        # svl -> svl: thistransit[fromstate,tostate,:] *=  (1.-usvlprob)
+        thistransit[ix_(svl, svl, arange(npops))]  *= einsum(',k,ij->ijk', (1.-usvlprob), ones(npops), fromtoarr[ix_(svl,svl)])
+        # svl -> usvl: thistransit[fromstate,tostate,:] *=  usvlprob
+        thistransit[ix_(svl, usvl, arange(npops))]  *= einsum(',k,ij->ijk', usvlprob, ones(npops), fromtoarr[ix_(svl,usvl)])
 
         # USVL to SVL
         svlprob = min(regainvs[t]*numvlmon[t]*dt/(eps+people[alltx,:,t].sum()),1) if userate(propsupp,t) else 0.

--- a/optima/model.py
+++ b/optima/model.py
@@ -1023,7 +1023,7 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
                 people[:,:,t+1] += swapaxes(peoplefromto2,1,2).sum(axis=1)
                 if advancedtracking:
                     raw_transitpopbypop[:,allplhiv,:,t+1] += swapaxes(peoplefromto1[allplhiv,:,:],1,2)/dt #annualize
-                    raw_transitpopbypop[:,allplhiv,:,t+1] += swapaxes(peoplefromto2[allplhiv,:,:],1,2)/dt #annualize
+                    raw_transitpopbypop[:,allplhiv,:,t+1] += peoplefromto2[allplhiv,:,:]/dt #annualize
 
 
             ###############################################################################

--- a/optima/model.py
+++ b/optima/model.py
@@ -28,8 +28,8 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
 
     # PMTCT behaviour
     oldbehaviour = compareversions(version,"2.12.0") < 0 # Remove new pmtct behaviour from 2.11.x versions and before
-    if oldbehaviour: diagnosemothersforpmtct = False  # Don't diagnose mothers
-    else:            diagnosemothersforpmtct = False
+    if oldbehaviour: diagnosemothersforpmtct = False  # Diagnosing mothers breaks calibrations somewhat depending on MTCT levels
+    else:            diagnosemothersforpmtct = True
     putinstantlyontopmtct = True  # Should be True, since we are only considering mothers to be preg when they are giving birth - otherwise we get too many diagnosed by ANC
     printpmtctinformation = False
 
@@ -842,7 +842,7 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
         totalbirthrate = birthratesarr[:,:,t].sum(axis=1)
         _all,_allplhiv,_undx,_alldx,_alltx = range(5) # Start with underscore to not override other variables
         numpotmothers = zeros((npops,5))
-        numpotmothers[:,_all]      = people[:,:,t].sum(axis=0)       * relhivbirth
+        numpotmothers[:,_all]      = people[:,:,t].sum(axis=0)
         numpotmothers[:,_allplhiv] = people[allplhiv,:,t].sum(axis=0)* relhivbirth
         numpotmothers[:,_undx]     = people[undx,:,t].sum(axis=0)    * relhivbirth
         numpotmothers[:,_alldx]    = people[alldx,:,t].sum(axis=0)   * relhivbirth

--- a/optima/model.py
+++ b/optima/model.py
@@ -644,11 +644,13 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
                 forceinffull[:,pop1,:,pop2] *= (1-fracacts[t]*thistrans*cond[t]*einsum('a,b',alleff[pop1,t,:],effallprev[:,pop2]))
                 if wholeacts[t]: forceinffull[:,pop1,:,pop2] *= npow((1-thistrans*cond[t]*einsum('a,b',alleff[pop1,t,:],effallprev[:,pop2])), int(wholeacts[t]))
 
-                if debug and not((forceinffull[:,pop1,:,pop2]>=0).all()):
-                    errormsg = label + 'Sexual force-of-infection is invalid between populations %s and %s, time %0.1f, FOI:\n%s)' % (popkeys[pop1], popkeys[pop2], tvec[t], forceinffull[:,pop1,:,pop2])
-                    for var in ['thistrans', 'circeff[pop1,t]', 'prepeff[pop1,t]', 'stieff[pop1,t]', 'cond', 'wholeacts', 'fracacts', 'effallprev[:,pop2]']:
-                        errormsg += '\n%20s = %f' % (var, eval(var)) # Print out extra debugging information
-                    raise OptimaException(errormsg)
+            if debug and not((forceinffull[:,:,:,:]>=0).all()):
+                for pop1, pop2, wholeacts, fracacts, cond, thistrans in sexactslist:
+                    if not ((forceinffull[:,pop1,:,pop2] >= 0).all()):
+                        errormsg = label + 'Sexual force-of-infection is invalid between populations %s and %s, time %0.1f, FOI:\n%s)' % (popkeys[pop1], popkeys[pop2], tvec[t], forceinffull[:,pop1,:,pop2])
+                        for var in ['thistrans', 'circeff[pop1,t]', 'prepeff[pop1,t]', 'stieff[pop1,t]', 'cond', 'wholeacts', 'fracacts', 'effallprev[:,pop2]']:
+                            errormsg += '\n%20s = %f' % (var, eval(var)) # Print out extra debugging information
+                        raise OptimaException(errormsg)
 
             # Injection-related infections -- probability of pop1 getting infected by pop2
             for pop1,pop2,wholeacts,fracacts in injactslist:
@@ -659,11 +661,13 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
                 for index in sus: # Assign the same probability of getting infected by injection to both circs and uncircs, as it doesn't matter
                     forceinffull[index,pop1,:,pop2] *= thisforceinfinj
 
-                if debug and not((forceinffull[:,pop1,:,pop2]>=0).all()):
-                    errormsg = label + 'Injecting force-of-infection is invalid between populations %s and %s, time %0.1f, FOI:\n%s)' % (popkeys[pop1], popkeys[pop2], tvec[t], forceinffull[:,pop1,:,pop2])
-                    for var in ['transinj', 'sharing[pop1,t]', 'wholeacts', 'fracacts', 'osteff[t]', 'effallprev[:,pop2]']:
-                        errormsg += '\n%20s = %f' % (var, eval(var)) # Print out extra debugging information
-                    raise OptimaException(errormsg)
+            if debug and not((forceinffull[:,:,:,:]>=0).all()):
+                for pop1,pop2,wholeacts,fracacts in injactslist:
+                    if not ((forceinffull[:,pop1,:,pop2] >= 0).all()):
+                        errormsg = label + 'Injecting force-of-infection is invalid between populations %s and %s, time %0.1f, FOI:\n%s)' % (popkeys[pop1], popkeys[pop2], tvec[t], forceinffull[:,pop1,:,pop2])
+                        for var in ['transinj', 'sharing[pop1,t]', 'wholeacts', 'fracacts', 'osteff[t]', 'effallprev[:,pop2]']:
+                            errormsg += '\n%20s = %f' % (var, eval(var)) # Print out extra debugging information
+                        raise OptimaException(errormsg)
 
 
         # Probability of getting infected is one minus forceinffull times any scaling factors !! copied below !!

--- a/optima/model.py
+++ b/optima/model.py
@@ -658,8 +658,7 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
                 thisforceinfinj = 1-transinj*sharing[pop1,t]*osteff[t]*prepeff[pop1,t]*fracacts[t]*effallprev[:,pop2]
                 if wholeacts[t]: thisforceinfinj *= npow((1-transinj*sharing[pop1,t]*osteff[t]*prepeff[pop1,t]*effallprev[:,pop2]), int(wholeacts[t]))
 
-                for index in sus: # Assign the same probability of getting infected by injection to both circs and uncircs, as it doesn't matter
-                    forceinffull[index,pop1,:,pop2] *= thisforceinfinj
+                forceinffull[sus,pop1,:,pop2] *= thisforceinfinj  # Assign the same probability of getting infected by injection to both circs and uncircs, as it doesn't matter
 
             if debug and not((forceinffull[:,:,:,:]>=0).all()):
                 for pop1,pop2,wholeacts,fracacts in injactslist:

--- a/optima/model.py
+++ b/optima/model.py
@@ -783,12 +783,10 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
 
         # USVL to SVL
         svlprob = min(regainvs[t]*numvlmon[t]*dt/(eps+people[alltx,:,t].sum()),1) if userate(propsupp,t) else 0.
-        for fromstate in usvl:
-            for tostate in fromto[fromstate]:
-                if tostate in usvl: # Probability of not receiving a VL test & thus remaining failed
-                    thistransit[fromstate,tostate,:] *= (1.-svlprob)
-                elif tostate in svl: # Probability of receiving a VL test, switching to a new regime & becoming suppressed
-                    thistransit[fromstate,tostate,:] *= svlprob
+        # usvl -> usvl: thistransit[fromstate,tostate,:] *=  (1.-svlprob)
+        thistransit[ix_(usvl, usvl, arange(npops))]  *= einsum(',k,ij->ijk', (1.-svlprob), ones(npops), fromtoarr[ix_(usvl,usvl)])
+        # usvl -> svl: thistransit[fromstate,tostate,:] *=  svlprob
+        thistransit[ix_(usvl, svl, arange(npops))]  *= einsum(',k,ij->ijk', svlprob, ones(npops), fromtoarr[ix_(usvl,svl)])
 
         # Check that probabilities all sum to 1
         if debug:

--- a/optima/model.py
+++ b/optima/model.py
@@ -975,7 +975,8 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
             people[susreg,:,t+1]   -= circppl
             people[progcirc,:,t+1] += circppl
 
-            if oldbehaviour:
+            # The old model here had a small bug: people are moved into the next class, and then some of those will move into the next class, skipping an age group
+            if oldbehaviour:  # This code is kept in to not change the calibrations for versions 2.11.x and below
                 ## Age-related transitions
                 for p1,p2,thisagetransprob in agetransitlist:
                     thisagerate = agelist[p1][p2][t]
@@ -1005,7 +1006,7 @@ def model(simpars=None, settings=None, initpeople=None, verbose=None, die=False,
                     if advancedtracking:
                         raw_transitpopbypop[p2,allplhiv,p1, t+1] += peoplemoving1[allplhiv]/dt #annualize
                         raw_transitpopbypop[p1,allplhiv,p2, t+1] += peoplemoving2[allplhiv]/dt #annualize
-            else:
+            else: # This version below is quicker and more accurate but produces results that are 0.5% different
                 ## Age-related transitions
                 peoplefromto = einsum('ki,ij->kij', people[:,:,t+1], agearr[:,:,t])
                 people[:,:,t+1] -= peoplefromto.sum(axis=2)  # sum over popto    # Ageing from a population

--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -345,7 +345,7 @@ def makeplots(results=None, toplot=None, die=False, verbose=2, plotstartyear=Non
     
     return allplots
 
-def plotchangeinplhivallsources(results,which='change',die=None,fig=None,eps=0.1,verbose=2,**kwargs):
+def plotchangeinplhivallsources(results,which='change',showdata=False,die=None,fig=None,eps=0.1,verbose=2,**kwargs):
     changekeys = ['change', 'changeinplhivallsources', 'changeinplhivallsources-population+stacked', 'changeinplhivallsources-stacked']
     plhivkeys = ['plhiv', 'plhivallsources', 'plhivallsources-population+stacked', 'plhivallsources-stacked']
     validplottypes = ['population+stacked', 'stacked']
@@ -396,6 +396,10 @@ def plotchangeinplhivallsources(results,which='change',die=None,fig=None,eps=0.1
 
             plottitle = 'Change in PLHIV'
             showoverall = True
+            numplhiv = results.main['numplhiv'].pops[scen]
+            diff = numplhiv[:,1:]-numplhiv[:,:-1]
+            data = concatenate((zeros((numplhiv.shape[0],1)), diff), axis=1)
+            data = [data for i in range(3)]
         elif plotname == 'plhivallsources':
             scen = 0  # 0th is best
             numincionpopbypop = results.other['numincionpopbypop'].pops[scen]
@@ -430,8 +434,8 @@ def plotchangeinplhivallsources(results,which='change',die=None,fig=None,eps=0.1
             plottitle = 'Number of PLHIV'
             showoverall = False
 
-        thisplots = plotstackedabovestackedbelow(results, toplot=[(plotname, plottype)],
-                                                 stackedabove=stackedabove, stackedbelow=stackedbelow, showoverall=showoverall, showdata=False,
+        thisplots = plotstackedabovestackedbelow(results, toplot=[(plotname, plottype)], data=[data], showdata=showdata,
+                                                 stackedabove=stackedabove, stackedbelow=stackedbelow, showoverall=showoverall,
                                                  stackedabovelabels=stackedabovelabels, stackedbelowlabels=stackedbelowlabels,
                                                  plottitles=[plottitle], die=die, fig=fig, **kwargs)
         plots.update(thisplots)

--- a/optima/results.py
+++ b/optima/results.py
@@ -65,7 +65,7 @@ class Resultset(object):
         if project is not None:
             if data is None: data = project.data # Copy data if not supplied -- DO worry if data don't exist!
             if settings is None: settings = project.settings
-        
+
         # Fundamental quantities -- populated by project.runsim()
         if keepraw: self.raw = raw # Keep raw, but only if asked
         if keepraw: self.simpars = simpars # ...likewise sim parameters
@@ -105,7 +105,7 @@ class Resultset(object):
         self.main['propincare']         = Result('Diagnosed PLHIV retained in care (%)',     ispercentage=True, defaultplot='total')
         self.main['proptreat']          = Result('Diagnosed PLHIV on treatment (%)',         ispercentage=True, defaultplot='total')
         self.main['propsuppressed']     = Result('Treated PLHIV with viral suppression (%)', ispercentage=True, defaultplot='total')
-        self.main['proppmtct']          = Result('HIV+ pregnant women receiving PMTCT (%)',           ispercentage=True, defaultplot='total')
+        self.main['proppmtct']          = Result('HIV+ pregnant women receiving PMTCT (%)',  ispercentage=True, defaultplot='total')
         
         self.main['prev']               = Result('HIV prevalence (%)',       ispercentage=True, defaultplot='population')
         self.main['force']              = Result('HIV incidence (per 100 p.y.)', ispercentage=True, defaultplot='population')
@@ -130,6 +130,9 @@ class Resultset(object):
         self.other['numimmi']           = Result('New immigrants')
         self.other['numimmiplhiv']      = Result('New PLHIV immigrants')
         if advancedtracking:
+            self.other['numnewdiagcd4']      = Result('New HIV diagnoses by CD4 count', defaultplot='stacked')
+            self.other['proplatediag']       = Result('Proportion of new HIV diagnoses with CD4<200 (%)', ispercentage=True, defaultplot='total')
+            self.other['propundxcd4lt200']   = Result('Proportion of undiagnosed PLHIV with CD4<200 (%)', ispercentage=True, defaultplot='total')
             self.other['numincionpopbypop']  = Result('New HIV infections acquired from pop', defaultplot='population+stacked')
             self.other['numtransitpopbypop'] = Result('HIV infections transitioned from pop', defaultplot='population+stacked')
             self.other['numincimethods']     = Result('New HIV infections by method of transmission', defaultplot='population+stacked')
@@ -317,6 +320,7 @@ class Resultset(object):
         alldeaths    = assemble('death')
         otherdeaths  = assemble('otherdeath') 
         alldiag      = assemble('diag')
+        alldiagcd4   = assemble('diagcd4')
         alldiagpmtct = assemble('diagpmtct')
         allmtct      = assemble('mtct')
         allhivbirths = assemble('hivbirths')
@@ -327,10 +331,12 @@ class Resultset(object):
         allsus       = self.settings.sus
         allaids      = self.settings.allaids
         alldx        = self.settings.alldx
+        undx         = self.settings.undx
         allevercare  = self.settings.allevercare
         allcare      = self.settings.allcare
         alltx        = self.settings.alltx
         svl          = self.settings.svl
+        cd4lt200inds = self.settings.cd4lt200inds
         data         = self.data
         if advancedtracking:
             alltransitpopbypop = assemble('transitpopbypop')
@@ -442,11 +448,7 @@ class Resultset(object):
             self.main['popsize'].datatot  = processtotalpopsizedata(self, data['popsize'])
             self.main['popsize'].datapops = processdata(data['popsize'], uncertainty=True, bypop=True)
 
-        self.other['numdiagpmtct'].pops = process(alldiagpmtct[:, :, indices])
-        self.other['numdiagpmtct'].tot  = process(alldiagpmtct[:, :, indices].sum(axis=1))  # Axis 1 is populations
 
-        self.other['propdiagpmtct'].pops = process(alldiagpmtct[:, :, indices]/maximum(alldiag[:, :, indices],eps))
-        self.other['propdiagpmtct'].tot  = process(alldiagpmtct[:, :, indices].sum(axis=1)/maximum(alldiag[:, :, indices].sum(axis=1),eps))  # Axis 1 is populations
 
         # Calculate DALYs
         
@@ -528,8 +530,26 @@ class Resultset(object):
         self.other['numimmiplhiv'].pops = process(allimmi[:,allplhiv,:,:][:,:,:,indices].sum(axis=1))  # Axis 1 is health state
         self.other['numimmiplhiv'].tot  = process(allimmi[:,allplhiv,:,:][:,:,:,indices].sum(axis=(1, 2)))   # Axis 2 is population
 
+        self.other['numdiagpmtct'].pops = process(alldiagpmtct[:,:,indices])
+        self.other['numdiagpmtct'].tot  = process(alldiagpmtct[:,:,indices].sum(axis=1))  # Axis 1 is populations
+
+        self.other['propdiagpmtct'].pops = process(alldiagpmtct[:,:,indices]/maximum(alldiag[:,:,indices],eps))
+        self.other['propdiagpmtct'].tot  = process(alldiagpmtct[:,:,indices].sum(axis=1)/maximum(alldiag[:,:,indices].sum(axis=1),eps))  # Axis 1 is populations
 
         if advancedtracking:
+            self.other['numnewdiagcd4'].pops = process(swapaxes(alldiagcd4[:,:,:,indices],1,2)) # In alldiagcd4, axis 1 is CD4 count, so we make axis 1 population, axis 2 CD4 count
+            self.other['numnewdiagcd4'].tot  = process(alldiagcd4[:,:,:,indices].sum(axis=2)) # Sum over populations
+            if data is not None:
+                self.other['numnewdiagcd4'].datatot = processdata(data['optnumdiag'], uncertainty=True)
+                self.other['numnewdiagcd4'].estimate = False  # It's real data, not just an estimate
+
+            self.other['proplatediag'].pops = process(alldiagcd4[:,cd4lt200inds,:,:][:,:,:,indices].sum(axis=1)/maximum(alldiag[:,:,indices],eps))
+            self.other['proplatediag'].tot  = process(alldiagcd4[:,cd4lt200inds,:,:][:,:,:,indices].sum(axis=(1,2))/maximum(alldiag[:,:,indices].sum(axis=1),eps))  # Axis 1 is populations
+
+            undxcd4lt200 = array(undx)[cd4lt200inds]
+            self.other['propundxcd4lt200'].pops = process(allpeople[:,undxcd4lt200,:,:][:,:,:,indices].sum(axis=1)/maximum(allpeople[:,undx,:,:][:,:,:,indices].sum(axis=1),eps))
+            self.other['propundxcd4lt200'].tot  = process(allpeople[:,undxcd4lt200,:,:][:,:,:,indices].sum(axis=(1,2))/maximum(allpeople[:,undx,:,:][:,:,:,indices].sum(axis=(1,2)),eps))
+
             self.other['numincionpopbypop'].pops = process(allincionpopbypop[:, :, :, :, indices].sum(axis=2))  # Axis 2 is health state of causers
             self.other['numincionpopbypop'].tot  = process(allincionpopbypop[:, :, :, :, indices].sum(axis=(2, 3)))  # Axis 3 is causer populations
             # Uncomment the lines below to check that numincionpopbypop is being calculated properly compared with numinci - it will show as data on the plots

--- a/optima/results.py
+++ b/optima/results.py
@@ -320,7 +320,6 @@ class Resultset(object):
         alldeaths    = assemble('death')
         otherdeaths  = assemble('otherdeath') 
         alldiag      = assemble('diag')
-        alldiagcd4   = assemble('diagcd4')
         alldiagpmtct = assemble('diagpmtct')
         allmtct      = assemble('mtct')
         allhivbirths = assemble('hivbirths')
@@ -336,9 +335,10 @@ class Resultset(object):
         allcare      = self.settings.allcare
         alltx        = self.settings.alltx
         svl          = self.settings.svl
-        cd4lt200inds = self.settings.cd4lt200inds
+        aidsind      = self.settings.aidsind
         data         = self.data
         if advancedtracking:
+            alldiagcd4         = assemble('diagcd4')
             alltransitpopbypop = assemble('transitpopbypop')
             allincionpopbypop  = assemble('incionpopbypop')
             allincimethods     = assemble('incimethods')
@@ -543,10 +543,11 @@ class Resultset(object):
                 self.other['numnewdiagcd4'].datatot = processdata(data['optnumdiag'], uncertainty=True)
                 self.other['numnewdiagcd4'].estimate = False  # It's real data, not just an estimate
 
-            self.other['proplatediag'].pops = process(alldiagcd4[:,cd4lt200inds,:,:][:,:,:,indices].sum(axis=1)/maximum(alldiag[:,:,indices],eps))
-            self.other['proplatediag'].tot  = process(alldiagcd4[:,cd4lt200inds,:,:][:,:,:,indices].sum(axis=(1,2))/maximum(alldiag[:,:,indices].sum(axis=1),eps))  # Axis 1 is populations
+            # Assume CD4<200 is anything after aidsind (aidsind = location of 'gt50' = 50<CD4<200)
+            self.other['proplatediag'].pops = process(alldiagcd4[:,aidsind:,:,:][:,:,:,indices].sum(axis=1)/maximum(alldiag[:,:,indices],eps)) # Axis 1 is cd4 state
+            self.other['proplatediag'].tot  = process(alldiagcd4[:,aidsind:,:,:][:,:,:,indices].sum(axis=(1,2))/maximum(alldiag[:,:,indices].sum(axis=1),eps))  # Axis 1 is populations
 
-            undxcd4lt200 = array(undx)[cd4lt200inds]
+            undxcd4lt200 = array(undx)[aidsind:] # Assume anything after aidsind (aidsind = location of 'gt50' = 50<CD4<200)
             self.other['propundxcd4lt200'].pops = process(allpeople[:,undxcd4lt200,:,:][:,:,:,indices].sum(axis=1)/maximum(allpeople[:,undx,:,:][:,:,:,indices].sum(axis=1),eps))
             self.other['propundxcd4lt200'].tot  = process(allpeople[:,undxcd4lt200,:,:][:,:,:,indices].sum(axis=(1,2))/maximum(allpeople[:,undx,:,:][:,:,:,indices].sum(axis=(1,2)),eps))
 

--- a/optima/settings.py
+++ b/optima/settings.py
@@ -24,8 +24,7 @@ class Settings(object):
         self.now = 2022.0 # Default current year
         self.dataend = 2030.0 # Default end year for data entry
         self.end = 2040.0 # Default end year for projections
-        self.hivstates = ['acute', 'gt500', 'gt350', 'gt200', 'gt50', 'lt50']   # Be careful changing this, check settings.cd4lt200inds too
-        self.cd4lt200inds = [4,5]   # 'gt50', 'lt50' are CD4<200
+        self.hivstates = ['acute', 'gt500', 'gt350', 'gt200', 'gt50', 'lt50']   # Be careful changing this, check settings.aidsind and where aidsind is used too
         self.healthstates = ['susreg', 'progcirc', 'undx', 'dx', 'care', 'lost', 'usvl', 'svl']
         self.ncd4 = len(self.hivstates)
         self.nhealth = len(self.healthstates)

--- a/optima/settings.py
+++ b/optima/settings.py
@@ -24,7 +24,8 @@ class Settings(object):
         self.now = 2022.0 # Default current year
         self.dataend = 2030.0 # Default end year for data entry
         self.end = 2040.0 # Default end year for projections
-        self.hivstates = ['acute', 'gt500', 'gt350', 'gt200', 'gt50', 'lt50']
+        self.hivstates = ['acute', 'gt500', 'gt350', 'gt200', 'gt50', 'lt50']   # Be careful changing this, check settings.cd4lt200inds too
+        self.cd4lt200inds = [4,5]   # 'gt50', 'lt50' are CD4<200
         self.healthstates = ['susreg', 'progcirc', 'undx', 'dx', 'care', 'lost', 'usvl', 'svl']
         self.ncd4 = len(self.hivstates)
         self.nhealth = len(self.healthstates)

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,2 +1,2 @@
-version = "2.11.1"
-versiondate = "2022-10-06"
+version = "2.11.2"
+versiondate = "2022-10-10"

--- a/tests/benchmarkmodel.py
+++ b/tests/benchmarkmodel.py
@@ -17,12 +17,12 @@ Version: 2018apr24
 """
 
 dobenchmark = True
-doprofile = False
+doprofile = True
 
 n_benchmark = 10  # Number of times to run the cpu benchmark
 n_runsim = 1     # Number of times to run the model
 
-# If running profiling, choose which function to line profile. 
+# If running profiling, choose which function to line profile.
 functiontoprofile = 'model' # Choices are: model, runsim, makesimpars, interp
 tobenchmark = 'runsim' # Choices are 'runsim' or 'runbudget'
 
@@ -66,14 +66,14 @@ if dobenchmark:
     performance = sum([performance1, performance2])/2. # Find average of before and after
     benchmarktxt = "for %s (benchmark:%0.2fm iterations/second)" % (tobenchmark, performance)
     print(benchmarktxt)
-    
+
     # Gather the output data
     elapsedstr = '%0.3f' % elapsed
     todaystr = getdate(today()).replace(' ','_')
     gitbranch, gitversion = gitinfo()
     gitversion = gitversion[:hashlen]
     thisout = ' '.join([elapsedstr, todaystr, gitversion, gitbranch, benchmarktxt])
-    
+
     # Save, but only if hash not already in file
     if dosave:
         output = loadtext(filename, splitlines=True)
@@ -99,7 +99,7 @@ if doprofile:
     P = Project(spreadsheet='generalized.xlsx', dorun=False)
     runsim = P.runsim # analysis:ignore
     interp = P.pars()['hivtest'].interp
-    
+
     def profile():
         print('Profiling...')
 
@@ -117,16 +117,16 @@ if doprofile:
                       profiler.print_stats()
               return profiled_func
           return inner
-        
-        
-        
+
+
+
         @do_profile(follow=[eval(functiontoprofile)]) # Add decorator to runmodel function
-        def runsimwrapper(): 
+        def runsimwrapper():
             P.runsim()
         runsimwrapper()
-        
+
         print('Done.')
-    
+
     profile()
 
 if 'elapsedstr' in locals():


### PR DESCRIPTION
**To be merged after the model speedups**
 - The model always tracks diagnoses by CD4 count since it doesn't add much overhead, but it only creates the results if advancedtracking=True
If advancedtracking=True:
 - Add 'numnewdiagcd4' to results.other - the number of diagnoses split by cd4 count - currently not plottable (want to update plotbycd4())
 - Add 'plotlatediag' to results.other - the proportion of diagnoses that have CD4<200 - plottable as a stacked, total (default) or population
 - Add 'propundxcd4lt200' to results.other - the proportion of undiagnosed PLHIV with CD4<200 - as a comparison to 'proplatediag' - at the moment has to be a separate plot to 'plotlatediag'