### PR TITLE
Actsreg, actscas, actscom now only have insertive acts in them

### DIFF
--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -99,6 +99,7 @@ def setmigrations(which='migrations'):
         ('2.11.1', ('2.11.2', '2022-10-10', None,            'Big model speed ups (about 25%) and split diagnoses by CD4 count')),
         ('2.11.2', ('2.11.3', '2022-11-02', None,            'Annual data takes precedence over assumption when loading databook, bug fixes, FE Scenario tab add stacked for one scenario + other things.')),
         ('2.11.3', ('2.11.4', '2023-02-07',addallconstraintsoptim, 'Adds absconstraints and proporigconstraints to Optim, model works with initpeople and optimization improvements')),
+        ('2.11.4', ('2.12.0', '2023-03-10',addinsertonlyacts,'Adds ANC testing to diagnose mothers to put onto PMTCT, actsreg etc only contain insertive acts, and relhivbirth only reduces birth rate of diagnosed HIV+ potential mothers.')),
         ])
     
     
@@ -1466,6 +1467,20 @@ def addallconstraintsoptim(project=None, **kwargs):
             if not hasattr(optim, 'absconstraints'):      optim.absconstraints      = None
     return None
 
+def addinsertonlyacts(project=None, **kwargs):
+    '''
+    Migration between Optima 2.11.4 and 2.12.0
+    - actsreg, actscas, actscom are now only insertive acts, so we add a attribute insertiveonly to pars['actsreg'] etc
+    '''
+    if project is not None:
+        for parset in project.parsets.values():
+            for parname in ['actsreg', 'actscas', 'actscom']:
+                par = parset.pars[parname]
+                if not hasattr(par, 'insertiveonly'):
+                    par.insertiveonly = False  # Previously generated parsets don't have insertive only
+    return None
+
+
 ##########################################################################################
 ### CORE MIGRATION FUNCTIONS
 ##########################################################################################
@@ -1474,12 +1489,12 @@ def migrate(project, verbose=2, die=False):
     """
     Migrate an Optima Project by inspecting the version and working its way up.
     """
-    
+
     migrations = setmigrations() # Get the migrations to run
 
     while str(project.version) != str(op.version):
         currentversion = str(project.version)
-        
+
         # Check that the migration exists
         if not currentversion in migrations:
             if op.compareversions(currentversion, op.version)<0:
@@ -1493,8 +1508,8 @@ def migrate(project, verbose=2, die=False):
         # Do the migration
         newversion,currentdate,migrator,msg = migrations[currentversion] # Get the details of the current migration -- version, date, function ("migrator"), and message
         op.printv('Migrating "%s" from %6s -> %s' % (project.name, currentversion, newversion), 2, verbose)
-        if migrator is not None: 
-            try: 
+        if migrator is not None:
+            try:
                 migrator(project, verbose=verbose, die=die) # Sometimes there is no upgrader
             except Exception as E:
                 errormsg = 'WARNING, migrating "%s" from %6s -> %6s failed:\n%s' % (project.name, currentversion, newversion, repr(E))
@@ -1503,20 +1518,20 @@ def migrate(project, verbose=2, die=False):
                 if die: raise op.OptimaException(errormsg)
                 else:   op.printv(errormsg, 1, verbose)
                 return project # Abort, if haven't died already
-        
+
         # Update project info
         project.version = newversion # Update the version info
-    
+
     # Restore links just in case
     project.restorelinks()
-    
+
     # If any warnings were generated during the migration, print them now
     warnings = project.getwarnings()
-    if warnings and die: 
+    if warnings and die:
         errormsg = 'WARNING, Please resolve warnings in projects before continuing'
         if die: raise op.OptimaException(errormsg)
         else:   op.printv(errormsg+'\n'+warnings, 1, verbose)
-    
+
     op.printv('Migration successful!', 3, verbose)
     return project
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -846,6 +846,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         if t<npts-1:
             people[:,:,t+1] += einsum('ij,ikj->kj',people[:,:,t],thistransit[:,:,:])  # Assuming that there are no illegal tranfers in thistransit
 
+            print('here?', people[2,:,t+1])
 
         ##############################################################################################################
         ### Calculate births

--- a/optima/model.py
+++ b/optima/model.py
@@ -452,7 +452,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
     ninjacts = 0
     allsexkeys = {}
     for actind,act in enumerate(['reg','cas','com']):
-        if compareversions(version,"2.12.0") >= 0: # New behaviour
+        if compareversions(version,"2.12.0") >= 0 and f'acts{act}insertive' in simpars.keys(): # New behaviour
             allsexkeys[act] = set(simpars[f'acts{act}insertive'].keys())  # Make a set of all partnerships for reg, cas, com
             allsexkeys[act].update(set(simpars[f'acts{act}receptive'].keys()))
         else: # Old behaviour
@@ -478,7 +478,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             pop1 = popkeys.index(key[0])
             pop2 = popkeys.index(key[1])
 
-            if compareversions(version, "2.12.0") >= 0:  # New behaviour
+            if compareversions(version, "2.12.0") >= 0 and f'acts{act}insertive' in simpars.keys():  # New behaviour
                 insertiveacts = simpars[f'acts{act}insertive'][key] if key in simpars[f'acts{act}insertive'].keys() else 0
                 receptiveacts = simpars[f'acts{act}receptive'][key] if key in simpars[f'acts{act}receptive'].keys() else 0
                 totalacts = insertiveacts + receptiveacts

--- a/optima/model.py
+++ b/optima/model.py
@@ -467,7 +467,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
     ninjacts = 0
     allsexkeys = {}
     for actind,act in enumerate(['reg','cas','com']):
-        allsexkeys[act] = set(simpars[f'acts{act}insertive'].keys())
+        allsexkeys[act] = set(simpars[f'acts{act}insertive'].keys())  # Make a set of all partnerships for reg, cas, com
         allsexkeys[act].update(set(simpars[f'acts{act}receptive'].keys()))
         nsexacts[actind] += len(allsexkeys[act])
     for key in simpars['actsinj']:

--- a/optima/model.py
+++ b/optima/model.py
@@ -519,7 +519,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
 
             if male[pop1] and male[pop2]: homopartnerarr.add((pop1, pop2))
             else: heteropartnerarr.add((pop1, pop2))  # If a population is both male and female default to heterosexual
-            # print(act, key, trans[-1], wholeactssexarr[actind][i,:], fracactssexarr[actind][i,:], condarr[actind][i,:], sexpartnerarr[actind][i,:])
+            print(act, key, trans[-1], wholeactssexarr[actind][i,:], fracactssexarr[actind][i,:], condarr[actind][i,:], sexpartnerarr[actind][i,:])
 
             if debug:
                 for k,arr in {'wholeacts':wholeactssexarr[actind][i,:],'fracacts':fracactssexarr[actind][i,:],'cond':condarr[actind][i,:]}.items():
@@ -663,7 +663,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-        print(f'forceinffull t {tvec[t]} ', forceinffull.sum())
+        # print(f'forceinffull t {tvec[t]} ', forceinffull.sum())
         if advancedtracking:
             forceinffullsexinj[homosexsex,:,homopartnerarr[:,0],:,homopartnerarr[:,1]] = forceinffull[:,homopartnerarr[:,0],:,homopartnerarr[:,1]]
             forceinffullsexinj[heterosexsex,:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]] = forceinffull[:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]]

--- a/optima/model.py
+++ b/optima/model.py
@@ -663,7 +663,8 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-            print(f'forceinffull t {tvec[t]} ', forceinffullsex.sum(), 'asdfas', people[2,:,t])
+            print(f'forceinffull t {tvec[t]} ', forceinffullsex.sum(axis=(0,1)), 'asdfas', people[2,:,t])
+            # print(f'forceinffull t {tvec[t]} ', forceinffullsex.sum(), 'asdfas', people[2,:,t])
             # print(f'forceinffull t {tvec[t]} ', forceinffull[:,2,:,2], array(popkeys), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
             # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
             # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), fracactssexarr[i][:,t], wholeactssexarr[i][:,t].astype(int), transsexarr[i][:,t], condarr[i][:,t],  alleff[pop1,t,:],  effallprev[:,pop2])

--- a/optima/model.py
+++ b/optima/model.py
@@ -537,8 +537,6 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         fracactsinjarr[i,:] = dt*simpars['actsinj'][key] - wholeactsinjarr[i,:]
         injpartnerarr[i,:] = [popkeys.index(key[0]), popkeys.index(key[1])]
 
-        print(key, wholeactsinjarr[i,:], fracactsinjarr[i,:], injpartnerarr[i,:])
-
         if debug:
             for k,arr in {'wholeacts':wholeactsinjarr[i,:],'fracacts':fracactsinjarr[i,:]}.items():
                 if not(all(arr>=0)):
@@ -692,7 +690,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
                                         wholeactsinjarr[:,t].astype(int))   # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
 
         forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullinj[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-        print('!!!', forceinffull.sum(axis=(2, 3)))
+
         if advancedtracking:
             forceinffullsexinj[inj,:,:,:,:][:,pop1,:,pop2] = swapaxes(swapaxes(forceinffullinj[:,:,:],1,2),0,1)
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -485,6 +485,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
     # Sex
     for actind, act in enumerate(['reg','cas','com']):
         for i,key in enumerate(simpars['acts'+act]):
+            print('MODEL SETUP', 'acts'+act, key, simpars['acts'+act][key])
             wholeactssexarr[actind][i,:] = floor(dt*simpars['acts'+act][key])
             fracactssexarr[actind][i,:]  = dt*simpars['acts'+act][key] - wholeactssexarr[actind][i,:] # Probability of an additional act
 
@@ -657,7 +658,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-
+        print(f'forceinffull t {tvec[t]} ', forceinffull.sum())
         if advancedtracking:
             forceinffullsexinj[homosexsex,:,homopartnerarr[:,0],:,homopartnerarr[:,1]] = forceinffull[:,homopartnerarr[:,0],:,homopartnerarr[:,1]]
             forceinffullsexinj[heterosexsex,:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]] = forceinffull[:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]]

--- a/optima/model.py
+++ b/optima/model.py
@@ -537,6 +537,8 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         fracactsinjarr[i,:] = dt*simpars['actsinj'][key] - wholeactsinjarr[i,:]
         injpartnerarr[i,:] = [popkeys.index(key[0]), popkeys.index(key[1])]
 
