### PR TITLE
Fix budget year and budget values not being arrays

### DIFF
--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1163,11 +1163,7 @@ def revert_scenario_pars(pars):
 
 def convert_program_list(program_list):
     items = program_list.items()
-    result_list = [None] * len(items)
-    for i, (x,y) in enumerate(items):
-        if y is not None: y = op.promotetoarray(y) # FE has problems if budget values aren't arrays
-        result_list[i] = {"program": x, "values": y}
-    return result_list
+    return [{"program": x, "values": op.promotetoarray(y) if y is not None else y} for x, y in items]
 
 
 def revert_program_list(program_list):

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -17,6 +17,7 @@ from uuid import UUID
 
 import numpy as np
 import optima as op
+from sciris import isiterable
 
 from .exceptions import ParsetDoesNotExist, ProgramDoesNotExist, ProgsetDoesNotExist
 
@@ -1258,6 +1259,9 @@ def get_scenario_summary(project, scenario):
 
     warning, _,_,_, combinedwarningmsg, warningmessages = \
         op.checkifparsetoverridesscenario(project=project, parset=parset,progset=progset, scen=scenario, formatfor='html', createmessages=True)
+
+    # The FE has problems if the time the scenario starts isn't in an array
+    scenario.t = op.promotetoarray(scenario.t)
 
     result = {
         'id': scenario_id,

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1164,7 +1164,7 @@ def revert_scenario_pars(pars):
 
 def convert_program_list(program_list):
     items = program_list.items()
-    return [{"program": x, "values": y} for x, y in items]
+    return [{"program": x, "values": op.promotetoarray(y)} for x, y in items]
 
 
 def revert_program_list(program_list):

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -17,7 +17,6 @@ from uuid import UUID
 
 import numpy as np
 import optima as op
-from sciris import isiterable
 
 from .exceptions import ParsetDoesNotExist, ProgramDoesNotExist, ProgsetDoesNotExist
 
@@ -1164,7 +1163,7 @@ def revert_scenario_pars(pars):
 
 def convert_program_list(program_list):
     items = program_list.items()
-    return [{"program": x, "values": op.promotetoarray(y)} for x, y in items]
+    return [{"program": x, "values": op.promotetoarray(y)} for x, y in items] # FE has problems if budget values aren't arrays
 
 
 def revert_program_list(program_list):

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1168,6 +1168,7 @@ def convert_program_list(program_list):
 
 
 def revert_program_list(program_list):
+    print('\nrevert_program_list: ', program_list)
     result = {}
     for entry in program_list:
         key = entry["program"]

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1168,7 +1168,6 @@ def convert_program_list(program_list):
 
 
 def revert_program_list(program_list):
-    print('\nrevert_program_list: ', program_list)
     result = {}
     for entry in program_list:
         key = entry["program"]

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1163,7 +1163,11 @@ def revert_scenario_pars(pars):
 
 def convert_program_list(program_list):
     items = program_list.items()
-    return [{"program": x, "values": op.promotetoarray(y)} for x, y in items] # FE has problems if budget values aren't arrays
+    result_list = [None] * len(items)
+    for i, (x,y) in enumerate(items):
+        if y is not None: y = op.promotetoarray(y) # FE has problems if budget values aren't arrays
+        result_list[i] = {"program": x, "values": y}
+    return result_list
 
 
 def revert_program_list(program_list):
@@ -1260,7 +1264,7 @@ def get_scenario_summary(project, scenario):
         op.checkifparsetoverridesscenario(project=project, parset=parset,progset=progset, scen=scenario, formatfor='html', createmessages=True)
 
     # The FE has problems if the time the scenario starts isn't in an array
-    scenario.t = op.promotetoarray(scenario.t)
+    if scenario.t is not None: scenario.t = op.promotetoarray(scenario.t)
 
     result = {
         'id': scenario_id,


### PR DESCRIPTION
The FE expects both the budget year(s) and budget values to be arrays, not single numbers which the BE sometimes gives. This promotes the values to arrays if they are not None before passing to the FE. They stay as plain numbers in the BE until the FE clicks save.