### PR TITLE
Penalty = 0

### DIFF
--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -564,7 +564,7 @@ def separatetv(inputvec=None, optiminds=None, optimkeys=None):
 def outcomecalc(budgetvec=None, which=None, project=None, parsetname=None, progsetname=None, scaleupmethod='multiply',
                 objectives=None, absconstraints=None, totalbudget=None, optiminds=None, optimkeys=None, origbudget=None,
                 tvec=None, initpeople=None, initprops=None, startind=None, outputresults=False, verbose=2, ccsample='best',
-                doconstrainbudget=True, tvsettings=None, tvcontrolvec=None, origoutcomes=None, penalty=1e9, warn=True,**kwargs):
+                doconstrainbudget=True, tvsettings=None, tvcontrolvec=None, origoutcomes=None, penalty=0, warn=True,**kwargs):
     ''' Function to evaluate the objective for a given budget vector (note, not time-varying) '''
 
     # Set up defaults


### PR DESCRIPTION
However, I am also skeptical of the penalty = 1e9  which is added to the outcome, if the any one of the outcomes like inci is worse than inci  in the optimization baseline, even if the sum of inci and death  would be lower. So this could make outcomes that should be lower, actually higher.
eg baseline inci: 1000, death:200 => total = 2000 (using 1:5 ratio), trial inci: 1001, death: 199  should give total = 1996 which would be better, but instead gives total > 1e9  since 1001 > 1000
The algorithm just seems to act on a if the new total outcome > best total outcome do X, otherwise do Y, which I think it should. So I think the penalty should amount certainly be set to 0. Although why was it put in, in the first place?