### PR TITLE
Actsreg, actscas, actscom now only have insertive acts in them

### DIFF
--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -99,6 +99,7 @@ def setmigrations(which='migrations'):
         ('2.11.1', ('2.11.2', '2022-10-10', None,            'Big model speed ups (about 25%) and split diagnoses by CD4 count')),
         ('2.11.2', ('2.11.3', '2022-11-02', None,            'Annual data takes precedence over assumption when loading databook, bug fixes, FE Scenario tab add stacked for one scenario + other things.')),
         ('2.11.3', ('2.11.4', '2023-02-07',addallconstraintsoptim, 'Adds absconstraints and proporigconstraints to Optim, model works with initpeople and optimization improvements')),
+        ('2.11.4', ('2.12.0', '2023-03-10',addinsertonlyacts,'Adds ANC testing to diagnose mothers to put onto PMTCT, actsreg etc only contain insertive acts, and relhivbirth only reduces birth rate of diagnosed HIV+ potential mothers.')),
         ])
     
     
@@ -1466,6 +1467,20 @@ def addallconstraintsoptim(project=None, **kwargs):
             if not hasattr(optim, 'absconstraints'):      optim.absconstraints      = None
     return None
 
+def addinsertonlyacts(project=None, **kwargs):
+    '''
+    Migration between Optima 2.11.4 and 2.12.0
+    - actsreg, actscas, actscom are now only insertive acts, so we add a attribute insertiveonly to pars['actsreg'] etc
+    '''
+    if project is not None:
+        for parset in project.parsets.values():
+            for parname in ['actsreg', 'actscas', 'actscom']:
+                par = parset.pars[parname]
+                if not hasattr(par, 'insertiveonly'):
+                    par.insertiveonly = False  # Previously generated parsets don't have insertive only
+    return None
+
+
 ##########################################################################################
 ### CORE MIGRATION FUNCTIONS
 ##########################################################################################
@@ -1474,12 +1489,12 @@ def migrate(project, verbose=2, die=False):
     """
     Migrate an Optima Project by inspecting the version and working its way up.
     """
-    
+
     migrations = setmigrations() # Get the migrations to run
 
     while str(project.version) != str(op.version):
         currentversion = str(project.version)
-        
+
         # Check that the migration exists
         if not currentversion in migrations:
             if op.compareversions(currentversion, op.version)<0:
@@ -1493,8 +1508,8 @@ def migrate(project, verbose=2, die=False):
         # Do the migration
         newversion,currentdate,migrator,msg = migrations[currentversion] # Get the details of the current migration -- version, date, function ("migrator"), and message
         op.printv('Migrating "%s" from %6s -> %s' % (project.name, currentversion, newversion), 2, verbose)
-        if migrator is not None: 
-            try: 
+        if migrator is not None:
+            try:
                 migrator(project, verbose=verbose, die=die) # Sometimes there is no upgrader
             except Exception as E:
                 errormsg = 'WARNING, migrating "%s" from %6s -> %6s failed:\n%s' % (project.name, currentversion, newversion, repr(E))
@@ -1503,20 +1518,20 @@ def migrate(project, verbose=2, die=False):
                 if die: raise op.OptimaException(errormsg)
                 else:   op.printv(errormsg, 1, verbose)
                 return project # Abort, if haven't died already
-        
+
         # Update project info
         project.version = newversion # Update the version info
-    
+
     # Restore links just in case
     project.restorelinks()
-    
+
     # If any warnings were generated during the migration, print them now
     warnings = project.getwarnings()
-    if warnings and die: 
+    if warnings and die:
         errormsg = 'WARNING, Please resolve warnings in projects before continuing'
         if die: raise op.OptimaException(errormsg)
         else:   op.printv(errormsg+'\n'+warnings, 1, verbose)
-    
+
     op.printv('Migration successful!', 3, verbose)
     return project
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -452,7 +452,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
     ninjacts = 0
     allsexkeys = {}
     for actind,act in enumerate(['reg','cas','com']):
