### PR TITLE
Inf budget gets scaled up properly

### DIFF
--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -462,16 +462,6 @@ def outcomecalc(budgetvec=None, which=None, project=None, parsetname=None, progs
                 tvsettings=None, tvcontrolvec=None, origoutcomes=None, penalty=1e9, **kwargs):
     ''' Function to evaluate the objective for a given budget vector (note, not time-varying) '''
 
-    infmoney = op.Settings().infmoney
-    if totalbudget is not None and totalbudget>=infmoney:
-        budgetvec = dcp(budgetvec)
-        origbudget = dcp(origbudget)
-        for i, v in enumerate(budgetvec):
-            budgetvec[i] += infmoney
-        for k, v in origbudget.items():
-            origbudget[k] += infmoney
-
-
     # Set up defaults
     if which is None: 
         if objectives is not None: which = objectives['which']

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -462,6 +462,16 @@ def outcomecalc(budgetvec=None, which=None, project=None, parsetname=None, progs
                 tvsettings=None, tvcontrolvec=None, origoutcomes=None, penalty=1e9, **kwargs):
     ''' Function to evaluate the objective for a given budget vector (note, not time-varying) '''
 
+    infmoney = op.Settings().infmoney
+    if totalbudget is not None and totalbudget>=infmoney:
+        budgetvec = dcp(budgetvec)
+        origbudget = dcp(origbudget)
+        for i, v in enumerate(budgetvec):
+            budgetvec[i] += infmoney
+        for k, v in origbudget.items():
+            origbudget[k] += infmoney
+
+
     # Set up defaults
     if which is None: 
         if objectives is not None: which = objectives['which']

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -1230,7 +1230,7 @@ def minmoney(project=None, optim=None, tvec=None, verbose=None, maxtime=None, ma
     
     if multi: printv('Performing parallel money optimization with %s chains...' % nchains, 2, verbose)
     else:     printv('Performing serial money optimization...', 2, verbose)
-
+    seed(randseed)
     
     #%% Definitions
     def distance(target, this):


### PR DESCRIPTION
For minmoney, the budget gets scaled up by setting totalbudget and letting constrainbudget scale it up. This previously multiplied the current budget by the necessary factor which left 0 budgets at 0.

Now, the budget gets scaled up by adding the difference from the current budget evenly between all programs. This means that for inf budget, each program gets inf budget / nprograms.

We could change that inf budget actually is infbudget*nprograms so that each program gets infbudget added?

This doesn't change that constraints are relative yet.

It seems to produce good results from the brief testing that I have done, but shouldn't produce worse results as this is only used when scaling up, not scaling down - and the minmoney optimization makes sure to try to scale each program down appropriately.