### PR TITLE
Admin reset password fix

### DIFF
--- a/client/source/js/modules/admin/users.js
+++ b/client/source/js/modules/admin/users.js
@@ -67,7 +67,8 @@ define(['angular', 'ui.router',], function(angular) {
             .rpcRun('reset_password', [user.id])
             .then(function(response) {
               console.log('reset passsword response:',response)
-              toastr.success('Password reset to "optima"!');
+              text = 'Password reset to "';
+              toastr.success(text1.concat(response.data,'"!'));
             });
         },
         undefined,

--- a/client/source/js/modules/admin/users.js
+++ b/client/source/js/modules/admin/users.js
@@ -66,7 +66,8 @@ define(['angular', 'ui.router',], function(angular) {
           rpcService
             .rpcRun('reset_password', [user.id])
             .then(function(response) {
-              toastr.success('Password reset!');
+              console.log('reset passsword response:',response)
+              toastr.success('Password reset to "optima"!');
             });
         },
         undefined,

--- a/client/source/js/modules/admin/users.js
+++ b/client/source/js/modules/admin/users.js
@@ -68,7 +68,7 @@ define(['angular', 'ui.router',], function(angular) {
             .then(function(response) {
               console.log('reset passsword response:',response)
               text = 'Password reset to "';
-              toastr.success(text1.concat(response.data,'"!'));
+              toastr.success(text.concat(response.data,'"!'));
             });
         },
         undefined,

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -160,6 +160,7 @@ def hashed_password(password_str):
 
 
 def parse_user_args(args):
+    print('@#$%#$%', args.get('password'), type(args.get('password')))
     return {
         'email': nullable_email(args.get('email', None)),
         'name': args.get('displayName', ''),
@@ -293,6 +294,7 @@ def reset_password(user_id):
     ''' Reset the user's password to "optima" '''
     defaultpassword = 'optima'
     hashed_password = sha224()
+    print(defaultpassword, type(defaultpassword))
     hashed_password.update(defaultpassword)
     password = hashed_password.hexdigest()
     args = {'password':password}

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -293,11 +293,9 @@ def revoke_admin(user_id):
 def reset_password(user_id):
     ''' Reset the user's password to "optima" '''
     defaultpassword = 'optima'
-    defaultpassword = defaultpassword.encode(encoding='UTF-8', errors='strict')
+    defaultpasswordbytes = defaultpassword.encode(encoding='UTF-8', errors='strict')
     hashed_password = sha224()
-    print(defaultpassword, type(defaultpassword))
-    hashed_password.update(defaultpassword)
-    print(hashed_password, type(hashed_password))
+    hashed_password.update(defaultpasswordbytes)
     password = hashed_password.hexdigest()
     args = {'password':password}
     update_user(user_id, args)

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -160,7 +160,6 @@ def hashed_password(password_str):
 
 
 def parse_user_args(args):
-    print('@#$%#$%', args.get('password'), type(args.get('password')))
     return {
         'email': nullable_email(args.get('email', None)),
         'name': args.get('displayName', ''),
@@ -300,7 +299,7 @@ def reset_password(user_id):
     args = {'password':password}
     update_user(user_id, args)
     print('Password for user %s reset to "%s"' % (user_id,defaultpassword))
-    return None
+    return defaultpassword
 
 
 def do_logout_current_user():

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -293,9 +293,11 @@ def revoke_admin(user_id):
 def reset_password(user_id):
     ''' Reset the user's password to "optima" '''
     defaultpassword = 'optima'
+    defaultpassword = defaultpassword.encode(encoding='UTF-8', errors='strict')
     hashed_password = sha224()
     print(defaultpassword, type(defaultpassword))
     hashed_password.update(defaultpassword)
+    print(hashed_password, type(hashed_password))
     password = hashed_password.hexdigest()
     args = {'password':password}
     update_user(user_id, args)


### PR DESCRIPTION
Fix to error "TypeError: Unicode-objects must be encoded before hashing" from Reset password in admin panel.

Fixed by encoding with UTF-8 before hashing.

FE popup now says "Password reset to "optima"!"