### PR TITLE
Scenario tab loads quicker + no smoothing of cost-coverage curves + fix popsize interpolation

### DIFF
--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -799,7 +799,8 @@ class Popsizepar(Par):
                 yinterp = meta * smoothinterp(localtvec, self.t[key], self.y[key], smoothness=0) # Use interpolation without smoothness so that it aligns exactly with a starting point for 
                 #2. Replace linear interpolation after self.start
                 expstartind = findnearest(localtvec, self.start[key])
-                yinterp[expstartind:] = yinterp[expstartind] * grow(self.e[key], array(localtvec[expstartind:])-self.start[key]) #don't apply meta again (it's already factored into the linear part)
+                if abs(localtvec[expstartind] - self.start[key]) < dt: # Check localtvec[expstartind] is close enough to self.start[key], otherwise self.start[key] is not in localtvec
+                    yinterp[expstartind:] = yinterp[expstartind] * grow(self.e[key], array(localtvec[expstartind:])-self.start[key]) #don't apply meta again (it's already factored into the linear part)
                 #3. Apply limits
                 yinterp = applylimits(par=self, y=yinterp, limits=self.limits, dt=dt)
             else:

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -1231,7 +1231,7 @@ class CCOF(object):
         # Calculate interpolated parameters
         for j,param in enumerate(ccopars_sample.keys()): 
             knownparam = array([ccopartuple[j+1] for ccopartuple in ccopartuples])
-            allparams = smoothinterp(t, knownt, knownparam, smoothness=1)
+            allparams = smoothinterp(t, knownt, knownparam, smoothness=0)
             ccopar[param] = zeros(nyrs)
             for yr in range(nyrs):
                 ccopar[param][yr] = allparams[yr]

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -470,7 +470,7 @@ class Programset(object):
                     aft[i] = perf_counter() - start_t - a - b[i]
             else: coverage[thisprog] = None
         total = perf_counter() - start_t
-        print(f'>>>>> {a}, {b}, {aft}, {total}')
+        print(f'>>>>> {a}, {b}, {aft},{aft.sum()}, {total}')
         return coverage
 
 

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -1073,52 +1073,37 @@ class Program(object):
 
     def getcoverage(self, x, t, parset=None, results=None, total=True, proportion=False, toplot=False, sample='best'):
         '''Returns coverage for a time/spending vector'''
-
-        times = zeros(100)
-        i=0
-        times[i] = perf_counter()
-        i+=1
-        times[i] = perf_counter()
-        i += 1
+        start_time = perf_counter()
         # Validate inputs
         x = promotetoarray(x)
-        times[i] = perf_counter()
-        i += 1
         t = promotetoarray(t)
-        times[i] = perf_counter()
-        i += 1
 
+        # This line is slow ~6ms
+        a = perf_counter()
         poptargeted = self.gettargetpopsize(t=t, parset=parset, results=results, total=False)
-        times[i] = perf_counter()
-        i += 1
+        b = perf_counter()
 
         totaltargeted = sum(list(poptargeted.values()))
-        times[i] = perf_counter()
-        i += 1
+        # This line is slow ~1ms
+        c = perf_counter()
         totalreached = self.costcovfn.evaluate(x=x, popsize=totaltargeted, t=t, toplot=toplot, sample=sample)
-        times[i] = perf_counter()
-        i += 1
+        d = perf_counter()
 
         if total: 
             if proportion: output = totalreached/totaltargeted
             else:          output = totalreached
-            times[i] = perf_counter()
-            i += 1
         else:
             popreached = odict()
             targetcomposition = self.targetcomposition if self.targetcomposition else self.gettargetcomposition(t=t,parset=parset)
-            times[i] = perf_counter()
-            i += 1
             for targetpop in self.targetpops:
                 popreached[targetpop] = totalreached*targetcomposition[targetpop]
                 if proportion: popreached[targetpop] /= poptargeted[targetpop]
-                times[i] = perf_counter()
-                i += 1
             output = popreached
 
-        times[i] = perf_counter()
-        i += 1
-        print(total,times,np.diff(times))
+        end = perf_counter()
+        total = end - start_time
+        lines = [b-a,d-c]
+        print(total,lines,(lines[0]+lines[1])/total)
         return output
             
 

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -426,7 +426,8 @@ class Programset(object):
 
     def getdefaultcoverage(self, t=None, parset=None, results=None, verbose=2, sample='best', proportion=False):
         ''' Extract the coverage levels corresponding to the default budget'''