+        print(key, wholeactsinjarr[i,:], fracactsinjarr[i,:], injpartnerarr[i,:])
+
         if debug:
             for k,arr in {'wholeacts':wholeactsinjarr[i,:],'fracacts':fracactsinjarr[i,:]}.items():
                 if not(all(arr>=0)):

--- a/optima/model.py
+++ b/optima/model.py
@@ -663,6 +663,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
+            print('!', forceinffull.sum(axis=(2, 3)))
             print(f'forceinffull t {tvec[t]} ', forceinffullsex.sum(axis=(0,1)), 'asdfas', people[2,:,t])
             # print(f'forceinffull t {tvec[t]} ', forceinffullsex.sum(), 'asdfas', people[2,:,t])
             # print(f'forceinffull t {tvec[t]} ', forceinffull[:,2,:,2], array(popkeys), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
@@ -671,6 +672,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         if advancedtracking:
             forceinffullsexinj[homosexsex,:,homopartnerarr[:,0],:,homopartnerarr[:,1]] = forceinffull[:,homopartnerarr[:,0],:,homopartnerarr[:,1]]
             forceinffullsexinj[heterosexsex,:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]] = forceinffull[:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]]
+        print('!!', forceinffull.sum(axis=(2, 3)))
 
         if debug and ( not((forceinffull[:,:,:,:]>=0).all()) or not((forceinffull[:,:,:,:]<=1).all()) ):
             for i,arr in enumerate(sexpartnerarr):
@@ -695,7 +697,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
                                         wholeactsinjarr[:,t].astype(int))   # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
 
         forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullinj[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-
+        print('!!!', forceinffull.sum(axis=(2, 3)))
         if advancedtracking:
             forceinffullsexinj[inj,:,:,:,:][:,pop1,:,pop2] = swapaxes(swapaxes(forceinffullinj[:,:,:],1,2),0,1)
 
@@ -709,6 +711,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
                     raise OptimaException(errormsg)
 
         # Probability of getting infected is one minus forceinffull times any scaling factors !! copied below !!
+        print('***',forceinffull.sum(axis=(2,3)))
         forceinffull  = einsum('ijkl,j,j,j->ijkl', 1.-forceinffull, force, inhomo,(1.-background[:,t]))
         infections_to = forceinffull.sum(axis=(2,3)) # Infections acquired through sex and injecting - by population who gets infected
         infections_to = minimum(infections_to, 1.0-eps-background[:,t].max()) # Make sure it never exceeds the limit

--- a/optima/model.py
+++ b/optima/model.py
@@ -519,7 +519,6 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
 
             if male[pop1] and male[pop2]: homopartnerarr.add((pop1, pop2))
             else: heteropartnerarr.add((pop1, pop2))  # If a population is both male and female default to heterosexual
-            # print(act, key, trans[-1], wholeactssexarr[actind][i,:], fracactssexarr[actind][i,:], condarr[actind][i,:], sexpartnerarr[actind][i,:])
 
             if debug:
                 for k,arr in {'wholeacts':wholeactssexarr[actind][i,:],'fracacts':fracactssexarr[actind][i,:],'cond':condarr[actind][i,:]}.items():
@@ -663,16 +662,10 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-            print('!', forceinffull.sum(axis=(2, 3)))
-            print(f'forceinffull t {tvec[t]} ', forceinffullsex.sum(axis=(0,1)), 'asdfas', people[2,:,t])
-            # print(f'forceinffull t {tvec[t]} ', forceinffullsex.sum(), 'asdfas', people[2,:,t])
-            # print(f'forceinffull t {tvec[t]} ', forceinffull[:,2,:,2], array(popkeys), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
-            # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
-            # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), fracactssexarr[i][:,t], wholeactssexarr[i][:,t].astype(int), transsexarr[i][:,t], condarr[i][:,t],  alleff[pop1,t,:],  effallprev[:,pop2])
+
         if advancedtracking:
             forceinffullsexinj[homosexsex,:,homopartnerarr[:,0],:,homopartnerarr[:,1]] = forceinffull[:,homopartnerarr[:,0],:,homopartnerarr[:,1]]
             forceinffullsexinj[heterosexsex,:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]] = forceinffull[:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]]
-        print('!!', forceinffull.sum(axis=(2, 3)))
 
         if debug and ( not((forceinffull[:,:,:,:]>=0).all()) or not((forceinffull[:,:,:,:]<=1).all()) ):
             for i,arr in enumerate(sexpartnerarr):
@@ -711,24 +704,19 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
                     raise OptimaException(errormsg)
 
         # Probability of getting infected is one minus forceinffull times any scaling factors !! copied below !!
-        print('***',forceinffull.sum(axis=(2,3)))
         forceinffull  = einsum('ijkl,j,j,j->ijkl', 1.-forceinffull, force, inhomo,(1.-background[:,t]))
         infections_to = forceinffull.sum(axis=(2,3)) # Infections acquired through sex and injecting - by population who gets infected
         infections_to = minimum(infections_to, 1.0-eps-background[:,t].max()) # Make sure it never exceeds the limit
-        print('**',forceinffull.sum(axis=(2,3)), infections_to, force, inhomo, (1.-background[:,t]))
+
         # Add these transition probabilities to the main array
         si = susreg[0] # susreg is a single element, but needs an index since can't index a list with an array
         pi = progcirc[0] # as above
         ui = undx[0]
-        K=0
-        print(K, thistransit.sum(axis=(0, 1)), people[sus,:,t], people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
-        K += 1
         thistransit[si,si,:] *= (1.-background[:,t]) - infections_to[si] # Index for moving from sus to sus
         thistransit[si,ui,:] *= infections_to[si] # Index for moving from sus to infection
         thistransit[pi,pi,:] *= (1.-background[:,t]) - infections_to[pi] # Index for moving from circ to circ
         thistransit[pi,ui,:] *= infections_to[pi] # Index for moving from circ to infection
-        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
-        K += 1
+
         # Calculate infections acquired and transmitted
         raw_inci[:,t]               = einsum('ij,ijkl->j', people[sus,:,t], forceinffull)/dt
         raw_incibypop[:,:,t]        = einsum('ij,ijkl->kl', people[sus,:,t], forceinffull)/dt
@@ -759,8 +747,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         ##############################################################################################################
         ### Calculate deaths
         ##############################################################################################################
-        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
-        K += 1
+
         # Adjust transition rates
         thistransit[nsus:,:,:] *= (1.-background[:,t])
 
@@ -777,8 +764,6 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             elif isnan(prop[t-1]): return True # The previous timestep had a rate, so keep the rate here
             else:                  return False # Neither: use a proportion instead of a rate
 
-        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
-        K += 1
         # Undiagnosed to diagnosed
         if userate(propdx,t): # Need to project forward one year to avoid mismatch
             dxprobarr = tile(hivtest[:,t], (ncd4,1))
@@ -790,8 +775,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         thistransit[ix_(undx, alldx, arange(npops))] *= einsum('ik,ij->ijk', dxprobarr[undx - undx[0],:], fromtoarr[ix_(undx,alldx)])
         raw_diagcd4[:,:,t] += einsum('ij,ij->ij', people[undx,:,t], thistransit[ix_(undx, alldx, arange(npops))].sum(axis=1) ) /dt
 
-        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
-        K += 1
+
         # Diagnosed/lost to care
         if True: # userate(propcare,t): Put people onto care even if there is propcare set, propcare will adjust after the fact. Otherwise, propcare doesn't link people to care at the rate that people should be (because theres enough in care) and we get too many people diagnosed but not linked.
             careprobarr   = tile(linktocare[:,t],   (ncd4,1))
@@ -834,8 +818,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         thistransit[ix_(usvl, usvl, arange(npops))]  *= einsum(',k,ij->ijk', (1.-svlprob), ones(npops), fromtoarr[ix_(usvl,usvl)])
         # usvl -> svl: thistransit[fromstate,tostate,:] *=  svlprob
         thistransit[ix_(usvl, svl, arange(npops))]  *= einsum(',k,ij->ijk', svlprob, ones(npops), fromtoarr[ix_(usvl,svl)])
-        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
-        K += 1
+
         # Check that probabilities all sum to 1
         if debug:
             transtest = array([(abs(thistransit[j,:,:].sum(axis=0)/(1.-background[:,t])+deathprob[j]*transdeathmatrix[j,:,t]-ones(npops))>eps).any() for j in range(nstates)])
@@ -854,12 +837,10 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             errormsg = label + 'Transitions are less than 0 at time t=%f for states %s: sums are \n%s' % (tvec[t], wrongstates, wrongprobs)
             raise OptimaException(errormsg)
 
-
         ## Shift people as required
         if t<npts-1:
             people[:,:,t+1] += einsum('ij,ikj->kj',people[:,:,t],thistransit[:,:,:])  # Assuming that there are no illegal tranfers in thistransit
 
-            print('here?', people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
 
         ##############################################################################################################
         ### Calculate births

--- a/optima/model.py
+++ b/optima/model.py
@@ -486,7 +486,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
 
     # Sex
     for actind, act in enumerate(['reg','cas','com']):
-        for i,key in enumerate(allsexkeys[act]):
+        for i,key in enumerate(sorted(allsexkeys[act])):
             insertiveacts = simpars[f'acts{act}insertive'][key] if key in simpars[f'acts{act}insertive'].keys() else 0
             receptiveacts = simpars[f'acts{act}receptive'][key] if key in simpars[f'acts{act}receptive'].keys() else 0
             totalacts = insertiveacts + receptiveacts

--- a/optima/model.py
+++ b/optima/model.py
@@ -519,7 +519,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
 
             if male[pop1] and male[pop2]: homopartnerarr.add((pop1, pop2))
             else: heteropartnerarr.add((pop1, pop2))  # If a population is both male and female default to heterosexual
-            print(act, key, trans[-1], wholeactssexarr[actind][i,:], fracactssexarr[actind][i,:], condarr[actind][i,:], sexpartnerarr[actind][i,:])
+            # print(act, key, trans[-1], wholeactssexarr[actind][i,:], fracactssexarr[actind][i,:], condarr[actind][i,:], sexpartnerarr[actind][i,:])
 
             if debug:
                 for k,arr in {'wholeacts':wholeactssexarr[actind][i,:],'fracacts':fracactssexarr[actind][i,:],'cond':condarr[actind][i,:]}.items():
@@ -663,7 +663,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-        # print(f'forceinffull t {tvec[t]} ', forceinffull.sum())
+        print(f'forceinffull t {tvec[t]} ', forceinffull.sum())
         if advancedtracking:
             forceinffullsexinj[homosexsex,:,homopartnerarr[:,0],:,homopartnerarr[:,1]] = forceinffull[:,homopartnerarr[:,0],:,homopartnerarr[:,1]]
             forceinffullsexinj[heterosexsex,:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]] = forceinffull[:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]]