-        if compareversions(version,"2.12.0") >= 0: # New behaviour
+        if compareversions(version,"2.12.0") >= 0 and f'acts{act}insertive' in simpars.keys(): # New behaviour
             allsexkeys[act] = set(simpars[f'acts{act}insertive'].keys())  # Make a set of all partnerships for reg, cas, com
             allsexkeys[act].update(set(simpars[f'acts{act}receptive'].keys()))
         else: # Old behaviour
@@ -478,7 +478,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             pop1 = popkeys.index(key[0])
             pop2 = popkeys.index(key[1])
 
-            if compareversions(version, "2.12.0") >= 0:  # New behaviour
+            if compareversions(version, "2.12.0") >= 0 and f'acts{act}insertive' in simpars.keys():  # New behaviour
                 insertiveacts = simpars[f'acts{act}insertive'][key] if key in simpars[f'acts{act}insertive'].keys() else 0
                 receptiveacts = simpars[f'acts{act}receptive'][key] if key in simpars[f'acts{act}receptive'].keys() else 0
                 totalacts = insertiveacts + receptiveacts

--- a/optima/model.py
+++ b/optima/model.py
@@ -322,41 +322,26 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         # Iterate over the states you could be going to
         for tostate in fromto[fromstate]:
             if fromstate in acute: # You can progress from acute
-                if tostate in acute:
-                    transmatrix[fromstate,tostate,:] = 1.-prog[0]
-                elif tostate in gt500:
-                    transmatrix[fromstate,tostate,:] = prog[0]
+                if tostate in acute:   transmatrix[fromstate,tostate,:] = 1.-prog[0]
+                elif tostate in gt500: transmatrix[fromstate,tostate,:] = prog[0]
             elif fromstate in gt500:
-                if tostate in gt500:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlproggt500']*dt
-                elif tostate in gt350:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlproggt500']*dt
+                if tostate in gt500:   transmatrix[fromstate,tostate,:] = 1.-simpars['usvlproggt500']*dt
+                elif tostate in gt350: transmatrix[fromstate,tostate,:] = simpars['usvlproggt500']*dt
             elif fromstate in gt350:
-                if tostate in gt500:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt350']*dt
-                elif tostate in gt350:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt350']*dt-simpars['usvlproggt350']*dt
-                elif tostate in gt200:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlproggt350']*dt
+                if tostate in gt500:   transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt350']*dt
+                elif tostate in gt350: transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt350']*dt-simpars['usvlproggt350']*dt
+                elif tostate in gt200: transmatrix[fromstate,tostate,:] = simpars['usvlproggt350']*dt
             elif fromstate in gt200:
-                if tostate in gt350:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt200']*dt
-                elif tostate in gt200:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt200']*dt-simpars['usvlproggt200']*dt
-                elif tostate in gt50:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlproggt200']*dt
+                if tostate in gt350:   transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt200']*dt
+                elif tostate in gt200: transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt200']*dt-simpars['usvlproggt200']*dt
+                elif tostate in gt50:  transmatrix[fromstate,tostate,:] = simpars['usvlproggt200']*dt
             elif fromstate in gt50:
-                if tostate in gt200:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt50']*dt
-                elif tostate in gt50:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt50']*dt-simpars['usvlproggt50']*dt
-                elif tostate in lt50:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlproggt50']*dt
+                if tostate in gt200:   transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt50']*dt
+                elif tostate in gt50:  transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt50']*dt-simpars['usvlproggt50']*dt
+                elif tostate in lt50:  transmatrix[fromstate,tostate,:] = simpars['usvlproggt50']*dt
             elif fromstate in lt50:
-                if tostate in gt50:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlrecovlt50']*dt
-                elif tostate in lt50:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovlt50']*dt
+                if tostate in gt50:    transmatrix[fromstate,tostate,:] = simpars['usvlrecovlt50']*dt
+                elif tostate in lt50:  transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovlt50']*dt
 
             # Death probabilities
             transmatrix[fromstate,tostate,:] *= 1.-deathhiv[fromhealthstate]*relhivdeath*deathusvl*dt