-        defaultbudget = self.getdefaultbudget(t+0.33) # WARNING: should be passing t here, but this causes interpolation issues
+        defaultbudget = self.getdefaultbudget() # WARNING: should be passing t here, but this causes interpolation issues
+        print('!!!!',defaultbudget)
         # The next line is the slow one
         defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
         #if t is not None and len(list(t)) > 1:

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -426,8 +426,8 @@ class Programset(object):
 
     def getdefaultcoverage(self, t=None, parset=None, results=None, verbose=2, sample='best', proportion=False):
         ''' Extract the coverage levels corresponding to the default budget'''
-        defaultbudget = self.getdefaultbudget() # WARNING: should be passing t here, but this causes interpolation issues
-        print('!!!!',defaultbudget)
+        defaultbudget = self.getdefaultbudget(t) # WARNING: should be passing t here, but this causes interpolation issues
+        print('!!!!',t,defaultbudget,self.getdefaultbudget())
         # The next line is the slow one
         defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
         #if t is not None and len(list(t)) > 1:

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -9,8 +9,6 @@ Version: 2019jan09
 from optima import OptimaException, Link, printv, uuid, today, sigfig, getdate, dcp, smoothinterp, findinds, odict, Settings, sanitize, defaultrepr, isnumber, promotetoarray, vec2obj, asd, convertlimits, Timepar, Yearpar, checkifparsoverridepars, createwarningforoverride
 from numpy import ones, prod, array, zeros, exp, log, append, nan, isnan, maximum, minimum, sort, concatenate as cat, transpose, mean, argsort
 from random import uniform
-from time import perf_counter
-import numpy as np
 import six
 if six.PY3:
 	basestring = str
@@ -415,7 +413,6 @@ class Programset(object):
                 for yr in t:
                     yrindex = findinds(tvec,yr)
                     selectbudget[program].append(totalbudget[program][yrindex][0])
-                    print('??',program,totalbudget[program],yr,tvec,yrindex,totalbudget[program][yrindex],selectbudget[program])
 
         # Store default budget as an attribute
         self.defaultbudget = lastbudget
@@ -432,7 +429,6 @@ class Programset(object):
         if t is not None:
             for prog,budget in defaultbudget.items():
                 defaultbudget[prog] = budget*ones(len(t))
-        # The next line is the slow one
         defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
         if t is None or len(list(t)) <= 1:
             for progno in range(len(defaultcoverage)):
@@ -470,7 +466,6 @@ class Programset(object):
                     coverage[thisprog] = None
                 else:
                     spending = budget[thisprog] # Get the amount of money spent on this program