--- a/optima/model.py
+++ b/optima/model.py
@@ -663,7 +663,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-        print(f'forceinffull t {tvec[t]} ', forceinffull.sum())
+            print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), fracactssexarr[i][:,t], wholeactssexarr[i][:,t].astype(int), transsexarr[i][:,t], condarr[i][:,t],  alleff[pop1,t,:],  effallprev[:,pop2])
         if advancedtracking:
             forceinffullsexinj[homosexsex,:,homopartnerarr[:,0],:,homopartnerarr[:,1]] = forceinffull[:,homopartnerarr[:,0],:,homopartnerarr[:,1]]
             forceinffullsexinj[heterosexsex,:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]] = forceinffull[:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]]

--- a/optima/model.py
+++ b/optima/model.py
@@ -663,7 +663,8 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-            print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
+            print(f'forceinffull t {tvec[t]} ', forceinffull[:,2,:,2], array(popkeys), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
+            # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
             # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), fracactssexarr[i][:,t], wholeactssexarr[i][:,t].astype(int), transsexarr[i][:,t], condarr[i][:,t],  alleff[pop1,t,:],  effallprev[:,pop2])
         if advancedtracking:
             forceinffullsexinj[homosexsex,:,homopartnerarr[:,0],:,homopartnerarr[:,1]] = forceinffull[:,homopartnerarr[:,0],:,homopartnerarr[:,1]]

--- a/optima/model.py
+++ b/optima/model.py
@@ -663,7 +663,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-        print(f'forceinffull t {tvec[t]} ', forceinffull.sum())
+        # print(f'forceinffull t {tvec[t]} ', forceinffull.sum())
         if advancedtracking:
             forceinffullsexinj[homosexsex,:,homopartnerarr[:,0],:,homopartnerarr[:,1]] = forceinffull[:,homopartnerarr[:,0],:,homopartnerarr[:,1]]
             forceinffullsexinj[heterosexsex,:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]] = forceinffull[:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]]

--- a/optima/model.py
+++ b/optima/model.py
@@ -519,6 +519,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
 
             if male[pop1] and male[pop2]: homopartnerarr.add((pop1, pop2))
             else: heteropartnerarr.add((pop1, pop2))  # If a population is both male and female default to heterosexual
+            print(act, key, trans[-1], wholeactssexarr[actind][i,:], fracactssexarr[actind][i,:], condarr[actind][i,:], sexpartnerarr[actind][i,:])
 
             if debug:
                 for k,arr in {'wholeacts':wholeactssexarr[actind][i,:],'fracacts':fracactssexarr[actind][i,:],'cond':condarr[actind][i,:]}.items():

--- a/optima/model.py
+++ b/optima/model.py
@@ -712,7 +712,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         forceinffull  = einsum('ijkl,j,j,j->ijkl', 1.-forceinffull, force, inhomo,(1.-background[:,t]))
         infections_to = forceinffull.sum(axis=(2,3)) # Infections acquired through sex and injecting - by population who gets infected
         infections_to = minimum(infections_to, 1.0-eps-background[:,t].max()) # Make sure it never exceeds the limit
-
+        print('**',forceinffull.sum(axis=(2,3)), infections_to, force, inhomo, (1.-background[:,t]))
         # Add these transition probabilities to the main array
         si = susreg[0] # susreg is a single element, but needs an index since can't index a list with an array
         pi = progcirc[0] # as above