--- a/optima/model.py
+++ b/optima/model.py
@@ -937,8 +937,8 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         calcproppmtct = thisnumpmtct / (eps*dt+numdxhivpospregwomen.sum()) # eps*dt to make sure that backwards compatible
         calcproppmtct = minimum(calcproppmtct,1)
         if oldbehaviour: thisproppmtct = calcproppmtct  # old behaviour is calcproppmtct = numpmtct / dxpregwomen, and thisproppmtct = numpmtct / dxpregwomen
-        else:           thisproppmtct = thisnumpmtct / (eps+numhivpospregwomen.sum())
-        thisproppmtct = minimum(calcproppmtct, 1)
+        else:            thisproppmtct = thisnumpmtct / (eps+numhivpospregwomen.sum())
+        thisproppmtct = minimum(thisproppmtct, 1)
 
         undxhivbirths = zeros(npops) # Store undiagnosed HIV+ births for this timestep
         dxhivbirths = zeros(npops) # Store diagnosed HIV+ births for this timestep

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1382,7 +1382,9 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
     # Loop over requested keys
     for key in keys: # Loop over all keys
         if compareversions(version,"2.12.0") >= 0 and key in ['actsreg', 'actscas', 'actscom', 'actsreginsertive', 'actscasinsertive', 'actscominsertive', 'actsregreceptive', 'actscasreceptive', 'actscomreceptive']:
-            continue  # New behaviour, the above pars are handled in the next loop
+            par = pars[key[0:7]]
+            if hasattr(par, 'insertiveonly') and par.insertiveonly:
+                continue  # New behaviour, the insertiveonly pars are handled in the next loop
         if isinstance(pars[key], Par): # Check that it is actually a parameter -- it could be the popkeys odict, for example
             thissample = sample # Make a copy of it to check it against the list of things we are sampling
             if tosample and tosample[0] is not None and key not in tosample: thissample = False # Don't sample from unselected parameters -- tosample[0] since it's been promoted to a list
@@ -1411,8 +1413,9 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
 
         for key in keys:
             if key in ['actsreg', 'actscas', 'actscom', 'actsreginsertive', 'actscasinsertive', 'actscominsertive', 'actsregreceptive', 'actscasreceptive', 'actscomreceptive']:
-                if 'popsize' not in keys:
-                    raise OptimaException(f'In order to makesimpars for "{key}", "popsize" needs to be in the keys to be included in the simpars.')
+                if not (hasattr(pars[key], 'insertiveonly') and pars[key].insertiveonly):
+                    print(f'WARNING: Acts "{key}" are not "insertiveonly" so these sexual acts will have the old (v2.11.4) non-directional behaviour!')
+                    continue
                 key = key[0:7]
 
                 insertivepar = pars[key]  # actsreg only contains insertive acts, eg. actsreg[(popA, popB)] = c is c insertive acts for each person in popA

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1400,13 +1400,13 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
         for key in ['actsreg', 'actscas', 'actscom']:
             for times in pars[key].t.values():
                 alltimes.update(set(times))
-        alltimes = array(sorted(list(alltimes)))
+        list_times = linspace(min(alltimes), max(alltimes),num=(int(max(alltimes)/dt)-int(min(alltimes)/dt)+1))
 
         popsizesample = sample
         if tosample and tosample[0] is not None and 'popsize' not in tosample: popsizesample = False
 
         if len(alltimes):
-            popsizeinterped = pars['popsize'].interp(tvec=alltimes, dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=True, sample=popsizesample, randseed=randseed)
+            popsizeinterped = pars['popsize'].interp(tvec=list_times, dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=True, sample=popsizesample, randseed=randseed)
         else: popsizeinterped = None
 
         for key in keys:
