### PR TITLE
Fix budget year and budget values not being arrays

### DIFF
--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1163,7 +1163,7 @@ def revert_scenario_pars(pars):
 
 def convert_program_list(program_list):
     items = program_list.items()
-    return [{"program": x, "values": y} for x, y in items]
+    return [{"program": x, "values": op.promotetoarray(y) if y is not None else y} for x, y in items]
 
 
 def revert_program_list(program_list):
@@ -1258,6 +1258,9 @@ def get_scenario_summary(project, scenario):
 
     warning, _,_,_, combinedwarningmsg, warningmessages = \
         op.checkifparsetoverridesscenario(project=project, parset=parset,progset=progset, scen=scenario, formatfor='html', createmessages=True)
+
+    # The FE has problems if the time the scenario starts isn't in an array
+    if scenario.t is not None: scenario.t = op.promotetoarray(scenario.t)
 
     result = {
         'id': scenario_id,


### PR DESCRIPTION
The FE expects both the budget year(s) and budget values to be arrays, not single numbers which the BE sometimes gives. This promotes the values to arrays if they are not None before passing to the FE. They stay as plain numbers in the BE until the FE clicks save.