--- a/optima/model.py
+++ b/optima/model.py
@@ -663,7 +663,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-            print(f'forceinffull t {tvec[t]} ', forceinffull[:,2,:,2], 'asdfas', people[:,2,t], array(popkeys), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
+            print(f'forceinffull t {tvec[t]} ', forceinffullsex.sum(), 'asdfas', people[2,:,t])
             # print(f'forceinffull t {tvec[t]} ', forceinffull[:,2,:,2], array(popkeys), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
             # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
             # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), fracactssexarr[i][:,t], wholeactssexarr[i][:,t].astype(int), transsexarr[i][:,t], condarr[i][:,t],  alleff[pop1,t,:],  effallprev[:,pop2])

--- a/optima/model.py
+++ b/optima/model.py
@@ -322,41 +322,26 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         # Iterate over the states you could be going to
         for tostate in fromto[fromstate]:
             if fromstate in acute: # You can progress from acute
-                if tostate in acute:
-                    transmatrix[fromstate,tostate,:] = 1.-prog[0]
-                elif tostate in gt500:
-                    transmatrix[fromstate,tostate,:] = prog[0]
+                if tostate in acute:   transmatrix[fromstate,tostate,:] = 1.-prog[0]
+                elif tostate in gt500: transmatrix[fromstate,tostate,:] = prog[0]
             elif fromstate in gt500:
-                if tostate in gt500:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlproggt500']*dt
-                elif tostate in gt350:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlproggt500']*dt
+                if tostate in gt500:   transmatrix[fromstate,tostate,:] = 1.-simpars['usvlproggt500']*dt
+                elif tostate in gt350: transmatrix[fromstate,tostate,:] = simpars['usvlproggt500']*dt
             elif fromstate in gt350:
-                if tostate in gt500:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt350']*dt
-                elif tostate in gt350:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt350']*dt-simpars['usvlproggt350']*dt
-                elif tostate in gt200:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlproggt350']*dt
+                if tostate in gt500:   transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt350']*dt
+                elif tostate in gt350: transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt350']*dt-simpars['usvlproggt350']*dt
+                elif tostate in gt200: transmatrix[fromstate,tostate,:] = simpars['usvlproggt350']*dt
             elif fromstate in gt200:
-                if tostate in gt350:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt200']*dt
-                elif tostate in gt200:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt200']*dt-simpars['usvlproggt200']*dt
-                elif tostate in gt50:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlproggt200']*dt
+                if tostate in gt350:   transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt200']*dt
+                elif tostate in gt200: transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt200']*dt-simpars['usvlproggt200']*dt
+                elif tostate in gt50:  transmatrix[fromstate,tostate,:] = simpars['usvlproggt200']*dt
             elif fromstate in gt50:
-                if tostate in gt200:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt50']*dt
-                elif tostate in gt50:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt50']*dt-simpars['usvlproggt50']*dt
-                elif tostate in lt50:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlproggt50']*dt
+                if tostate in gt200:   transmatrix[fromstate,tostate,:] = simpars['usvlrecovgt50']*dt
+                elif tostate in gt50:  transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovgt50']*dt-simpars['usvlproggt50']*dt
+                elif tostate in lt50:  transmatrix[fromstate,tostate,:] = simpars['usvlproggt50']*dt
             elif fromstate in lt50:
-                if tostate in gt50:
-                    transmatrix[fromstate,tostate,:] = simpars['usvlrecovlt50']*dt
-                elif tostate in lt50:
-                    transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovlt50']*dt
+                if tostate in gt50:    transmatrix[fromstate,tostate,:] = simpars['usvlrecovlt50']*dt
+                elif tostate in lt50:  transmatrix[fromstate,tostate,:] = 1.-simpars['usvlrecovlt50']*dt
 
             # Death probabilities
             transmatrix[fromstate,tostate,:] *= 1.-deathhiv[fromhealthstate]*relhivdeath*deathusvl*dt

--- a/optima/model.py
+++ b/optima/model.py
@@ -937,8 +937,8 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         calcproppmtct = thisnumpmtct / (eps*dt+numdxhivpospregwomen.sum()) # eps*dt to make sure that backwards compatible
         calcproppmtct = minimum(calcproppmtct,1)
         if oldbehaviour: thisproppmtct = calcproppmtct  # old behaviour is calcproppmtct = numpmtct / dxpregwomen, and thisproppmtct = numpmtct / dxpregwomen
-        else:           thisproppmtct = thisnumpmtct / (eps+numhivpospregwomen.sum())
-        thisproppmtct = minimum(calcproppmtct, 1)
+        else:            thisproppmtct = thisnumpmtct / (eps+numhivpospregwomen.sum())
+        thisproppmtct = minimum(thisproppmtct, 1)
 
         undxhivbirths = zeros(npops) # Store undiagnosed HIV+ births for this timestep
         dxhivbirths = zeros(npops) # Store diagnosed HIV+ births for this timestep

--- a/optima/model.py
+++ b/optima/model.py
@@ -718,13 +718,13 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         pi = progcirc[0] # as above
         ui = undx[0]
         K=0
-        print(K, thistransit.sum(axis=(0, 1)))
+        print(K, thistransit.sum(axis=(0, 1)), people[sus,:,t], people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
         K += 1
         thistransit[si,si,:] *= (1.-background[:,t]) - infections_to[si] # Index for moving from sus to sus
         thistransit[si,ui,:] *= infections_to[si] # Index for moving from sus to infection
         thistransit[pi,pi,:] *= (1.-background[:,t]) - infections_to[pi] # Index for moving from circ to circ
         thistransit[pi,ui,:] *= infections_to[pi] # Index for moving from circ to infection
-        print(K, thistransit.sum(axis=(0, 1)))
+        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
         K += 1
         # Calculate infections acquired and transmitted
         raw_inci[:,t]               = einsum('ij,ijkl->j', people[sus,:,t], forceinffull)/dt
@@ -756,7 +756,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         ##############################################################################################################
         ### Calculate deaths
         ##############################################################################################################
-        print(K, thistransit.sum(axis=(0, 1)))
+        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
         K += 1
         # Adjust transition rates
         thistransit[nsus:,:,:] *= (1.-background[:,t])
@@ -774,7 +774,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             elif isnan(prop[t-1]): return True # The previous timestep had a rate, so keep the rate here
             else:                  return False # Neither: use a proportion instead of a rate
 
-        print(K, thistransit.sum(axis=(0, 1)))
+        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
         K += 1
         # Undiagnosed to diagnosed
         if userate(propdx,t): # Need to project forward one year to avoid mismatch
@@ -787,7 +787,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         thistransit[ix_(undx, alldx, arange(npops))] *= einsum('ik,ij->ijk', dxprobarr[undx - undx[0],:], fromtoarr[ix_(undx,alldx)])
         raw_diagcd4[:,:,t] += einsum('ij,ij->ij', people[undx,:,t], thistransit[ix_(undx, alldx, arange(npops))].sum(axis=1) ) /dt
 
-        print(K, thistransit.sum(axis=(0, 1)))
+        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
         K += 1
         # Diagnosed/lost to care
         if True: # userate(propcare,t): Put people onto care even if there is propcare set, propcare will adjust after the fact. Otherwise, propcare doesn't link people to care at the rate that people should be (because theres enough in care) and we get too many people diagnosed but not linked.
@@ -831,7 +831,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         thistransit[ix_(usvl, usvl, arange(npops))]  *= einsum(',k,ij->ijk', (1.-svlprob), ones(npops), fromtoarr[ix_(usvl,usvl)])
         # usvl -> svl: thistransit[fromstate,tostate,:] *=  svlprob
         thistransit[ix_(usvl, svl, arange(npops))]  *= einsum(',k,ij->ijk', svlprob, ones(npops), fromtoarr[ix_(usvl,svl)])
-        print(K, thistransit.sum(axis=(0, 1)))
+        print(K, thistransit.sum(axis=(0, 1)),  people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
         K += 1
         # Check that probabilities all sum to 1
         if debug:
@@ -856,7 +856,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         if t<npts-1:
             people[:,:,t+1] += einsum('ij,ikj->kj',people[:,:,t],thistransit[:,:,:])  # Assuming that there are no illegal tranfers in thistransit
 
-            print('here?', people[2,:,t+1],people[2,[3,4],t+1])
+            print('here?', people[2,:,t+1], thistransit[:,2,:].sum(axis=1))
 
         ##############################################################################################################
         ### Calculate births

--- a/optima/model.py
+++ b/optima/model.py
@@ -663,7 +663,8 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-            print(f'forceinffull t {tvec[t]} ', forceinffull[:,2,:,2], array(popkeys), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
+            print(f'forceinffull t {tvec[t]} ', forceinffull[:,2,:,2], 'asdfas', people[:,2,t], array(popkeys), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
+            # print(f'forceinffull t {tvec[t]} ', forceinffull[:,2,:,2], array(popkeys), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
             # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
             # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), fracactssexarr[i][:,t], wholeactssexarr[i][:,t].astype(int), transsexarr[i][:,t], condarr[i][:,t],  alleff[pop1,t,:],  effallprev[:,pop2])
         if advancedtracking:

--- a/optima/model.py
+++ b/optima/model.py
@@ -663,7 +663,8 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[i][:,t], condarr[i][:,t], alleff[pop1,t,:], effallprev[:,pop2],
                                 (wholeactssexarr[i][:,t].astype(int) != 0) ), wholeactssexarr[i][:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
             forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullsex[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
-            print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), fracactssexarr[i][:,t], wholeactssexarr[i][:,t].astype(int), transsexarr[i][:,t], condarr[i][:,t],  alleff[pop1,t,:],  effallprev[:,pop2])
+            print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), effallprev, pop1, pop2, array(popkeys)[pop1], array(popkeys)[pop2])
+            # print(f'forceinffull t {tvec[t]} ', forceinffull.sum(), fracactssexarr[i][:,t], wholeactssexarr[i][:,t].astype(int), transsexarr[i][:,t], condarr[i][:,t],  alleff[pop1,t,:],  effallprev[:,pop2])
         if advancedtracking:
             forceinffullsexinj[homosexsex,:,homopartnerarr[:,0],:,homopartnerarr[:,1]] = forceinffull[:,homopartnerarr[:,0],:,homopartnerarr[:,1]]
             forceinffullsexinj[heterosexsex,:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]] = forceinffull[:,heteropartnerarr[:,0],:,heteropartnerarr[:,1]]

--- a/optima/model.py
+++ b/optima/model.py
@@ -871,10 +871,10 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
         _all,_allplhiv,_undx,_alldx,_alltx = range(5) # Start with underscore to not override other variables
         numpotmothers = zeros((npops,5))
         numpotmothers[:,_all]      = people[:,:,t].sum(axis=0)
-        numpotmothers[:,_allplhiv] = people[allplhiv,:,t].sum(axis=0)* relhivbirth
-        numpotmothers[:,_undx]     = people[undx,:,t].sum(axis=0)    * relhivbirth
-        numpotmothers[:,_alldx]    = people[alldx,:,t].sum(axis=0)   * relhivbirth
-        numpotmothers[:,_alltx]    = people[alltx,:,t].sum(axis=0)   * relhivbirth
+        numpotmothers[:,_allplhiv] = people[alldx,:,t].sum(axis=0) * relhivbirth + people[undx,:,t].sum(axis=0)
+        numpotmothers[:,_undx]     = people[undx,:,t].sum(axis=0)
+        numpotmothers[:,_alldx]    = people[alldx,:,t].sum(axis=0) * relhivbirth
+        numpotmothers[:,_alltx]    = people[alltx,:,t].sum(axis=0) * relhivbirth
         numpotmothers[notmotherpops,:] = 0
 
         numhivpospregwomen     = numpotmothers[:,_allplhiv] * totalbirthrate
@@ -900,7 +900,7 @@ def model(simpars=None, settings=None, initpeople=None, initprops=None, verbose=
             initrawdiag = raw_diagcd4[:,:,t].sum(axis=(0,1))
 
             numdxforpmtct = 0 #total
-            thispoptobedx = einsum('ij,j->ij',people[undx, :, t],totalbirthrate) * relhivbirth * proptobedx # this is split by cd4 state
+            thispoptobedx = einsum('ij,j->ij',people[undx,:,t], totalbirthrate) * proptobedx # this is split by cd4 state
             if t<npts-1:
                     people[undx, :, t+1] -= thispoptobedx
                     people[dx,   :, t+1] += thispoptobedx

--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -14,6 +14,7 @@ from time import time
 import optima as op # Used by minmoney, at some point should make syntax consistent
 import sciris as sc
 from hashlib import md5
+from traceback import print_exc
 
 # Import dependencies here so no biggie if they fail
 from multiprocessing import Process, Queue
@@ -1347,9 +1348,13 @@ def minoutcomes(project=None, optim=None, tvec=None, absconstraints=None, verbos
             else: not_parsettings = {'parallelizer':'serial-nocopy'}
 
             try: asdrawresults = sc.parallelize(asd, iterkwargs=allargs, ncpus=int(ncpus), **(not_parsettings if not parallel else {}))
-            except AssertionError as e:
+            except Exception as e:
                 parallel = False
-                printv('\nWARNING: Could not run in parallel because this process is already running in parallel. Trying in serial...',1,verbose)
+                if isinstance(e, AssertionError):
+                    printv('\nWARNING: Could not run in parallel because this process is already running in parallel. Trying in serial...',1,verbose)
+                else:
+                    print_exc()
+                    printv('\nWARNING: Could not run in parallel from some unknown error: Trying in serial...',1,verbose)
                 asdrawresults = sc.parallelize(asd, iterkwargs=allargs, ncpus=int(ncpus), **not_parsettings)
 
             if verbose >=3: print(f'\nasd returned best outcomes {list(zip(allbudgetvecs.keys(),[res["fval"] for res in asdrawresults]))}\n')
@@ -1731,10 +1736,14 @@ def minmoney(project=None, optim=None, tvec=None, verbose=None, maxtime=None, fi
                 # Run here in parallel
                 iterkwargs = {'budgetvec': allbudgets, 'printdone': [f'    {key} of {n_throws}' for key in allkeys]}
                 try: all_results_throws = sc.parallelize(op.outcomecalc, iterkwargs=iterkwargs, kwargs=parallelargs, ncpus=int(ncpus))
-                except AssertionError as e:
+                except Exception as e:
                     parallel = False
-                    printv('\nWARNING: Could not run in parallel because this process is already running in parallel. Trying in serial...',1,verbose)
-            if not parallel: all_results_throws = [None]*(n_throws-1)  # Note else in case the above fails
+                    if isinstance(e, AssertionError):
+                        printv('\nWARNING: Could not run in parallel because this process is already running in parallel. Trying in serial...',1,verbose)
+                    else:
+                        print_exc()
+                        printv('\nWARNING: Could not run in parallel from some unknown error: Trying in serial...',1,verbose)
+            if not parallel: all_results_throws = [None]*(n_throws-1)  # Not else in case the above fails
 
             for t,throw in enumerate(range(n_throws-1)): # -1 since include current budget
                 if not parallel: # Run here not in parallel

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1115,8 +1115,8 @@ def balance(act=None, which=None, data=None, popkeys=None, limits=None, popsizep
                     thispoint[pop1,pop2] = (tmpsim[pop1,t]+tmpsim[pop2,t])/2.0
                     thispoint[pop2,pop1] = thispoint[pop1,pop2]
 
-        # if act == 'reg' and which == 'numacts':
-        #     print(f"BALANCE\nmixmatrix\n{mixmatrix}\nthispoint\n{thispoint.round(3)}")
+        if act == 'inj' and which == 'numacts':
+            print(f"BALANCE\nmixmatrix\n{mixmatrix}\nsmatrix\n{smatrix}\nbalancedmatrix\n{balancedmatrix}\nbalancedmatrix.T\n{balancedmatrix.transpose()}\nthispoint\n{thispoint.round(3)}")
 
 
         output[:,:,t] = thispoint

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1382,7 +1382,9 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
     # Loop over requested keys
     for key in keys: # Loop over all keys
         if compareversions(version,"2.12.0") >= 0 and key in ['actsreg', 'actscas', 'actscom', 'actsreginsertive', 'actscasinsertive', 'actscominsertive', 'actsregreceptive', 'actscasreceptive', 'actscomreceptive']:
-            continue  # New behaviour, the above pars are handled in the next loop
+            par = pars[key[0:7]]
+            if hasattr(par, 'insertiveonly') and par.insertiveonly:
+                continue  # New behaviour, the insertiveonly pars are handled in the next loop
         if isinstance(pars[key], Par): # Check that it is actually a parameter -- it could be the popkeys odict, for example
             thissample = sample # Make a copy of it to check it against the list of things we are sampling
             if tosample and tosample[0] is not None and key not in tosample: thissample = False # Don't sample from unselected parameters -- tosample[0] since it's been promoted to a list
@@ -1411,8 +1413,9 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
 
         for key in keys:
             if key in ['actsreg', 'actscas', 'actscom', 'actsreginsertive', 'actscasinsertive', 'actscominsertive', 'actsregreceptive', 'actscasreceptive', 'actscomreceptive']:
-                if 'popsize' not in keys:
-                    raise OptimaException(f'In order to makesimpars for "{key}", "popsize" needs to be in the keys to be included in the simpars.')
+                if not (hasattr(pars[key], 'insertiveonly') and pars[key].insertiveonly):
+                    print(f'WARNING: Acts "{key}" are not "insertiveonly" so these sexual acts will have the old (v2.11.4) non-directional behaviour!')
+                    continue
                 key = key[0:7]
 
                 insertivepar = pars[key]  # actsreg only contains insertive acts, eg. actsreg[(popA, popB)] = c is c insertive acts for each person in popA

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1100,13 +1100,17 @@ def balance(act=None, which=None, data=None, popkeys=None, limits=None, popsizep
             for pop1 in range(npops): smatrix[:,pop1] = psize[pop1]*popacts[pop1]*smatrix[:,pop1] / float(eps+sum(smatrix[:,pop1])) # Divide by the sum of the column to normalize the probability, then multiply by the number of acts and population size to get total number of acts
         
         # Reconcile different estimates of number of acts, which must balance
+        balancedmatrix = zeros((npops, npops))
+        proportioninsertive = zeros((npops, npops))
         thispoint = zeros((npops,npops));
         for pop1 in range(npops):
             for pop2 in range(npops):
                 if which=='numacts':
-                    balanced = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
-                    thispoint[pop2,pop1] = balanced/psize[pop2] # Divide by population size to get per-person estimate
-                    thispoint[pop1,pop2] = balanced/psize[pop1] # ...and for the other population
+                    balancedmatrix[pop1,pop2] = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
+                    proportioninsertive[pop1,pop2] = mixmatrix[pop1,pop2] / (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) \
+                                                            if (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) > 0 else 1.
+                    thispoint[pop1,pop2] = balancedmatrix[pop1,pop2] * proportioninsertive[pop1,pop2] / psize[pop1]
+                    print(popkeys[pop1], popkeys[pop2], f'balancedmatrix[pop1,pop2] {balancedmatrix[pop1,pop2]} proportioninsertive[pop1,pop2] {proportioninsertive[pop1,pop2]} psize[pop1] {psize[pop1]} thispoint[pop1,pop2] {thispoint[pop1,pop2]}')
                 if which=='condom':
                     thispoint[pop1,pop2] = (tmpsim[pop1,t]+tmpsim[pop2,t])/2.0
                     thispoint[pop2,pop1] = thispoint[pop1,pop2]

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1110,16 +1110,13 @@ def balance(act=None, which=None, data=None, popkeys=None, limits=None, popsizep
                     proportioninsertive[pop1,pop2] = mixmatrix[pop1,pop2] / (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) \
                                                             if (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) > 0 else 1.
                     thispoint[pop1,pop2] = balancedmatrix[pop1,pop2] * proportioninsertive[pop1,pop2] / psize[pop1]
-                    print(popkeys[pop1], popkeys[pop2], f'balancedmatrix[pop1,pop2] {balancedmatrix[pop1,pop2]} proportioninsertive[pop1,pop2] {proportioninsertive[pop1,pop2]} psize[pop1] {psize[pop1]} thispoint[pop1,pop2] {thispoint[pop1,pop2]}')
+                    # print(popkeys[pop1], popkeys[pop2], f'balancedmatrix[pop1,pop2] {balancedmatrix[pop1,pop2]} proportioninsertive[pop1,pop2] {proportioninsertive[pop1,pop2]} psize[pop1] {psize[pop1]} thispoint[pop1,pop2] {thispoint[pop1,pop2]}')
                 if which=='condom':
                     thispoint[pop1,pop2] = (tmpsim[pop1,t]+tmpsim[pop2,t])/2.0
                     thispoint[pop2,pop1] = thispoint[pop1,pop2]
-    
-        # if act == 'reg' and which == 'numacts':
-        #     print(f"BALANCE\nmixmatrix\n{mixmatrix}\nsymmetricmatrix\n{symmetricmatrix.round()}\nsmatrix\n{smatrix.round()}\nthispoint\n{thispoint}")
 
-        if act == 'reg' and which == 'numacts':
-            print(f"BALANCE\nmixmatrix\n{mixmatrix}\nthispoint\n{thispoint.round(3)}")
+        # if act == 'reg' and which == 'numacts':
+        #     print(f"BALANCE\nmixmatrix\n{mixmatrix}\nthispoint\n{thispoint.round(3)}")
 
 
         output[:,:,t] = thispoint

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1332,6 +1332,9 @@ def getreceptiveactsfrominsertive(insertivepar, popsizesimpar, popkeys, simparst
         receptivepar.t[reversedpartnership] = times
         receptivepar.y[reversedpartnership] = receptiveactsperB
 
+        print(f'{insertivepar.short} {partnership} Using popsizeA {popsizeA[0]} popsizeB {popsizeB[0]} insertiveactsA {insertivepar.y[partnership][0]} receptiveactsperB {receptiveactsperB[0]} times {times}')
+
+
     return receptivepar
 
 

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1105,6 +1105,13 @@ def balance(act=None, which=None, data=None, popkeys=None, limits=None, popsizep
                     thispoint[pop1,pop2] = (tmpsim[pop1,t]+tmpsim[pop2,t])/2.0
                     thispoint[pop2,pop1] = thispoint[pop1,pop2]
     
+        # if act == 'reg' and which == 'numacts':
+        #     print(f"BALANCE\nmixmatrix\n{mixmatrix}\nsymmetricmatrix\n{symmetricmatrix.round()}\nsmatrix\n{smatrix.round()}\nthispoint\n{thispoint}")
+
+        if act == 'reg' and which == 'numacts':
+            print(f"BALANCE\nmixmatrix\n{mixmatrix}\nthispoint\n{thispoint.round(3)}")
+
+
         output[:,:,t] = thispoint
     
     return output, ctrlpts

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1110,14 +1110,9 @@ def balance(act=None, which=None, data=None, popkeys=None, limits=None, popsizep
                     proportioninsertive[pop1,pop2] = mixmatrix[pop1,pop2] / (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) \
                                                             if (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) > 0 else 1.
                     thispoint[pop1,pop2] = balancedmatrix[pop1,pop2] * proportioninsertive[pop1,pop2] / psize[pop1]
-                    # print(popkeys[pop1], popkeys[pop2], f'balancedmatrix[pop1,pop2] {balancedmatrix[pop1,pop2]} proportioninsertive[pop1,pop2] {proportioninsertive[pop1,pop2]} psize[pop1] {psize[pop1]} thispoint[pop1,pop2] {thispoint[pop1,pop2]}')
                 if which=='condom':
                     thispoint[pop1,pop2] = (tmpsim[pop1,t]+tmpsim[pop2,t])/2.0
                     thispoint[pop2,pop1] = thispoint[pop1,pop2]
-
-        if act == 'inj' and which == 'numacts':
-            print(f"BALANCE\nmixmatrix\n{mixmatrix}\nsmatrix\n{smatrix}\nbalancedmatrix\n{balancedmatrix}\nbalancedmatrix.T\n{balancedmatrix.transpose()}\nthispoint\n{thispoint.round(3)}")
-
 
         output[:,:,t] = thispoint
     
@@ -1417,6 +1412,7 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
                 errormsg = 'Could not figure out how to interpolate parameter "%s"' % key
                 errormsg += 'Error: "%s"' % repr(E)
                 raise OptimaException(errormsg)
+
 
     return simpars
 

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1089,10 +1089,13 @@ def balance(act=None, which=None, data=None, popkeys=None, limits=None, popsizep
         if which=='numacts':
             smatrix = dcp(symmetricmatrix) # Initialize
             psize = popsize[:,t]
-            popsize_div_mean_2d = psize[:,None] / psize.max() # divide by max is just so numbers don't blow up / shrink causing roundoff errors
             popacts = tmpsim[:,t]
 
-            smatrix = smatrix / multiply(popsize_div_mean_2d,popsize_div_mean_2d.T) # divide the partnership a,b by the product of the popsizes a,b
+            ## The below commented out code makes it so that the numbers in the Partnership matrices in the databook
+            ## don't get multiplied by popsizes before being balanced
+            # popsize_div_mean_2d = psize[:,None] / psize.max() # divide by max is just so numbers don't blow up / shrink causing roundoff errors
+            # smatrix = smatrix / multiply(popsize_div_mean_2d,popsize_div_mean_2d.T) # divide the partnership a,b by the product of the popsizes a,b
+
             for pop1 in range(npops): smatrix[pop1,:] = smatrix[pop1,:]*psize[pop1] # Yes, this needs to be separate! Don't try to put in the next for loop, the indices are opposite!
             for pop1 in range(npops): smatrix[:,pop1] = psize[pop1]*popacts[pop1]*smatrix[:,pop1] / float(eps+sum(smatrix[:,pop1])) # Divide by the sum of the column to normalize the probability, then multiply by the number of acts and population size to get total number of acts
         

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -6,7 +6,7 @@ parameters, the Parameterset class.
 Version: 2.1 (2017apr04)
 """
 
-from numpy import array, nan, isnan, isfinite, zeros, ones, argmax, mean, log, polyfit, exp, maximum, minimum, Inf, linspace, median, shape, append, logical_and, isin
+from numpy import array, nan, isnan, isfinite, zeros, ones, argmax, mean, log, polyfit, exp, maximum, minimum, Inf, linspace, median, shape, append, logical_and, isin, multiply
 from numpy.random import uniform, normal, seed
 from optima import OptimaException, version, compareversions, Link, odict, dataframe, printv, sanitize, uuid, today, getdate, makefilepath, smoothinterp, dcp, defaultrepr, isnumber, findinds, findnearest, getvaliddata, promotetoarray, promotetolist, inclusiverange # Utilities
 from optima import Settings, getresults, convertlimits, gettvecdt, loadpartable, loadtranstable # Heftier functions
@@ -1089,7 +1089,10 @@ def balance(act=None, which=None, data=None, popkeys=None, limits=None, popsizep
         if which=='numacts':
             smatrix = dcp(symmetricmatrix) # Initialize
             psize = popsize[:,t]
+            popsize_div_mean_2d = psize[:,None] / psize.max() # divide by max is just so numbers don't blow up / shrink causing roundoff errors
             popacts = tmpsim[:,t]
+
+            smatrix = smatrix / multiply(popsize_div_mean_2d,popsize_div_mean_2d.T) # divide the partnership a,b by the product of the popsizes a,b
             for pop1 in range(npops): smatrix[pop1,:] = smatrix[pop1,:]*psize[pop1] # Yes, this needs to be separate! Don't try to put in the next for loop, the indices are opposite!
             for pop1 in range(npops): smatrix[:,pop1] = psize[pop1]*popacts[pop1]*smatrix[:,pop1] / float(eps+sum(smatrix[:,pop1])) # Divide by the sum of the column to normalize the probability, then multiply by the number of acts and population size to get total number of acts
         

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1400,13 +1400,13 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
         for key in ['actsreg', 'actscas', 'actscom']:
             for times in pars[key].t.values():
                 alltimes.update(set(times))
-        alltimes = array(sorted(list(alltimes)))
+        list_times = linspace(min(alltimes), max(alltimes),num=(int(max(alltimes)/dt)-int(min(alltimes)/dt)+1))
 
         popsizesample = sample
         if tosample and tosample[0] is not None and 'popsize' not in tosample: popsizesample = False
 
         if len(alltimes):
-            popsizeinterped = pars['popsize'].interp(tvec=alltimes, dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=True, sample=popsizesample, randseed=randseed)
+            popsizeinterped = pars['popsize'].interp(tvec=list_times, dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=True, sample=popsizesample, randseed=randseed)
         else: popsizeinterped = None
 
         for key in keys:
@@ -1416,7 +1416,7 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
                 key = key[0:7]
 
                 insertivepar = pars[key]  # actsreg only contains insertive acts, eg. actsreg[(popA, popB)] = c is c insertive acts for each person in popA
-                receptivepar = getreceptiveactsfrominsertive(insertivepar, alltimes, popsizeinterped, popkeys=popkeys)
+                receptivepar = getreceptiveactsfrominsertive(insertivepar, list_times, popsizeinterped, popkeys=popkeys)
 
                 insertivekey = key + 'insertive'
                 receptivekey = key + 'receptive'

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1341,7 +1341,7 @@ def getreceptiveactsfrominsertive(insertivepar, popsizepar, popkeys, popsizeargs
         alltimes.update(set(times))
     alltimes = array(sorted(list(alltimes)))
 
-    if alltimes:
+    if len(alltimes):
         popsizesimpar = popsizepar.interp(tvec=alltimes, **popsizeargs)
 
         for partnership, times in insertivepar.t.items():

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1303,10 +1303,11 @@ def makepars(data=None, verbose=2, die=True, fixprops=None):
                     pars[actsname].y[(key1,key2)] = array(tmpacts[act])[i,j,:]
                     pars[actsname].t[(key1,key2)] = array(tmpactspts[act])
                     if act!='inj':
-                        if key1 in mpopkeys or key1 not in fpopkeys: # For condom use, only store one of the pair -- and store male first -- WARNING, would this fail with multiple MSM populations?
-                            pars[condname].y[(key1,key2)] = array(tmpcond[act])[i,j,:]
-                            pars[condname].t[(key1,key2)] = array(tmpcondpts[act])
-    
+                        if (key2, key1) not in pars[condname].y.keys(): # For condom use, only store one of the pair
+                            if not (key1 in fpopkeys and key2 in mpopkeys):  # Store as (M,F) not (F,M) -- WARNING (F,F) partnerships are likely to cause errors elsewhere in the code, not here though
+                                pars[condname].y[(key1,key2)] = array(tmpcond[act])[i,j,:]
+                                pars[condname].t[(key1,key2)] = array(tmpcondpts[act])
+
     # Store information about injecting populations -- needs to be here since relies on other calculations
     pars['injects'] = array([pop in [pop1 for (pop1,pop2) in pars['actsinj'].keys()] for pop in pars['popkeys']])
     

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1063,7 +1063,7 @@ def balance(act=None, which=None, data=None, popkeys=None, fpopkeys=None, mpopke
             if which=='numacts': symmetricmatrix[pop1,pop2] = symmetricmatrix[pop1,pop2] + (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) / float(eps+((mixmatrix[pop1,pop2]>0)+(mixmatrix[pop2,pop1]>0)))
             if which=='condom': symmetricmatrix[pop1,pop2] = bool(symmetricmatrix[pop1,pop2] + mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1])
 
-    if which == 'numacts': # Check for F->M acts and F->F acts
+    if which == 'numacts' and act != 'inj': # Check for F->M acts and F->F acts
         for pop1 in range(npops):
             for pop2 in range(npops):
                 if mixmatrix[pop1,pop2] > 0 and popkeys[pop1] in fpopkeys:

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1332,7 +1332,8 @@ def getreceptiveactsfrominsertive(insertivepar, popsizesimpar, popkeys, simparst
         receptivepar.t[reversedpartnership] = times
         receptivepar.y[reversedpartnership] = receptiveactsperB
 
-        print(f'{insertivepar.short} {partnership} Using popsizeA {popsizeA[0]} popsizeB {popsizeB[0]} insertiveactsA {insertivepar.y[partnership][0]} receptiveactsperB {receptiveactsperB[0]} times {times}')
+        print(f'{insertivepar.short} {partnership} {popsizesimpar[popkeys.index(partnership[0]),:]} {popsizesimpar[popkeys.index(partnership[1]),:]}')
+        print(f'{insertivepar.short} {partnership} Using popsizeA {popsizeA} popsizeB {popsizeB} insertiveactsA {insertivepar.y[partnership][0]} receptiveactsperB {receptiveactsperB[0]} times {times}')
 
 
     return receptivepar

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1327,6 +1327,10 @@ def makepars(data=None, verbose=2, die=True, fixprops=None):
                             pars[condname].y[(key1,key2)] = array(tmpcond[act])[i,j,:]
                             pars[condname].t[(key1,key2)] = array(tmpcondpts[act])
 
+    insertiveonly = True if compareversions(version,"2.12.0") >= 0 else False
+    for act in ['reg', 'cas', 'com']:
+        pars['acts'+act].insertiveonly = insertiveonly # So that the model knows whether or not to use the new behaviour
+
     # Store information about injecting populations -- needs to be here since relies on other calculations
     pars['injects'] = array([pop in [pop1 for (pop1,pop2) in pars['actsinj'].keys()] for pop in pars['popkeys']])
     

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1330,7 +1330,6 @@ def getreceptiveactsfrominsertive(insertivepar, popsizepar, popkeys, popsizeargs
 
         for partnership, times in insertivepar.t.items():
             timeinds = findnearest(alltimes, times)
-            # print(partnership, times,alltimes[timeinds])
             popsizeA = popsizesimpar[popkeys.index(partnership[0])][timeinds]
             popsizeB = popsizesimpar[popkeys.index(partnership[1])][timeinds]
 
@@ -1338,10 +1337,6 @@ def getreceptiveactsfrominsertive(insertivepar, popsizepar, popkeys, popsizeargs
             reversedpartnership = (partnership[1], partnership[0])
             receptivepar.t[reversedpartnership] = times
             receptivepar.y[reversedpartnership] = receptiveactsperB
-
-            # print(f'{insertivepar.short} {partnership} {popsizesimpar[popkeys.index(partnership[0]),:]} {popsizesimpar[popkeys.index(partnership[1]),:]}')
-            # print(f'{insertivepar.short} {partnership} Using popsizeA {popsizeA} popsizeB {popsizeB} insertiveactsA {insertivepar.y[partnership][0]} receptiveactsperB {receptiveactsperB[0]} times {times}')
-
 
     return receptivepar
 

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1105,12 +1105,12 @@ def balance(act=None, which=None, data=None, popkeys=None, limits=None, popsizep
         thispoint = zeros((npops,npops));
         for pop1 in range(npops):
             for pop2 in range(npops):
-                if which=='numacts' and act != 'inj':
+                if which=='numacts' and act != 'inj': # The total number of acts = insertive + receptive, we only keep insertive in actsreg etc
                     balancedmatrix[pop1,pop2] = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
                     proportioninsertive[pop1,pop2] = mixmatrix[pop1,pop2] / (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) \
                                                             if (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) > 0 else 1.
                     thispoint[pop1,pop2] = balancedmatrix[pop1,pop2] * proportioninsertive[pop1,pop2] / psize[pop1]
-                if which=='numacts' and act == 'inj':
+                if which=='numacts' and act == 'inj': # We want the total number of acts = total number of injections, so we keep all
                     balanced = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
                     thispoint[pop1,pop2] = balanced/psize[pop1]
                 if which=='condom':

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1105,11 +1105,14 @@ def balance(act=None, which=None, data=None, popkeys=None, limits=None, popsizep
         thispoint = zeros((npops,npops));
         for pop1 in range(npops):
             for pop2 in range(npops):
-                if which=='numacts':
+                if which=='numacts' and act != 'inj':
                     balancedmatrix[pop1,pop2] = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
                     proportioninsertive[pop1,pop2] = mixmatrix[pop1,pop2] / (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) \
                                                             if (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) > 0 else 1.
                     thispoint[pop1,pop2] = balancedmatrix[pop1,pop2] * proportioninsertive[pop1,pop2] / psize[pop1]
+                if which=='numacts' and act == 'inj':
+                    balanced = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
+                    thispoint[pop1,pop2] = balanced/psize[pop1]
                 if which=='condom':
                     thispoint[pop1,pop2] = (tmpsim[pop1,t]+tmpsim[pop2,t])/2.0
                     thispoint[pop2,pop1] = thispoint[pop1,pop2]

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1332,7 +1332,7 @@ def makepars(data=None, verbose=2, die=True, fixprops=None):
     
     return pars
 
-def getreceptiveactsfrominsertive(insertivepar, popsizetimes, popsizeinterped, popkeys, popsizeargs):
+def getreceptiveactsfrominsertive(insertivepar, popsizetimes, popsizeinterped, popkeys):
     receptivepar = cp(insertivepar)
     receptivepar.t = odict()
     receptivepar.y = odict()
@@ -1416,7 +1416,7 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
                 key = key[0:7]
 
                 insertivepar = pars[key]  # actsreg only contains insertive acts, eg. actsreg[(popA, popB)] = c is c insertive acts for each person in popA
-                receptivepar = getreceptiveactsfrominsertive(insertivepar, alltimes, popsizeinterped, popkeys=popkeys, popsizeargs=popsizeargs)
+                receptivepar = getreceptiveactsfrominsertive(insertivepar, alltimes, popsizeinterped, popkeys=popkeys)
 
                 insertivekey = key + 'insertive'
                 receptivekey = key + 'receptive'

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1115,14 +1115,21 @@ def balance(act=None, which=None, data=None, popkeys=None, fpopkeys=None, mpopke
         thispoint = zeros((npops,npops));
         for pop1 in range(npops):
             for pop2 in range(npops):
-                if which=='numacts' and act != 'inj': # The total number of acts = insertive + receptive, we only keep insertive in actsreg etc
-                    balancedmatrix[pop1,pop2] = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
-                    proportioninsertive[pop1,pop2] = mixmatrix[pop1,pop2] / (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) \
-                                                            if (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) > 0 else 1.
-                    thispoint[pop1,pop2] = balancedmatrix[pop1,pop2] * proportioninsertive[pop1,pop2] / psize[pop1]
-                if which=='numacts' and act == 'inj': # We want the total number of acts = total number of injections, so we keep all
-                    balanced = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
-                    thispoint[pop1,pop2] = balanced/psize[pop1]
+                if compareversions(version,"2.12.0") >= 0: # New behaviour
+                    if which=='numacts' and act != 'inj': # The total number of acts = insertive + receptive, we only keep insertive in actsreg etc
+                        balancedmatrix[pop1,pop2] = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
+                        proportioninsertive[pop1,pop2] = mixmatrix[pop1,pop2] / (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) \
+                                                                if (mixmatrix[pop1,pop2] + mixmatrix[pop2,pop1]) > 0 else 1.
+                        thispoint[pop1,pop2] = balancedmatrix[pop1,pop2] * proportioninsertive[pop1,pop2] / psize[pop1]
+                    if which=='numacts' and act == 'inj': # We want the total number of acts = total number of injections, so we keep all
+                        balanced = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
+                        thispoint[pop1,pop2] = balanced/psize[pop1]
+                else: # Old behaviour
+                    if which=='numacts':
+                        balanced = (smatrix[pop1,pop2] * psize[pop1] + smatrix[pop2,pop1] * psize[pop2])/(psize[pop1]+psize[pop2]) # here are two estimates for each interaction; reconcile them here
+                        thispoint[pop2,pop1] = balanced/psize[pop2] # Divide by population size to get per-person estimate
+                        thispoint[pop1,pop2] = balanced/psize[pop1] # ...and for the other population
+
                 if which=='condom':
                     thispoint[pop1,pop2] = (tmpsim[pop1,t]+tmpsim[pop2,t])/2.0
                     thispoint[pop2,pop1] = thispoint[pop1,pop2]
@@ -1379,47 +1386,49 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
 
     # Loop over requested keys
     for key in keys: # Loop over all keys
-        if key not in ['actsreg', 'actscas', 'actscom', 'actsreginsertive', 'actscasinsertive', 'actscominsertive', 'actsregreceptive', 'actscasreceptive', 'actscomreceptive']:
-            if isinstance(pars[key], Par): # Check that it is actually a parameter -- it could be the popkeys odict, for example
-                thissample = sample # Make a copy of it to check it against the list of things we are sampling
-                if tosample and tosample[0] is not None and key not in tosample: thissample = False # Don't sample from unselected parameters -- tosample[0] since it's been promoted to a list
-                try:
-                    simpars[key] = pars[key].interp(tvec=simpars['tvec'], dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=asarray, sample=thissample, randseed=randseed)
-                except OptimaException as E:
-                    errormsg = 'Could not figure out how to interpolate parameter "%s"' % key
-                    errormsg += 'Error: "%s"' % repr(E)
-                    raise OptimaException(errormsg)
-
-    # Special treatment for actsreg, actscas, actscom because they contain only insertive acts and so we need to calculate the receptive acts
-    for key in keys:
-        if key in ['actsreg', 'actscas', 'actscom', 'actsreginsertive', 'actscasinsertive', 'actscominsertive', 'actsregreceptive', 'actscasreceptive', 'actscomreceptive']:
-            if 'popsize' not in keys:
-                raise OptimaException(f'In order to makesimpars for "{key}", "popsize" needs to be in the keys to be included in the simpars.')
-            key = key[0:7]
-
-            popsizesample = sample
-            if tosample and tosample[0] is not None and 'popsize' not in tosample: popsizesample = False
-            popsizeargs = {'dt':dt, 'popkeys':popkeys, 'smoothness':smoothness, 'asarray':asarray, 'sample':popsizesample, 'randseed':randseed}
-
-            insertivepar = pars[key]  # actsreg only contains insertive acts, eg. actsreg[(popA, popB)] = c is c insertive acts for each person in popA
-            receptivepar = getreceptiveactsfrominsertive(insertivepar, pars['popsize'], popkeys=popkeys, popsizeargs=popsizeargs)
-
-            insertivekey = key + 'insertive'
-            receptivekey = key + 'receptive'
-
-            insertivesample, receptivesample = sample, sample
-            if tosample and tosample[0] is not None: # We have a list of keys to check
-                thissample = key in tosample
-                insertivesample = thissample or insertivekey in tosample
-                receptivesample = thissample or receptivekey in tosample
-
+        if compareversions(version,"2.12.0") >= 0 and key in ['actsreg', 'actscas', 'actscom', 'actsreginsertive', 'actscasinsertive', 'actscominsertive', 'actsregreceptive', 'actscasreceptive', 'actscomreceptive']:
+            continue  # New behaviour, the above pars are handled in the next loop
+        if isinstance(pars[key], Par): # Check that it is actually a parameter -- it could be the popkeys odict, for example
+            thissample = sample # Make a copy of it to check it against the list of things we are sampling
+            if tosample and tosample[0] is not None and key not in tosample: thissample = False # Don't sample from unselected parameters -- tosample[0] since it's been promoted to a list
             try:
-                simpars[insertivekey] = insertivepar.interp(sample=insertivesample, tvec=simpars['tvec'], dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=asarray, randseed=randseed)
-                simpars[receptivekey] = receptivepar.interp(sample=receptivesample, tvec=simpars['tvec'], dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=asarray, randseed=randseed)
+                simpars[key] = pars[key].interp(tvec=simpars['tvec'], dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=asarray, sample=thissample, randseed=randseed)
             except OptimaException as E:
                 errormsg = 'Could not figure out how to interpolate parameter "%s"' % key
                 errormsg += 'Error: "%s"' % repr(E)
                 raise OptimaException(errormsg)
+
+    if compareversions(version,"2.12.0") >= 0:
+        # Special treatment for actsreg, actscas, actscom because they contain only insertive acts and so we need to calculate the receptive acts
+        for key in keys:
+            if key in ['actsreg', 'actscas', 'actscom', 'actsreginsertive', 'actscasinsertive', 'actscominsertive', 'actsregreceptive', 'actscasreceptive', 'actscomreceptive']:
+                if 'popsize' not in keys:
+                    raise OptimaException(f'In order to makesimpars for "{key}", "popsize" needs to be in the keys to be included in the simpars.')
+                key = key[0:7]
+
+                popsizesample = sample
+                if tosample and tosample[0] is not None and 'popsize' not in tosample: popsizesample = False
+                popsizeargs = {'dt':dt, 'popkeys':popkeys, 'smoothness':smoothness, 'asarray':asarray, 'sample':popsizesample, 'randseed':randseed}
+
+                insertivepar = pars[key]  # actsreg only contains insertive acts, eg. actsreg[(popA, popB)] = c is c insertive acts for each person in popA
+                receptivepar = getreceptiveactsfrominsertive(insertivepar, pars['popsize'], popkeys=popkeys, popsizeargs=popsizeargs)
+
+                insertivekey = key + 'insertive'
+                receptivekey = key + 'receptive'
+
+                insertivesample, receptivesample = sample, sample
+                if tosample and tosample[0] is not None: # We have a list of keys to check
+                    thissample = key in tosample
+                    insertivesample = thissample or insertivekey in tosample
+                    receptivesample = thissample or receptivekey in tosample
+
+                try:
+                    simpars[insertivekey] = insertivepar.interp(sample=insertivesample, tvec=simpars['tvec'], dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=asarray, randseed=randseed)
+                    simpars[receptivekey] = receptivepar.interp(sample=receptivesample, tvec=simpars['tvec'], dt=dt, popkeys=popkeys, smoothness=smoothness, asarray=asarray, randseed=randseed)
+                except OptimaException as E:
+                    errormsg = 'Could not figure out how to interpolate parameter "%s"' % key
+                    errormsg += 'Error: "%s"' % repr(E)
+                    raise OptimaException(errormsg)
 
 
     return simpars

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1325,21 +1325,22 @@ def getreceptiveactsfrominsertive(insertivepar, popsizepar, popkeys, popsizeargs
         alltimes.update(set(times))
     alltimes = array(sorted(list(alltimes)))
 
-    popsizesimpar = popsizepar.interp(tvec=alltimes, **popsizeargs)
+    if alltimes:
+        popsizesimpar = popsizepar.interp(tvec=alltimes, **popsizeargs)
 
-    for partnership, times in insertivepar.t.items():
-        timeinds = findnearest(alltimes, times)
-        # print(partnership, times,alltimes[timeinds])
-        popsizeA = popsizesimpar[popkeys.index(partnership[0])][timeinds]
-        popsizeB = popsizesimpar[popkeys.index(partnership[1])][timeinds]
+        for partnership, times in insertivepar.t.items():
+            timeinds = findnearest(alltimes, times)
+            # print(partnership, times,alltimes[timeinds])
+            popsizeA = popsizesimpar[popkeys.index(partnership[0])][timeinds]
+            popsizeB = popsizesimpar[popkeys.index(partnership[1])][timeinds]
 
-        receptiveactsperB = insertivepar.y[partnership] * popsizeA / popsizeB
-        reversedpartnership = (partnership[1], partnership[0])
-        receptivepar.t[reversedpartnership] = times
-        receptivepar.y[reversedpartnership] = receptiveactsperB
+            receptiveactsperB = insertivepar.y[partnership] * popsizeA / popsizeB
+            reversedpartnership = (partnership[1], partnership[0])
+            receptivepar.t[reversedpartnership] = times
+            receptivepar.y[reversedpartnership] = receptiveactsperB
 
-        # print(f'{insertivepar.short} {partnership} {popsizesimpar[popkeys.index(partnership[0]),:]} {popsizesimpar[popkeys.index(partnership[1]),:]}')
-        # print(f'{insertivepar.short} {partnership} Using popsizeA {popsizeA} popsizeB {popsizeB} insertiveactsA {insertivepar.y[partnership][0]} receptiveactsperB {receptiveactsperB[0]} times {times}')
+            # print(f'{insertivepar.short} {partnership} {popsizesimpar[popkeys.index(partnership[0]),:]} {popsizesimpar[popkeys.index(partnership[1]),:]}')
+            # print(f'{insertivepar.short} {partnership} Using popsizeA {popsizeA} popsizeB {popsizeB} insertiveactsA {insertivepar.y[partnership][0]} receptiveactsperB {receptiveactsperB[0]} times {times}')
 
 
     return receptivepar

--- a/optima/plotting.py
+++ b/optima/plotting.py
@@ -311,44 +311,53 @@ def makeplots(results=None, toplot=None, die=False, verbose=2, plotstartyear=Non
     ## Plot new infections, transitions, deaths and other death, giving total change in PLHIV
     if 'changeinplhivallsources' in toplot:
         toplot.remove('changeinplhivallsources')
-        plots = plotchangeinplhivallsources(results,which='changeinplhivallsources-population+stacked', die=die, fig=fig, **kwargs)
+        plots = plotchangeinplhivallsources(results,which='changeinplhivallsources-population+stacked', die=die,
+                                            plotstartyear=plotstartyear, plotendyear=plotendyear,fig=fig, **kwargs)
         allplots.update(plots)
     ## Plot new infections, transitions, deaths and other death, giving total change in PLHIV
     if 'changeinplhivallsources-population+stacked' in toplot:
         toplot.remove('changeinplhivallsources-population+stacked')
-        plots = plotchangeinplhivallsources(results,which='changeinplhivallsources-population+stacked', die=die, fig=fig, **kwargs)
+        plots = plotchangeinplhivallsources(results,which='changeinplhivallsources-population+stacked', die=die,
+                                            plotstartyear=plotstartyear, plotendyear=plotendyear, fig=fig, **kwargs)
         allplots.update(plots)
     ## Plot new infections, transitions, deaths and other death, giving total change in PLHIV
     if 'changeinplhivallsources-stacked' in toplot:
         toplot.remove('changeinplhivallsources-stacked')
-        plots = plotchangeinplhivallsources(results,which='changeinplhivallsources-stacked', die=die, fig=fig, **kwargs)
+        plots = plotchangeinplhivallsources(results,which='changeinplhivallsources-stacked', die=die, plotstartyear=plotstartyear,
+                                            plotendyear=plotendyear, fig=fig, **kwargs)
         allplots.update(plots)
     ## Plot new infections, transitions, deaths and other death, giving total change in PLHIV
     if 'plhivallsources' in toplot:
         toplot.remove('plhivallsources')
-        plots = plotchangeinplhivallsources(results, which='plhivallsources-population+stacked', die=die, fig=fig,**kwargs)
+        plots = plotchangeinplhivallsources(results, which='plhivallsources-population+stacked', die=die,
+                                            plotstartyear=plotstartyear, plotendyear=plotendyear, fig=fig,**kwargs)
         allplots.update(plots)
     if 'plhivallsources-population+stacked' in toplot:
         toplot.remove('plhivallsources-population+stacked')
-        plots = plotchangeinplhivallsources(results, which='plhivallsources-population+stacked', die=die, fig=fig,**kwargs)
+        plots = plotchangeinplhivallsources(results, which='plhivallsources-population+stacked', die=die, plotstartyear=plotstartyear,
+                                            plotendyear=plotendyear,fig=fig,**kwargs)
         allplots.update(plots)
     if 'plhivallsources-stacked' in toplot:
         toplot.remove('plhivallsources-stacked')
-        plots = plotchangeinplhivallsources(results, which='plhivallsources-stacked', die=die, fig=fig,**kwargs)
+        plots = plotchangeinplhivallsources(results, which='plhivallsources-stacked', die=die, plotstartyear=plotstartyear,
+                                            plotendyear=plotendyear, fig=fig,**kwargs)
         allplots.update(plots)
 
     ## Plot infections by method of transmission, and by population
     if 'numincimethods' in toplot:
         toplot.remove('numincimethods')  # Because everything else is passed to plotepi()
-        plots = plotbymethod(results, toplot='numincimethods', die=die, fig=fig, **kwargs)
+        plots = plotbymethod(results, toplot='numincimethods', die=die, fig=fig, plotstartyear=plotstartyear,
+                             plotendyear=plotendyear, **kwargs)
         allplots.update(plots)
     if 'numincimethods-population+stacked' in toplot:
         toplot.remove('numincimethods-population+stacked')  # Because everything else is passed to plotepi()
-        plots = plotbymethod(results, toplot='numincimethods-population+stacked', die=die, fig=fig, **kwargs)
+        plots = plotbymethod(results, toplot='numincimethods-population+stacked', die=die, fig=fig,
+                             plotstartyear=plotstartyear, plotendyear=plotendyear, **kwargs)
         allplots.update(plots)
     if 'numincimethods-stacked' in toplot:
         toplot.remove('numincimethods-stacked')  # Because everything else is passed to plotepi()
-        plots = plotbymethod(results, toplot='numincimethods-stacked', die=die, fig=fig, **kwargs)
+        plots = plotbymethod(results, toplot='numincimethods-stacked', die=die, fig=fig, plotstartyear=plotstartyear,
+                             plotendyear=plotendyear, **kwargs)
         allplots.update(plots)
 
 

--- a/optima/project.py
+++ b/optima/project.py
@@ -501,6 +501,7 @@ class Project(object):
                     if key!='initprev' or resetprevalence: # Initial prevalence is a special case: the only user-edited parameter that is also a data parameter
                         if hasattr(parset.pars[key],'y'): parset.pars[key].y = origparset.pars[key].y # Reset y (value) variable, if it exists
                         if hasattr(parset.pars[key],'t'): parset.pars[key].t = origparset.pars[key].t # Reset t (time) variable, if it exists
+                        if hasattr(parset.pars[key],'insertiveonly'): parset.pars[key].insertiveonly = origparset.pars[key].insertiveonly # Special to actsreg, actscas, actscom
                 # Reset transition matrices
                 if key in ['birthtransit','agetransit','risktransit']: 
                     parset.pars[key] = dcp(origparset.pars[key])

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,2 +1,2 @@
-version = "2.12.0"
+version = "2.11.4"
 versiondate = "2023-02-07"

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,2 +1,2 @@
-version = "2.12.0"
-versiondate = "2023-03-10"
+version = "2.11.4"
+versiondate = "2023-02-07"

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,2 +1,2 @@
-version = "2.11.4"
+version = "2.12.0"
 versiondate = "2023-02-07"

--- a/tests/benchmarkoptimization.py
+++ b/tests/benchmarkoptimization.py
@@ -23,10 +23,10 @@ n_benchmark = 10  # Number of times to run the cpu benchmark
 n_runsim = 1     # Number of times to run the model
 
 # If running profiling, choose which function to line profile.
-functiontoprofile = 'outcomecalc' # Choices are: P_optimize, optimize, minoutcomes, outcomecalc, runsim, makesimpars, getpars, getouctomes, progs_by_targetpar
+functiontoprofile = 'makesimpars' # Choices are: P_optimize, optimize, minoutcomes, outcomecalc, runsim, makesimpars, getpars, getouctomes, progs_by_targetpar
 tobenchmark = 'runsim' # Choices are 'runsim' or 'runbudget'
 
-args = {'multi':False,'nchains':2, 'nblocks':None, 'blockiters':20,'maxiters':20,'maxtime':100,'randseed':5,'mc':0}
+args = {'multi':False,'maxtime':10,'randseed':5,'parallel':False}
 
 
 ############################################################################################################################
@@ -102,6 +102,7 @@ if doprofile:
     from line_profiler import LineProfiler
     from optima.optimization import minoutcomes
     from optima import Project, Optim, optimize,model,makesimpars, applylimits,asd,outcomecalc,Programset,Program,convertlimits, smoothinterp# analysis:ignore -- called by eval() function
+    from optima.parameters import getreceptiveactsfrominsertive
     # P = Project(spreadsheet='generalized.xlsx', dorun=False)
 
     from hiv_utils import *


### PR DESCRIPTION
Finished version of https://github.com/optimamodel/optima/pull/1891

Adds a migration so that results using previous parsets are not changed - only changed a small amount by the PMTCT changes if you are using 2.12.0 or later. Only uses the new directional partnerships if you recreate the parset from the data - pars['actsreg'].insertiveonly is the attribute which determines whether the old or new behaviour.

Directionality in the Partnerships matrices is now observed. If both directions are put in the matrix then the ratio of the two directions in the matrix gives the ratio of the insertive acts.

Plus relhivbirth only applies to diagnosed mothers with HIV, not all PLHIV, and not those diagnosed by ANC