@@ -1416,7 +1416,7 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
                 key = key[0:7]
 
                 insertivepar = pars[key]  # actsreg only contains insertive acts, eg. actsreg[(popA, popB)] = c is c insertive acts for each person in popA
-                receptivepar = getreceptiveactsfrominsertive(insertivepar, alltimes, popsizeinterped, popkeys=popkeys)
+                receptivepar = getreceptiveactsfrominsertive(insertivepar, list_times, popsizeinterped, popkeys=popkeys)
 
                 insertivekey = key + 'insertive'
                 receptivekey = key + 'receptive'

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1327,6 +1327,10 @@ def makepars(data=None, verbose=2, die=True, fixprops=None):
                             pars[condname].y[(key1,key2)] = array(tmpcond[act])[i,j,:]
                             pars[condname].t[(key1,key2)] = array(tmpcondpts[act])
 
+    insertiveonly = True if compareversions(version,"2.12.0") >= 0 else False
+    for act in ['reg', 'cas', 'com']:
+        pars['acts'+act].insertiveonly = insertiveonly # So that the model knows whether or not to use the new behaviour
+
     # Store information about injecting populations -- needs to be here since relies on other calculations
     pars['injects'] = array([pop in [pop1 for (pop1,pop2) in pars['actsinj'].keys()] for pop in pars['popkeys']])
     

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1332,7 +1332,7 @@ def makepars(data=None, verbose=2, die=True, fixprops=None):
     
     return pars
 
-def getreceptiveactsfrominsertive(insertivepar, popsizetimes, popsizeinterped, popkeys, popsizeargs):
+def getreceptiveactsfrominsertive(insertivepar, popsizetimes, popsizeinterped, popkeys):
     receptivepar = cp(insertivepar)
     receptivepar.t = odict()
     receptivepar.y = odict()
@@ -1416,7 +1416,7 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
                 key = key[0:7]
 
                 insertivepar = pars[key]  # actsreg only contains insertive acts, eg. actsreg[(popA, popB)] = c is c insertive acts for each person in popA
-                receptivepar = getreceptiveactsfrominsertive(insertivepar, alltimes, popsizeinterped, popkeys=popkeys, popsizeargs=popsizeargs)
+                receptivepar = getreceptiveactsfrominsertive(insertivepar, alltimes, popsizeinterped, popkeys=popkeys)
 
                 insertivekey = key + 'insertive'
                 receptivekey = key + 'receptive'

--- a/optima/project.py
+++ b/optima/project.py
@@ -501,6 +501,7 @@ class Project(object):
                     if key!='initprev' or resetprevalence: # Initial prevalence is a special case: the only user-edited parameter that is also a data parameter
                         if hasattr(parset.pars[key],'y'): parset.pars[key].y = origparset.pars[key].y # Reset y (value) variable, if it exists
                         if hasattr(parset.pars[key],'t'): parset.pars[key].t = origparset.pars[key].t # Reset t (time) variable, if it exists
+                        if hasattr(parset.pars[key],'insertiveonly'): parset.pars[key].insertiveonly = origparset.pars[key].insertiveonly # Special to actsreg, actscas, actscom
                 # Reset transition matrices
                 if key in ['birthtransit','agetransit','risktransit']: 
                     parset.pars[key] = dcp(origparset.pars[key])


### PR DESCRIPTION
Finished version of https://github.com/optimamodel/optima/pull/1891

Adds a migration so that results using previous parsets are not changed - only changed a small amount by the PMTCT changes if you are using 2.12.0 or later. Only uses the new directional partnerships if you recreate the parset from the data - pars['actsreg'].insertiveonly is the attribute which determines whether the old or new behaviour.

Directionality in the Partnerships matrices is now observed. If both directions are put in the matrix then the ratio of the two directions in the matrix gives the ratio of the insertive acts.

Plus relhivbirth only applies to diagnosed mothers with HIV, not all PLHIV, and not those diagnosed by ANC