-                    # NEXT LINE IS THE SLOW ONE
                     coverage[thisprog] = self.programs[thisprog].getcoverage(x=spending, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
             else: coverage[thisprog] = None
 
@@ -1085,11 +1080,9 @@ class Program(object):
         x = promotetoarray(x)
         t = promotetoarray(t)
 
-        # This line is slow ~6ms
         poptargeted = self.gettargetpopsize(t=t, parset=parset, results=results, total=False)
 
         totaltargeted = sum(list(poptargeted.values()))
-        # This line is slow ~1ms
         totalreached = self.costcovfn.evaluate(x=x, popsize=totaltargeted, t=t, toplot=toplot, sample=sample)
 
         if total: 

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -467,10 +467,7 @@ class Programset(object):
                     spending = budget[thisprog] # Get the amount of money spent on this program
                     b[i] = perf_counter() - start_t - a
                     coverage[thisprog] = self.programs[thisprog].getcoverage(x=spending, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
-                    aft[i] = perf_counter() - start_t - a
-                    if i > 0:
-                        b[i] = b[i] - b[i-1]
-                        aft[i] = aft[i] - aft[i-1]
+                    aft[i] = perf_counter() - start_t - a - b[i]
             else: coverage[thisprog] = None
         total = perf_counter() - start_t
         print(f'>>>>> {a}, {b}, {aft}, {total}')

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -426,7 +426,7 @@ class Programset(object):
 
     def getdefaultcoverage(self, t=None, parset=None, results=None, verbose=2, sample='best', proportion=False):
         ''' Extract the coverage levels corresponding to the default budget'''
-        defaultbudget = self.getdefaultbudget(t) # WARNING: should be passing t here, but this causes interpolation issues
+        defaultbudget = self.getdefaultbudget(t+0.33) # WARNING: should be passing t here, but this causes interpolation issues
         # The next line is the slow one
         defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
         #if t is not None and len(list(t)) > 1:

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -427,14 +427,17 @@ class Programset(object):
 
     def getdefaultcoverage(self, t=None, parset=None, results=None, verbose=2, sample='best', proportion=False):
         ''' Extract the coverage levels corresponding to the default budget'''
-        defaultbudget = self.getdefaultbudget(t) # WARNING: should be passing t here, but this causes interpolation issues
-        print('!!!!',t,defaultbudget,self.getdefaultbudget())
+        if t is not None: t = promotetoarray(t)
+        defaultbudget = self.getdefaultbudget() # WARNING: should be passing t here, but this causes interpolation issues
+        if t is not None:
+            for prog,budget in defaultbudget.items():
+                defaultbudget[prog] = budget*ones(len(t))
         # The next line is the slow one
         defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
-        #if t is not None and len(list(t)) > 1:
-        for progno in range(len(defaultcoverage)):
-            # This does two this, selects the 0th entry from the list, turning it from a odict of lists, into odict of nums, and turns Nones into nans
-            defaultcoverage[progno] = defaultcoverage[progno][0] if defaultcoverage[progno] else nan
+        if t is None or len(list(t)) <= 1:
+            for progno in range(len(defaultcoverage)):
+                # This does two this, selects the 0th entry from the list, turning it from a odict of lists, into odict of nums, and turns Nones into nans
+                defaultcoverage[progno] = defaultcoverage[progno][0] if defaultcoverage[progno] else nan
         return defaultcoverage
 
 

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -9,8 +9,6 @@ Version: 2019jan09
 from optima import OptimaException, Link, printv, uuid, today, sigfig, getdate, dcp, smoothinterp, findinds, odict, Settings, sanitize, defaultrepr, isnumber, promotetoarray, vec2obj, asd, convertlimits, Timepar, Yearpar, checkifparsoverridepars, createwarningforoverride
 from numpy import ones, prod, array, zeros, exp, log, append, nan, isnan, maximum, minimum, sort, concatenate as cat, transpose, mean, argsort
 from random import uniform
-from time import perf_counter
-
 import six
 if six.PY3:
 	basestring = str
@@ -426,16 +424,10 @@ class Programset(object):
 
     def getdefaultcoverage(self, t=None, parset=None, results=None, verbose=2, sample='best', proportion=False):
         ''' Extract the coverage levels corresponding to the default budget'''
-        start_t = perf_counter()
         defaultbudget = self.getdefaultbudget() # WARNING: should be passing t here, but this causes interpolation issues
-        a = perf_counter() - start_t
         defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
-        b = perf_counter() - start_t - a
-        c = zeros(len(defaultcoverage))
         for progno in range(len(defaultcoverage)):
-            defaultcoverage[progno] = defaultcoverage[progno][0] if defaultcoverage[progno] else nan
-            c[progno] = perf_counter() - start_t - a - b
-        print(f'>>>> {a}, {b}, {c}, {defaultcoverage}')
+            defaultcoverage[progno] = defaultcoverage[progno][0] if defaultcoverage[progno] else nan    
         return defaultcoverage
 
 

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -9,6 +9,8 @@ Version: 2019jan09
 from optima import OptimaException, Link, printv, uuid, today, sigfig, getdate, dcp, smoothinterp, findinds, odict, Settings, sanitize, defaultrepr, isnumber, promotetoarray, vec2obj, asd, convertlimits, Timepar, Yearpar, checkifparsoverridepars, createwarningforoverride
 from numpy import ones, prod, array, zeros, exp, log, append, nan, isnan, maximum, minimum, sort, concatenate as cat, transpose, mean, argsort
 from random import uniform
+from time import perf_counter
+
 import six
 if six.PY3:
 	basestring = str
@@ -424,10 +426,16 @@ class Programset(object):
 
     def getdefaultcoverage(self, t=None, parset=None, results=None, verbose=2, sample='best', proportion=False):
         ''' Extract the coverage levels corresponding to the default budget'''
+        start_t = perf_counter()
         defaultbudget = self.getdefaultbudget() # WARNING: should be passing t here, but this causes interpolation issues
+        a = perf_counter() - start_t
         defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
+        b = perf_counter() - start_t - a
+        c = zeros(len(defaultcoverage))
         for progno in range(len(defaultcoverage)):
-            defaultcoverage[progno] = defaultcoverage[progno][0] if defaultcoverage[progno] else nan    
+            defaultcoverage[progno] = defaultcoverage[progno][0] if defaultcoverage[progno] else nan
+            c[progno] = perf_counter() - start_t - a - b
+        print(f'>>>> {a}, {b}, {c}, {defaultcoverage}')
         return defaultcoverage
 
 

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -136,7 +136,7 @@ class Programset(object):
         ''' Add new programs'''
         if type(newprograms)==Program: newprograms = [newprograms]
         if type(newprograms)==list:
-            for newprogram in newprograms: 
+            for newprogram in newprograms:
                 if newprogram not in self.programs.values():
                     self.programs[newprogram.short] = newprogram
                     printv('\nAdded program "%s" to programset "%s". \nPrograms in this programset are: %s' % (newprogram.short, self.name, [thisprog.short for thisprog in self.programs.values()]), 3, verbose)
@@ -382,7 +382,7 @@ class Programset(object):
 
     def getdefaultbudget(self, t=None, verbose=2, optimizable=None):
         ''' Extract the budget if cost data has been provided; if optimizable is True, then only return optimizable programs '''
-        
+
         # Initialise outputs
         totalbudget, lastbudget, selectbudget = odict(), odict(), odict()
 
@@ -392,9 +392,9 @@ class Programset(object):
 
         # Set up internal variables
         settings = self.getsettings()
-        tvec = settings.maketvec() 
+        tvec = settings.maketvec()
         emptyarray = array([nan]*len(tvec))
-        
+
         # Get cost data for each program in each year that it exists
         for program in self.programs:
             totalbudget[program] = dcp(emptyarray)
@@ -406,15 +406,15 @@ class Programset(object):
                 lastbudget[program] = sanitize(totalbudget[program])[-1]
             except:
                 lastbudget[program] = nan # Initialize, to overwrite if there's data
-            if isnan(lastbudget[program]): 
+            if isnan(lastbudget[program]):
                 printv('WARNING: no cost data defined for program "%s"...' % program, 1, verbose)
-                
-            # Extract cost data for particular years, if requested 
+
+            # Extract cost data for particular years, if requested
             if t is not None:
                 for yr in t:
                     yrindex = findinds(tvec,yr)
                     selectbudget[program].append(totalbudget[program][yrindex][0])
-                    
+
         # Store default budget as an attribute
         self.defaultbudget = lastbudget
         if t is None:   thisbudget = dcp(lastbudget)
@@ -429,7 +429,7 @@ class Programset(object):
         # The next line is the slow one
         defaultcoverage = self.getprogcoverage(budget=defaultbudget, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
         for progno in range(len(defaultcoverage)):
-            defaultcoverage[progno] = defaultcoverage[progno][0] if defaultcoverage[progno] else nan    
+            defaultcoverage[progno] = defaultcoverage[progno][0] if defaultcoverage[progno] else nan
         return defaultcoverage
 
 
@@ -443,7 +443,7 @@ class Programset(object):
 
     def getprogcoverage(self, budget, t, parset=None, results=None, proportion=False, sample='best', verbose=2):
         '''Budget is currently assumed to be a DICTIONARY OF ARRAYS'''
-        start_t = perf_counter()
+
         # Initialise output
         coverage = odict()
 
@@ -454,23 +454,18 @@ class Programset(object):
         if type(budget)==dict: budget = odict(budget) # Convert to odict
         budget.sort([p.short for p in self.programs.values()])
 
-        a = perf_counter() - start_t
-        b = zeros(len(self.programs.keys()))
-        aft = zeros(len(self.programs.keys()))
         # Get program-level coverage for each program
-        for i, thisprog in enumerate(self.programs.keys()):
+        for thisprog in self.programs.keys():
             if self.programs[thisprog].optimizable():
                 if not self.programs[thisprog].costcovfn.ccopars:
                     printv('WARNING: no cost-coverage function defined for optimizable program, setting coverage to None...', 1, verbose)
                     coverage[thisprog] = None
                 else:
                     spending = budget[thisprog] # Get the amount of money spent on this program
-                    b[i] = perf_counter() - start_t - a
+                    # NEXT LINE IS THE SLOW ONE
                     coverage[thisprog] = self.programs[thisprog].getcoverage(x=spending, t=t, parset=parset, results=results, proportion=proportion, sample=sample)
-                    aft[i] = perf_counter() - start_t - a - b[i]
             else: coverage[thisprog] = None
-        total = perf_counter() - start_t
-        print(f'>>>>> {a}, {b}, {aft},{aft.sum()}, {total}')
+
         return coverage
 
 
@@ -1077,6 +1072,7 @@ class Program(object):
 
     def getcoverage(self, x, t, parset=None, results=None, total=True, proportion=False, toplot=False, sample='best'):
         '''Returns coverage for a time/spending vector'''
+
 
         # Validate inputs
         x = promotetoarray(x)

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -415,6 +415,7 @@ class Programset(object):
                 for yr in t:
                     yrindex = findinds(tvec,yr)
                     selectbudget[program].append(totalbudget[program][yrindex][0])
+                    print('??',program,totalbudget[program],yr,tvec,yrindex,totalbudget[program][yrindex],selectbudget[program])
 
         # Store default budget as an attribute
         self.defaultbudget = lastbudget

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -10,6 +10,7 @@ from optima import OptimaException, Link, printv, uuid, today, sigfig, getdate, 
 from numpy import ones, prod, array, zeros, exp, log, append, nan, isnan, maximum, minimum, sort, concatenate as cat, transpose, mean, argsort
 from random import uniform
 from time import perf_counter
+import numpy as np
 import six
 if six.PY3:
 	basestring = str
@@ -1073,26 +1074,51 @@ class Program(object):
     def getcoverage(self, x, t, parset=None, results=None, total=True, proportion=False, toplot=False, sample='best'):
         '''Returns coverage for a time/spending vector'''
 
-
+        times = zeros(100)
+        i=0
+        times[i] = perf_counter()
+        i+=1
+        times[i] = perf_counter()
+        i += 1
         # Validate inputs
         x = promotetoarray(x)
+        times[i] = perf_counter()
+        i += 1
         t = promotetoarray(t)
+        times[i] = perf_counter()
+        i += 1
 
         poptargeted = self.gettargetpopsize(t=t, parset=parset, results=results, total=False)
+        times[i] = perf_counter()
+        i += 1
 
         totaltargeted = sum(list(poptargeted.values()))
+        times[i] = perf_counter()
+        i += 1
         totalreached = self.costcovfn.evaluate(x=x, popsize=totaltargeted, t=t, toplot=toplot, sample=sample)
+        times[i] = perf_counter()
+        i += 1
 
         if total: 
             if proportion: output = totalreached/totaltargeted
             else:          output = totalreached
+            times[i] = perf_counter()
+            i += 1
         else:
             popreached = odict()
-            targetcomposition = self.targetcomposition if self.targetcomposition else self.gettargetcomposition(t=t,parset=parset) 
+            targetcomposition = self.targetcomposition if self.targetcomposition else self.gettargetcomposition(t=t,parset=parset)
+            times[i] = perf_counter()
+            i += 1
             for targetpop in self.targetpops:
                 popreached[targetpop] = totalreached*targetcomposition[targetpop]
                 if proportion: popreached[targetpop] /= poptargeted[targetpop]
+                times[i] = perf_counter()
+                i += 1
             output = popreached
+
+        times[i] = perf_counter()
+        i += 1
+        print(total,times,np.diff(times))
         return output
             
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -590,21 +590,13 @@ def get_coverages_for_scenarios(project, year=None):
             result[parset_id][progset_id] = {}
             for year in years:
                 i += 1
-                a, b, c,d = 0,0,0,0
-                new_time = perf_counter()
                 try:
-                    print(f'>> {new_time-start_time} > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
-                    a = perf_counter() - new_time
+                    print(f'>>{perf_counter()-start_time} > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
                     coverage = progset.getdefaultcoverage(t=year, parset=parset)
-                    b = perf_counter() - new_time
                     coverage = normalize_obj(coverage)
-                    c = perf_counter() - new_time
                 except:
                     coverage = None
-                    a = perf_counter() - new_time
                 result[parset_id][progset_id][year] = coverage
-                d = perf_counter() - new_time
-                print(f'>> {a*1000}, {b*1000}, {c*1000}, {d*1000}')
     print('>> finished get_coverages_for_scenarios')
     return result
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -590,7 +590,7 @@ def get_coverages_for_scenarios(project, year=None):
                 prog_list = coverage.keys()
                 coverage = np.column_stack(coverage.values())
                 for yrno,year in enumerate(years):
-                    result[parset_id][progset_id][year] = op.odict(zip(prog_list,coverage[yrno,:]))
+                    result[parset_id][progset_id][year] = normalize_obj(op.odict(zip(prog_list,coverage[yrno,:])))
                 print('~~~',result[parset_id][progset_id])
 
             except:

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -585,7 +585,9 @@ def get_coverages_for_scenarios(project, year=None):
             progset_id = str(progset.uid)
             result[parset_id][progset_id] = {}
             try:
-                result[parset_id][progset_id] = progset.getdefaultcoverage(t=list(years), parset=parset)
+                coverage = progset.getdefaultcoverage(t=list(years), parset=parset)
+                print('~~~',coverage)
+                result[parset_id][progset_id] = coverage
             except:
                 print('!?!?!')
                 import traceback

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -590,13 +590,21 @@ def get_coverages_for_scenarios(project, year=None):
             result[parset_id][progset_id] = {}
             for year in years:
                 i += 1
+                a, b, c,d = 0,0,0,0
+                new_time = perf_counter()
                 try:
-                    print(f'>>{perf_counter()-start_time} > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
+                    print(f'>> {new_time-start_time} > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
+                    a = perf_counter() - new_time
                     coverage = progset.getdefaultcoverage(t=year, parset=parset)
+                    b = perf_counter() - new_time
                     coverage = normalize_obj(coverage)
+                    c = perf_counter() - new_time
                 except:
                     coverage = None
+                    a = perf_counter() - new_time
                 result[parset_id][progset_id][year] = coverage
+                d = perf_counter() - new_time
+                print(f'>> {a*1000}, {b*1000}, {c*1000}, {d*1000}')
     print('>> finished get_coverages_for_scenarios')
     return result
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -578,6 +578,7 @@ def get_coverages_for_scenarios(project, year=None):
     start = project.settings.start
     end = project.settings.end
     years = range(int(start), int(end) + 1)
+    i=0
     for parset in project.parsets.values():
         parset_id = str(parset.uid)
         result[parset_id] = {}
@@ -585,7 +586,9 @@ def get_coverages_for_scenarios(project, year=None):
             progset_id = str(progset.uid)
             result[parset_id][progset_id] = {}
             for year in years:
+                i += 1
                 try:
+                    print(f'>> > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
                     coverage = progset.getdefaultcoverage(t=year, parset=parset)
                     coverage = normalize_obj(coverage)
                 except:

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -591,8 +591,8 @@ def get_coverages_for_scenarios(project, year=None):
             for year in years:
                 i += 1
                 try:
-                    print(f'>>{perf_counter()-start_time} > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
-                    coverage = progset.getdefaultcoverage(t=year, parset=parset)
+                    # print(f'>>{perf_counter()-start_time} > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
+                    coverage = progset.getdefaultcoverage(t=year, parset=parset) # This is the slow line, takes ~0.130s
                     coverage = normalize_obj(coverage)
                 except:
                     coverage = None

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -578,26 +578,20 @@ def get_coverages_for_scenarios(project, year=None):
     start = project.settings.start
     end = project.settings.end
     years = range(int(start), int(end) + 1)
-
-    from time import perf_counter
-    i=0
-    start_time = perf_counter()
     for parset in project.parsets.values():
         parset_id = str(parset.uid)
         result[parset_id] = {}
         for progset in project.progsets.values():
             progset_id = str(progset.uid)
             result[parset_id][progset_id] = {}
-            for year in years:
-                i += 1
-                try:
-                    # print(f'>>{perf_counter()-start_time} > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
-                    coverage = progset.getdefaultcoverage(t=year, parset=parset) # This is the slow line, takes ~0.130s
-                    coverage = normalize_obj(coverage)
-                except:
-                    coverage = None
-                result[parset_id][progset_id][year] = coverage
-    print('>> finished get_coverages_for_scenarios')
+            try:
+                result[parset_id][progset_id] = progset.getdefaultcoverage(t=years, parset=parset)
+            except:
+                print('!?!?!')
+                import traceback
+                traceback.print_exc()
+                for year in years:
+                    result[parset_id][progset_id][year] = None
     return result
 
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -586,10 +586,11 @@ def get_coverages_for_scenarios(project, year=None):
             result[parset_id][progset_id] = {}
             try:
                 coverage = progset.getdefaultcoverage(t=list(years), parset=parset)
+                # Now we swap from an odict of arrays, with a key per program, to an odict of odicts, with a key per year
                 prog_list = coverage.keys()
                 coverage = np.column_stack(coverage.values())
                 for yrno,year in enumerate(years):
-                    result[parset_id][progset_id][year] = odict(zip(prog_list,coverage[yrno,:]))
+                    result[parset_id][progset_id][year] = op.odict(zip(prog_list,coverage[yrno,:]))
                 print('~~~',result[parset_id][progset_id])
 
             except:

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -586,8 +586,12 @@ def get_coverages_for_scenarios(project, year=None):
             result[parset_id][progset_id] = {}
             try:
                 coverage = progset.getdefaultcoverage(t=list(years), parset=parset)
-                print('~~~',coverage)
-                result[parset_id][progset_id] = coverage
+                prog_list = coverage.keys()
+                coverage = np.column_stack(coverage.values())
+                for yrno,year in enumerate(years):
+                    result[parset_id][progset_id][year] = odict(zip(prog_list,coverage[yrno,:]))
+                print('~~~',result[parset_id][progset_id])
+
             except:
                 print('!?!?!')
                 import traceback

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -591,6 +591,7 @@ def get_coverages_for_scenarios(project, year=None):
                 except:
                     coverage = None
                 result[parset_id][progset_id][year] = coverage
+    print('>> finished get_coverages_for_scenarios')
     return result
 
 

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -578,7 +578,10 @@ def get_coverages_for_scenarios(project, year=None):
     start = project.settings.start
     end = project.settings.end
     years = range(int(start), int(end) + 1)
+
+    from time import perf_counter
     i=0
+    start_time = perf_counter()
     for parset in project.parsets.values():
         parset_id = str(parset.uid)
         result[parset_id] = {}
@@ -588,7 +591,7 @@ def get_coverages_for_scenarios(project, year=None):
             for year in years:
                 i += 1
                 try:
-                    print(f'>> > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
+                    print(f'>>{perf_counter()-start_time} > {i} getting coverage for {project.name},{parset.name},{progset.name},{year}')
                     coverage = progset.getdefaultcoverage(t=year, parset=parset)
                     coverage = normalize_obj(coverage)
                 except:

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -585,7 +585,7 @@ def get_coverages_for_scenarios(project, year=None):
             progset_id = str(progset.uid)
             result[parset_id][progset_id] = {}
             try:
-                result[parset_id][progset_id] = progset.getdefaultcoverage(t=years, parset=parset)
+                result[parset_id][progset_id] = progset.getdefaultcoverage(t=list(years), parset=parset)
             except:
                 print('!?!?!')
                 import traceback

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -591,12 +591,7 @@ def get_coverages_for_scenarios(project, year=None):
                 coverage = np.column_stack(coverage.values())
                 for yrno,year in enumerate(years):
                     result[parset_id][progset_id][year] = normalize_obj(op.odict(zip(prog_list,coverage[yrno,:])))
-                print('~~~',result[parset_id][progset_id])
-
             except:
-                print('!?!?!')
-                import traceback
-                traceback.print_exc()
                 for year in years:
                     result[parset_id][progset_id][year] = None
     return result

--- a/tests/benchmarkoptimization.py
+++ b/tests/benchmarkoptimization.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+"""
+BENCHMARKOPTIMIZATION
+
+Copied from benchmarkmodel.py
+
+Mainly used for the line profiling because don't have a demo project with programs
+
+Now also does profiling! See: https://zapier.com/engineering/profiling-python-boss/
+
+Requires line_profiler, available from: 
+    https://pypi.python.org/pypi/line_profiler/
+or: 
+    pip install line_profiler
+
+Version: 2018apr24
+"""
+
+dobenchmark = True  # Just benchmarks the model itself
+doprofile = True
+
+n_benchmark = 10  # Number of times to run the cpu benchmark
+n_runsim = 1     # Number of times to run the model
+
+# If running profiling, choose which function to line profile.
+functiontoprofile = 'outcomecalc' # Choices are: P_optimize, optimize, minoutcomes, outcomecalc,
+tobenchmark = 'runsim' # Choices are 'runsim' or 'runbudget'
+
+args = {'multi':False,'nchains':2, 'nblocks':None, 'blockiters':30,'maxtime':1,'randseed':5}
+
+
+############################################################################################################################
+## Benchmarking
+############################################################################################################################
+if dobenchmark:
+    print('Benchmarking...')
+
+    from optima import demo, gitinfo, today, getdate, loadtext, savetext
+    import timeit
+
+    # Settings
+    hashlen = 7
+    filename = 'benchmark.txt'
+    dosave = True
+
+    # Run a benchmarking test
+    def cpubenchmark():
+        elapsed = timeit.timeit(lambda: [0+tmp for tmp in range(int(1e6))], number=n_benchmark)
+        elapsed = elapsed / n_benchmark
+        performance = 1.0/(elapsed)
+        return performance
+
+    # Prelminaries
+    from hiv_utils import *
+    P = get_latest_project('Kyrgyzstan')
+    performance1 = cpubenchmark()
+
+    elapsed = 0
+    # Run the model
+    if   tobenchmark == 'runsim':
+        elapsed = timeit.timeit(lambda: P.runsim(), number=n_runsim)
+    # elif   tobenchmark == 'optimize':
+    #     elapsed = timeit.timeit(lambda: P.optimize(**args), number=n_runsim)
+    elif tobenchmark == 'runbudget':
+        elapsed = timeit.timeit(lambda: P.runbudget(), number=n_runsim)
+    else: raise Exception('tobenchmark "%s" not recognized' % tobenchmark)
+
+    elapsed = elapsed / n_runsim  # Average of N runs
+
+    performance2 = cpubenchmark()
+    performance = sum([performance1, performance2])/2. # Find average of before and after
+    benchmarktxt = "for %s (benchmark:%0.2fm iterations/second)" % (tobenchmark, performance)
+    print(benchmarktxt)
+
+    # Gather the output data
+    elapsedstr = '%0.3f' % elapsed
+    todaystr = getdate(today()).replace(' ','_')
+    gitbranch, gitversion = gitinfo()
+    gitversion = gitversion[:hashlen]
+    thisout = ' '.join([elapsedstr, todaystr, gitversion, gitbranch, benchmarktxt])
+
+    # Save, but only if hash not already in file
+    if dosave:
+        output = loadtext(filename, splitlines=True)
+        output.append(thisout)
+        savetext(filename, output)
+
+    print(f'Done benchmarking: average model runtime was {elapsedstr} s. (over {n_runsim} run(s))')
+
+
+
+############################################################################################################################
+## Profiling
+############################################################################################################################
+try:
+    import line_profiler # analysis:ignore
+except:
+    print('WARNING: Line profiler "line_profiler" not available, not running line profiling')
+    doprofile = False # Don't profile if it can't be loaded
+
+if doprofile:
+    from line_profiler import LineProfiler
+    from optima.optimization import minoutcomes
+    from optima import Project, Optim, optimize,model,makesimpars, applylimits,asd,outcomecalc,Programset,Program # analysis:ignore -- called by eval() function
+    # P = Project(spreadsheet='generalized.xlsx', dorun=False)
+
+    from hiv_utils import *
+    P = get_latest_project('Kyrgyzstan')
+
+    getpars = Programset.getpars
+    getoutcomes = Programset.getoutcomes
+    gettargetpopsize = Program.gettargetpopsize
+    P_optimize = P.optimize
+    runsim = P.runsim # analysis:ignore
+    interp = P.pars()['hivtest'].interp
+
+    def profile():
+        print('Profiling...')
+
+        def do_profile(follow=None):
+          def inner(func):
+              def profiled_func(*args, **kwargs):
+                  try:
+                      profiler = LineProfiler()
+                      profiler.add_function(func)
+                      for f in follow:
+                          profiler.add_function(f)
+                      profiler.enable_by_count()
+                      return func(*args, **kwargs)
+                  finally:
+                      profiler.print_stats()
+              return profiled_func
+          return inner
+
+
+
+        @do_profile(follow=[eval(functiontoprofile)]) # Add decorator to runmodel function
+        def optimizewrapper():
+            P.optimize(**args)
+        optimizewrapper()
+
+        print('Done.')
+
+    profile()
+
+if 'elapsedstr' in locals():
+    print(f'And to summarize,  average model runtime was {elapsedstr} s. (over {n_runsim} run(s))')


### PR DESCRIPTION
On loading the scenario tab, the project gets the default coverage of all the programs for all times for all combinations of parsets and progsets. This is sped up by not looping over t values, but supplying the t values as an array.

This gave different results compared with inputting the t values one by one.

This was caused by two issues which have now been fixed:
 - The popsize interpolation would apply the exponential curve, even if it wasn't needed yet if only one t value was input. (Note that this fix likely fixes weird issues with the reconciliation page!)
 - When there are multiple cost-coverage curves, the model interpolates between these. This was being smoothed if an array of t values was input - leading to inconsistent results. Now, no smoothing is done, but still being interpolated.