### PR TITLE
(2) Improve export data for scenarios and optimizations and parallel scenarios

### DIFF
--- a/optima/optimization.py
+++ b/optima/optimization.py
@@ -6,7 +6,7 @@ Version: 2019dec02
 
 from optima import OptimaException, Link, Multiresultset, ICER, asd, getresults # Main functions
 from optima import printv, dcp, odict, findinds, today, getdate, uuid, objrepr, promotetoarray, findnearest, sanitize, \
-    inclusiverange, sigfig, compareversions # Utilities
+    inclusiverange, sigfig, compareversions, cpu_count # Utilities
 
 from numpy import zeros, ones, empty, arange, array, inf, isfinite, argmin, argsort, nan, floor, concatenate, exp, sqrt, logical_and, ceil
 from numpy.random import random, seed, randint
@@ -809,7 +809,7 @@ def optimize(optim=None, maxiters=None, maxtime=None, finishtime=None, verbose=2
     # Set defaults
     if sc.isnumber(mc): mc = (1,0,mc)
     elif mc is None or sum(mc) == 0: mc = (1,0,0) # Default to just running from Optimization baseline
-    if ncpus is None: ncpus = int(ceil( sc.cpu_count()/2 ))
+    if ncpus is None: ncpus = int(ceil( cpu_count()/2 ))
 
     # Optim structure validation
     progset = project.progsets[optim.progsetname] # Link to the original parameter set
@@ -887,7 +887,7 @@ def multioptimize(optim=None, nchains=None, nblocks=None, blockiters=None, mc=No
     if maxiters is None: maxiters = 5000
     if sc.isnumber(mc): mc = (1,0,mc)
     elif mc is None or sum(mc) == 0: mc = (1,0,0) # Default to just running from Optimization baseline
-    if ncpus is None:    ncpus    = int(ceil( sc.cpu_count()/2 ))
+    if ncpus is None:    ncpus    = int(ceil( cpu_count()/2 ))
     if parallel is None: parallel = True  # The individual chains should also run in parallel if there are enough cpus
     chaincpus = int(ceil( ncpus/nchains ))
 
@@ -1019,7 +1019,7 @@ def tvoptimize(project=None, optim=None, tvec=None, verbose=None, maxtime=None, 
     # Set defaults
     if sc.isnumber(mc): mc = (1,0,mc)
     elif mc is None or sum(mc) == 0: mc = (1,0,0) # Default to just running from Optimization baseline
-    if ncpus is None: ncpus = int(ceil( sc.cpu_count()/2 ))
+    if ncpus is None: ncpus = int(ceil( cpu_count()/2 ))
 
     # Do a preliminary non-time-varying optimization
     optim.tvsettings['timevarying'] = False # Turn off for the first run
@@ -1155,7 +1155,7 @@ def minoutcomes(project=None, optim=None, tvec=None, absconstraints=None, verbos
     if project is None or optim is None: raise OptimaException('An optimization requires both a project and an optimization object to run')
     if randseed is None: randseed = randint(2**31)
     if absconstraints is None: absconstraints = optim.getabsconstraints()
-    if ncpus is None: ncpus = int(ceil( sc.cpu_count()/2 ))
+    if ncpus is None: ncpus = int(ceil( cpu_count()/2 ))
     if not parallel: ncpus = 1
     if sc.isnumber(mc): mc = (1,0,mc)
     elif mc is None or sum(mc) == 0: mc = (1,0,0) # Default to just running from Optimization baseline
@@ -1499,7 +1499,7 @@ def minmoney(project=None, optim=None, tvec=None, verbose=None, maxtime=None, fi
     if n_success is None: n_success = max(200 ,nprogs*20) # The number of successes needed to terminate the throws
     if n_refine  is None: n_refine  = 2000  # The maximum number of refinement steps to take
     if schedule  is None: schedule  = [0.3, 0.6, 0.8, 0.9, 1.0] # The budget amounts to allocate on each round
-    if ncpus     is None: ncpus     = int(ceil(sc.cpu_count() / 2))
+    if ncpus     is None: ncpus     = int(ceil(cpu_count() / 2))
     search_step  = 2.0 # The size of the steps to establish the upper/lower limits for the binary search
     search_tol   = 0.01 # Tolerance of the binary search (maximum difference between upper and lower limits)
     refine_steps = [0.0, 0.5, 0.8, 0.9, 0.95, 0.99]  # During refinement, factor by which to scale programs

--- a/optima/project.py
+++ b/optima/project.py
@@ -1040,7 +1040,7 @@ class Project(object):
         # Set defaults
         if sc.isnumber(mc): mc = (1,0,mc)
         elif mc is None or sum(mc) == 0: mc = (3,0,0)
-        if ncpus is None: ncpus = int(ceil( sc.cpu_count()/2 ))
+        if ncpus is None: ncpus = int(ceil( cpu_count()/2 ))
 
         defaultbudget = self.progsets[progsetname].getdefaultbudget()
         

--- a/optima/results.py
+++ b/optima/results.py
@@ -1027,7 +1027,7 @@ class Multiresultset(Resultset):
             outputstr += sep.join(map(str,prog_budgets))
             outputstr += '\n'
         total_budgets = {scen_key: sum(self.budgets[scen_key][:]) for scen_key in scen_keys}
-        outputstr += sep.join(['Budget', 'TOTAL'])
+        outputstr += sep.join(['Budget', 'TOTAL']) + sep
         outputstr += sep.join(map(str, total_budgets.values()))
         outputstr += '\n'+'\n'
 
@@ -1035,7 +1035,7 @@ class Multiresultset(Resultset):
         for prog in all_progs:
             prog_budgets_percent = [self.budgets[scen_key][prog]/total_budgets[scen_key]*100
                                         for scen_key in scen_keys]
-            outputstr += sep.join(['% of budget', prog])
+            outputstr += sep.join(['% of budget', prog]) + sep
             outputstr += sep.join(map(str, prog_budgets_percent))
             outputstr += '\n'
         outputstr += '\n'+'\n'
@@ -1045,19 +1045,20 @@ class Multiresultset(Resultset):
             baseline_prog_budget = self.budgets[baseline_key][prog]
             prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget*100
                                     for scen_key in scen_keys]
-            outputstr += sep.join(['% budget change from baseline', prog])
+            outputstr += sep.join(['% budget change from baseline', prog]) + sep
             outputstr += sep.join(map(str, prog_budgets_percent))
             outputstr += '\n'
         total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key] * 100
                                    for scen_key in scen_keys]
-        outputstr += sep.join(['% budget change from baseline', 'TOTAL'])
+        outputstr += sep.join(['% budget change from baseline', 'TOTAL']) + sep
         outputstr += sep.join(map(str, total_budget_changes))
         outputstr += '\n'+'\n'
 
         # coverage
         for prog in all_progs:
             prog_coverages = [self.coverages[scen_key][prog] for scen_key in scen_keys]
-            outputstr += sep.join(['Coverage', prog])
+            prog_coverages_percent_change = [cov[0] if checktype(cov, 'arraylike') else cov for cov in prog_coverages]
+            outputstr += sep.join(['Coverage', prog]) + sep
             outputstr += sep.join(map(str, prog_coverages))
             outputstr += '\n'
         outputstr += '\n'+'\n'
@@ -1065,9 +1066,12 @@ class Multiresultset(Resultset):
         # % coverage change from baseline
         for prog in all_progs:
             baseline_prog_coverage = self.coverages[baseline_key][prog]
+            if checktype(baseline_prog_coverage, 'arraylike'):
+                baseline_prog_coverage = baseline_prog_coverage[0]  # Only pull out the first element if it's an array/list
             prog_coverages_percent_change = [(self.coverages[scen_key][prog]-baseline_prog_coverage) / baseline_prog_coverage*100
                                     for scen_key in scen_keys]
-            outputstr += sep.join(['% coverage change from baseline', prog])
+            prog_coverages_percent_change = [cov[0] if checktype(cov, 'arraylike') else cov for cov in prog_coverages_percent_change]
+            outputstr += sep.join(['% coverage change from baseline', prog]) + sep
             outputstr += sep.join(map(str, prog_coverages_percent_change))
             outputstr += '\n'
         outputstr += '\n'+'\n'

--- a/optima/results.py
+++ b/optima/results.py
@@ -1019,46 +1019,58 @@ class Multiresultset(Resultset):
 
         # Make the output
         outputstr = sep.join(['Output', 'Programs'] + list(scen_keys))  # Create headers
-        outputstr += '\n'
+        outputstr += '\n'+'\n'
         # Budgets first
         for prog in all_progs:
             prog_budgets = [self.budgets[scen_key][prog] for scen_key in scen_keys]
-            outputstr += sep.join(['Budget', prog] + prog_budgets)
+            outputstr += sep.join(['Budget', prog]) + sep
+            outputstr += sep.join(map(str,prog_budgets))
+            outputstr += '\n'
         total_budgets = {scen_key: sum(self.budgets[scen_key][:]) for scen_key in scen_keys}
-        outputstr += sep.join(['Budget', 'TOTAL'] + total_budgets.values())
-        outputstr += '\n'
+        outputstr += sep.join(['Budget', 'TOTAL'])
+        outputstr += sep.join(map(str, total_budgets.values()))
+        outputstr += '\n'+'\n'
 
         # % of budget
         for prog in all_progs:
             prog_budgets_percent = [self.budgets[scen_key][prog]/total_budgets[scen_key]*100
                                         for scen_key in scen_keys]
-            outputstr += sep.join(['% of budget', prog] + prog_budgets_percent)
-        outputstr += '\n'
+            outputstr += sep.join(['% of budget', prog])
+            outputstr += sep.join(map(str, prog_budgets_percent))
+            outputstr += '\n'
+        outputstr += '\n'+'\n'
 
         # % budget change from baseline
         for prog in all_progs:
             baseline_prog_budget = self.budgets[baseline_key][prog]
             prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget*100
                                     for scen_key in scen_keys]
-            outputstr += sep.join(['% budget change from baseline', prog] + prog_budgets_percent)
+            outputstr += sep.join(['% budget change from baseline', prog])
+            outputstr += sep.join(map(str, prog_budgets_percent))
+            outputstr += '\n'
         total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key] * 100
                                    for scen_key in scen_keys]
-        outputstr += sep.join(['% budget change from baseline', 'TOTAL'] + total_budget_changes)
-        outputstr += '\n'
+        outputstr += sep.join(['% budget change from baseline', 'TOTAL'])
+        outputstr += sep.join(map(str, total_budget_changes))
+        outputstr += '\n'+'\n'
 
         # coverage
         for prog in all_progs:
             prog_coverages = [self.coverages[scen_key][prog] for scen_key in scen_keys]
-            outputstr += sep.join(['Coverage', prog] + prog_coverages)
-        outputstr += '\n'
+            outputstr += sep.join(['Coverage', prog])
+            outputstr += sep.join(map(str, prog_coverages))
+            outputstr += '\n'
+        outputstr += '\n'+'\n'
 
         # % coverage change from baseline
         for prog in all_progs:
             baseline_prog_coverage = self.coverages[baseline_key][prog]
             prog_coverages_percent_change = [(self.coverages[scen_key][prog]-baseline_prog_coverage) / baseline_prog_coverage*100
                                     for scen_key in scen_keys]
-            outputstr += sep.join(['% coverage change from baseline', prog] + prog_coverages_percent)
-        outputstr += '\n'
+            outputstr += sep.join(['% coverage change from baseline', prog])
+            outputstr += sep.join(map(str, prog_coverages_percent_change))
+            outputstr += '\n'
+        outputstr += '\n'+'\n'
 
         # baselinetotal = sum(self.budgets.findbykey('Base').values())
         # optimtotal    = sum(self.budgets.findbykey('Optimized').values())

--- a/optima/results.py
+++ b/optima/results.py
@@ -1032,6 +1032,7 @@ class Multiresultset(Resultset):
             outputstr += sep.join(map(str,prog_budgets))
             outputstr += '\n'
         total_budgets = {scen_key: sum(self.budgets[scen_key][:]) for scen_key in scen_keys}
+        print({scen_key: (self.budgets[scen_key][:]) for scen_key in scen_keys})
         outputstr += sep.join(['Budget', 'TOTAL']) + sep
         outputstr += sep.join(map(str, total_budgets.values()))
         outputstr += '\n'+'\n'

--- a/optima/results.py
+++ b/optima/results.py
@@ -1336,6 +1336,8 @@ def exporttoexcel(filename=None, outdict=None):
 
                 percentincrease = False
                 percentdecrease = False
+                if conditionalcell:
+                    print('conditional cell', conditionalcell, thistxt, type(thistxt))
                 if conditionalcell and thistxt > 0:
                     percentincrease = True
                 elif conditionalcell and thistxt < 0:

--- a/optima/results.py
+++ b/optima/results.py
@@ -1043,12 +1043,12 @@ class Multiresultset(Resultset):
         # % budget change from baseline
         for prog in all_progs:
             baseline_prog_budget = self.budgets[baseline_key][prog]
-            prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget*100
+            prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget
                                     for scen_key in scen_keys]
             outputstr += sep.join(['% budget change from baseline', prog]) + sep
             outputstr += sep.join([str(out)+prcstr+condstr for out in prog_budgets_percent_change])
             outputstr += '\n'
-        total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key] * 100
+        total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key]
                                    for scen_key in scen_keys]
         outputstr += sep.join(['% budget change from baseline', 'TOTAL']) + sep
         outputstr += sep.join([str(out)+prcstr+condstr for out in total_budget_changes])
@@ -1068,7 +1068,7 @@ class Multiresultset(Resultset):
             baseline_prog_coverage = self.coverages[baseline_key][prog]
             if checktype(baseline_prog_coverage, 'arraylike'):
                 baseline_prog_coverage = baseline_prog_coverage[0]  # Only pull out the first element if it's an array/list
-            prog_coverages_percent_change = [(self.coverages[scen_key][prog]-baseline_prog_coverage) / baseline_prog_coverage*100
+            prog_coverages_percent_change = [(self.coverages[scen_key][prog]-baseline_prog_coverage) / baseline_prog_coverage
                                     for scen_key in scen_keys]
             prog_coverages_percent_change = [cov[0] if checktype(cov, 'arraylike') else cov for cov in prog_coverages_percent_change]
             outputstr += sep.join(['% coverage change from baseline', prog]) + sep

--- a/optima/results.py
+++ b/optima/results.py
@@ -1046,12 +1046,12 @@ class Multiresultset(Resultset):
             prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget*100
                                     for scen_key in scen_keys]
             outputstr += sep.join(['% budget change from baseline', prog]) + sep
-            outputstr += ('%'+sep).join(map(str, prog_budgets_percent_change))
+            outputstr += sep.join([str(out)+prcstr+condstr for out in prog_budgets_percent_change])
             outputstr += '\n'
         total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key] * 100
                                    for scen_key in scen_keys]
         outputstr += sep.join(['% budget change from baseline', 'TOTAL']) + sep
-        outputstr += sep.join(map(str, total_budget_changes))
+        outputstr += sep.join([str(out)+prcstr+condstr for out in total_budget_changes])
         outputstr += '\n'+'\n'
 
         # coverage
@@ -1072,7 +1072,7 @@ class Multiresultset(Resultset):
                                     for scen_key in scen_keys]
             prog_coverages_percent_change = [cov[0] if checktype(cov, 'arraylike') else cov for cov in prog_coverages_percent_change]
             outputstr += sep.join(['% coverage change from baseline', prog]) + sep
-            outputstr += sep.join(map(str, prog_coverages_percent_change))
+            outputstr += sep.join([str(out)+prcstr+condstr for out in prog_coverages_percent_change])
             outputstr += '\n'
         outputstr += '\n'+'\n'
 

--- a/optima/results.py
+++ b/optima/results.py
@@ -1003,6 +1003,11 @@ class Multiresultset(Resultset):
         
     def comparebudgets(self, sep=',', sigfigs=3):
         """ Make a separate sheet in the workbook with a comparison of budget and coverage for an optimization or scenarios """
+        def select_zeroth(possible_list):
+            if checktype(possible_list, 'arraylike'):
+                return possible_list[0]  # Only pull out the first element if it's an array/list
+            return possible_list
+
         scen_keys = self.budgets.keys()  # Only include scenarios/results with budgets ie no parameter scenarios
         if len(scen_keys) == 0:
             return None ### Don't put anything if there is no budget scenarios
@@ -1022,7 +1027,7 @@ class Multiresultset(Resultset):
         outputstr += '\n'+'\n'
         # Budgets first
         for prog in all_progs:
-            prog_budgets = [self.budgets[scen_key][prog] for scen_key in scen_keys]
+            prog_budgets = [select_zeroth(self.budgets[scen_key][prog]) for scen_key in scen_keys]
             outputstr += sep.join(['Budget', prog]) + sep
             outputstr += sep.join(map(str,prog_budgets))
             outputstr += '\n'
@@ -1033,7 +1038,7 @@ class Multiresultset(Resultset):
 
         # % of budget
         for prog in all_progs:
-            prog_budgets_percent = [self.budgets[scen_key][prog]/total_budgets[scen_key]*100 if total_budgets[scen_key] >0 else ""
+            prog_budgets_percent = [select_zeroth(self.budgets[scen_key][prog]) / total_budgets[scen_key]*100 if total_budgets[scen_key] >0 else ""
                                         for scen_key in scen_keys]
             outputstr += sep.join(['% of budget', prog]) + sep
             outputstr += sep.join(map(str, prog_budgets_percent))
@@ -1042,8 +1047,8 @@ class Multiresultset(Resultset):
 
         # % budget change from baseline
         for prog in all_progs:
-            baseline_prog_budget = self.budgets[baseline_key][prog]
-            prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget if baseline_prog_budget >0 else ""
+            baseline_prog_budget = select_zeroth(self.budgets[baseline_key][prog])
+            prog_budgets_percent_change = [select_zeroth(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget if baseline_prog_budget > 0 else ""
                                     for scen_key in scen_keys]
             outputstr += sep.join(['% budget change from baseline', prog]) + sep
             outputstr += sep.join([str(out)+prcstr+condstr for out in prog_budgets_percent_change])
@@ -1056,8 +1061,7 @@ class Multiresultset(Resultset):
 
         # coverage
         for prog in all_progs:
-            prog_coverages = [self.coverages[scen_key][prog] for scen_key in scen_keys]
-            prog_coverages = [cov[0] if checktype(cov, 'arraylike') else cov for cov in prog_coverages]
+            prog_coverages = [select_zeroth(self.coverages[scen_key][prog]) for scen_key in scen_keys]
             outputstr += sep.join(['Coverage', prog]) + sep
             outputstr += sep.join(map(str, prog_coverages))
             outputstr += '\n'
@@ -1065,12 +1069,9 @@ class Multiresultset(Resultset):
 
         # % coverage change from baseline
         for prog in all_progs:
-            baseline_prog_coverage = self.coverages[baseline_key][prog]
-            if checktype(baseline_prog_coverage, 'arraylike'):
-                baseline_prog_coverage = baseline_prog_coverage[0]  # Only pull out the first element if it's an array/list
-            prog_coverages_percent_change = [(self.coverages[scen_key][prog]-baseline_prog_coverage) / baseline_prog_coverage
+            baseline_prog_coverage = select_zeroth(self.coverages[baseline_key][prog])
+            prog_coverages_percent_change = [select_zeroth(self.coverages[scen_key][prog]-baseline_prog_coverage) / baseline_prog_coverage
                                     for scen_key in scen_keys]
-            prog_coverages_percent_change = [cov[0] if checktype(cov, 'arraylike') else cov for cov in prog_coverages_percent_change]
             outputstr += sep.join(['% coverage change from baseline', prog]) + sep
             outputstr += sep.join([str(out)+prcstr+condstr for out in prog_coverages_percent_change])
             outputstr += '\n'

--- a/optima/results.py
+++ b/optima/results.py
@@ -1032,18 +1032,20 @@ class Multiresultset(Resultset):
             outputstr += sep.join(map(str,prog_budgets))
             outputstr += '\n'
         total_budgets = {scen_key: select_zeroth(self.budgets[scen_key][:].sum(axis=self.budgets[scen_key][:].ndim-1)) for scen_key in scen_keys}
+        print({scen_key: select_zeroth(self.budgets[scen_key][:].sum(axis=self.budgets[scen_key][:].ndim-1)) for scen_key in scen_keys})
+        print({scen_key: select_zeroth(self.budgets[scen_key][:].sum(axis=0)) for scen_key in scen_keys})
         outputstr += sep.join(['Budget', 'TOTAL']) + sep
         outputstr += sep.join(map(str, total_budgets.values()))
         outputstr += '\n'+'\n'
 
         # % of budget
         for prog in all_progs:
-            prog_budgets_percent = [select_zeroth(self.budgets[scen_key][prog]) / total_budgets[scen_key]*100 if total_budgets[scen_key] >0 else ""
+            prog_budgets_percent = [select_zeroth(self.budgets[scen_key][prog]) / total_budgets[scen_key] if total_budgets[scen_key] >0 else ""
                                         for scen_key in scen_keys]
             outputstr += sep.join(['% of budget', prog]) + sep
-            outputstr += sep.join(map(str, prog_budgets_percent))
+            outputstr += sep.join([str(out)+prcstr for out in prog_budgets_percent])
             outputstr += '\n'
-        outputstr += '\n'+'\n'
+        outputstr += '\n'
 
         # % budget change from baseline
         for prog in all_progs:
@@ -1065,7 +1067,7 @@ class Multiresultset(Resultset):
             outputstr += sep.join(['Coverage', prog]) + sep
             outputstr += sep.join(map(str, prog_coverages))
             outputstr += '\n'
-        outputstr += '\n'+'\n'
+        outputstr += '\n'
 
         # % coverage change from baseline
         for prog in all_progs:
@@ -1075,41 +1077,7 @@ class Multiresultset(Resultset):
             outputstr += sep.join(['% coverage change from baseline', prog]) + sep
             outputstr += sep.join([str(out)+prcstr+condstr for out in prog_coverages_percent_change])
             outputstr += '\n'
-        outputstr += '\n'+'\n'
-
-        # baselinetotal = sum(self.budgets.findbykey('Base').values())
-        # optimtotal    = sum(self.budgets.findbykey('Optimized').values())
-        # for prog, baselinebud in self.budgets.findbykey('Base').items():
-        #     outputstr += '\n'
-        #
-        #     optimbud = self.budgets.findbykey('Optimized')[prog]
-        #     baselinecov = self.coverages.findbykey('Base')[prog]
-        #     if checktype(baselinecov, 'arraylike'):
-        #         baselinecov = baselinecov[0]  # Only pull out the first element if it's an array/list
-        #     if baselinecov is None: baselinecov = 0  # Just reset
-        #     optimcov = self.coverages.findbykey('Optimized')[prog]
-        #     if checktype(optimcov, 'arraylike'):
-        #         optimcov = optimcov[0]  # Only pull out the first element if it's an array/list
-        #     if optimcov is None: optimcov = 0  # Just reset
-        #
-        #     budchange = 0.0  # By default, assume no change
-        #     covchange = 0.0
-        #     if baselinebud > epsbudcov: budchange = (optimbud - baselinebud) / baselinebud  # Ensure budget to divide by is large enough
-        #     if baselinecov > epsbudcov: covchange = (optimcov - baselinecov) / baselinecov
-        #     baselinetotalstr = '%f' % (baselinebud/baselinetotal)
-        #     optimtotalstr    = '%f' % (optimbud/optimtotal)
-        #     covchangestr     = '%f' % covchange
-        #     budchangestr     = '%f' % budchange
-        #     outputstr += sanitizeseps(prog) + sep + str(baselinebud) + sep + \
-        #                  baselinetotalstr + prcstr + sep + \
-        #                  str(optimbud) + sep + \
-        #                  optimtotalstr + prcstr + sep + \
-        #                  budchangestr + prcstr + condstr + sep + \
-        #                  str(baselinecov) + sep + \
-        #                  str(optimcov) + sep + \
-        #                  covchangestr + prcstr + condstr
-        # outputstr += '\n'
-        # outputstr += sep.join(['Total', str(baselinetotal), '', str(optimtotal), '', '', '', '', ''])
+        outputstr += '\n'
 
         return outputstr
 
@@ -1336,8 +1304,6 @@ def exporttoexcel(filename=None, outdict=None):
 
                 percentincrease = False
                 percentdecrease = False
-                if conditionalcell:
-                    print('conditional cell', conditionalcell, thistxt, type(thistxt))
                 if conditionalcell and thistxt > 0:
                     percentincrease = True
                 elif conditionalcell and thistxt < 0:

--- a/optima/results.py
+++ b/optima/results.py
@@ -1057,7 +1057,7 @@ class Multiresultset(Resultset):
         # coverage
         for prog in all_progs:
             prog_coverages = [self.coverages[scen_key][prog] for scen_key in scen_keys]
-            prog_coverages_percent_change = [cov[0] if checktype(cov, 'arraylike') else cov for cov in prog_coverages]
+            prog_coverages = [cov[0] if checktype(cov, 'arraylike') else cov for cov in prog_coverages]
             outputstr += sep.join(['Coverage', prog]) + sep
             outputstr += sep.join(map(str, prog_coverages))
             outputstr += '\n'

--- a/optima/results.py
+++ b/optima/results.py
@@ -1033,7 +1033,7 @@ class Multiresultset(Resultset):
 
         # % of budget
         for prog in all_progs:
-            prog_budgets_percent = [self.budgets[scen_key][prog]/total_budgets[scen_key]*100
+            prog_budgets_percent = [self.budgets[scen_key][prog]/total_budgets[scen_key]*100 if total_budgets[scen_key] >0 else ""
                                         for scen_key in scen_keys]
             outputstr += sep.join(['% of budget', prog]) + sep
             outputstr += sep.join(map(str, prog_budgets_percent))
@@ -1043,12 +1043,12 @@ class Multiresultset(Resultset):
         # % budget change from baseline
         for prog in all_progs:
             baseline_prog_budget = self.budgets[baseline_key][prog]
-            prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget
+            prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget if baseline_prog_budget >0 else ""
                                     for scen_key in scen_keys]
             outputstr += sep.join(['% budget change from baseline', prog]) + sep
             outputstr += sep.join([str(out)+prcstr+condstr for out in prog_budgets_percent_change])
             outputstr += '\n'
-        total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key]
+        total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key]  if total_budgets[baseline_key] > 0 else ""
                                    for scen_key in scen_keys]
         outputstr += sep.join(['% budget change from baseline', 'TOTAL']) + sep
         outputstr += sep.join([str(out)+prcstr+condstr for out in total_budget_changes])

--- a/optima/results.py
+++ b/optima/results.py
@@ -1048,12 +1048,12 @@ class Multiresultset(Resultset):
         # % budget change from baseline
         for prog in all_progs:
             baseline_prog_budget = select_zeroth(self.budgets[baseline_key][prog])
-            prog_budgets_percent_change = [select_zeroth(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget if baseline_prog_budget > 0 else ""
+            prog_budgets_percent_change = [select_zeroth(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget if baseline_prog_budget > 0 else nan
                                     for scen_key in scen_keys]
             outputstr += sep.join(['% budget change from baseline', prog]) + sep
             outputstr += sep.join([str(out)+prcstr+condstr for out in prog_budgets_percent_change])
             outputstr += '\n'
-        total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key]  if total_budgets[baseline_key] > 0 else ""
+        total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key]  if total_budgets[baseline_key] > 0 else nan
                                    for scen_key in scen_keys]
         outputstr += sep.join(['% budget change from baseline', 'TOTAL']) + sep
         outputstr += sep.join([str(out)+prcstr+condstr for out in total_budget_changes])
@@ -1070,7 +1070,7 @@ class Multiresultset(Resultset):
         # % coverage change from baseline
         for prog in all_progs:
             baseline_prog_coverage = select_zeroth(self.coverages[baseline_key][prog])
-            prog_coverages_percent_change = [select_zeroth(self.coverages[scen_key][prog]-baseline_prog_coverage) / baseline_prog_coverage
+            prog_coverages_percent_change = [select_zeroth(self.coverages[scen_key][prog]-baseline_prog_coverage) / baseline_prog_coverage if baseline_prog_coverage > 0 else nan
                                     for scen_key in scen_keys]
             outputstr += sep.join(['% coverage change from baseline', prog]) + sep
             outputstr += sep.join([str(out)+prcstr+condstr for out in prog_coverages_percent_change])

--- a/optima/results.py
+++ b/optima/results.py
@@ -981,9 +981,9 @@ class Multiresultset(Resultset):
                 outputstr += thisoutput
                 outputstr += '\n'*5
 
-        if asexcel and hasattr(self, 'optim'): # Only produce a comparsion if it's an optimization and it's for Excel
+        if asexcel and (hasattr(self, 'optim') or self.name == 'scenarios'): # Only produce a comparsion if it's an optimization or scenarios and it's for Excel
             thisoutput = self.comparebudgets()
-            outputdict['Comparison'] = thisoutput
+            if thisoutput is not None: outputdict['Comparison'] = thisoutput
         
         if writetofile: 
             ext = 'xlsx' if asexcel else 'csv'
@@ -1002,43 +1002,97 @@ class Multiresultset(Resultset):
         
         
     def comparebudgets(self, sep=',', sigfigs=3):
-        """ Make a separate sheet in the workbook with a comparison of budget and coverage for an optimization """
-        outputstr = sep.join(['Programs', 'Baseline budget', '% baseline budget', 
-                              'Optimized budget', '% optimized budget', '% budget change',
-                              'Baseline coverage', 'Optimized coverage', '% coverage change'])  # Create headers
-        baselinetotal = sum(self.budgets.findbykey('Base').values())
-        optimtotal    = sum(self.budgets.findbykey('Optimized').values())
-        for prog, baselinebud in self.budgets.findbykey('Base').items():
-            outputstr += '\n'
+        """ Make a separate sheet in the workbook with a comparison of budget and coverage for an optimization or scenarios """
+        scen_keys = self.budgets.keys()  # Only include scenarios/results with budgets ie no parameter scenarios
+        if len(scen_keys) == 0:
+            return None ### Don't put anything if there is no budget scenarios
+        scen_keys = sorted(scen_keys) # sort alphabetically since baseline < optimization baselin < optimized
 
-            optimbud = self.budgets.findbykey('Optimized')[prog]
-            baselinecov = self.coverages.findbykey('Base')[prog]
-            if checktype(baselinecov, 'arraylike'):
-                baselinecov = baselinecov[0]  # Only pull out the first element if it's an array/list
-            if baselinecov is None: baselinecov = 0  # Just reset
-            optimcov = self.coverages.findbykey('Optimized')[prog]
-            if checktype(optimcov, 'arraylike'):
-                optimcov = optimcov[0]  # Only pull out the first element if it's an array/list
-            if optimcov is None: optimcov = 0  # Just reset
+        baseline_key = self.budgets.findkeys('aseline')  ### Baseline scenario looks for "aseline"
+        baseline_key = baseline_key[0] if len(baseline_key) > 0 else 0
 
-            budchange = 0.0  # By default, assume no change
-            covchange = 0.0
-            if baselinebud > epsbudcov: budchange = (optimbud - baselinebud) / baselinebud  # Ensure budget to divide by is large enough
-            if baselinecov > epsbudcov: covchange = (optimcov - baselinecov) / baselinecov
-            baselinetotalstr = '%f' % (baselinebud/baselinetotal)
-            optimtotalstr    = '%f' % (optimbud/optimtotal)
-            covchangestr     = '%f' % covchange
-            budchangestr     = '%f' % budchange
-            outputstr += sanitizeseps(prog) + sep + str(baselinebud) + sep + \
-                         baselinetotalstr + prcstr + sep + \
-                         str(optimbud) + sep + \
-                         optimtotalstr + prcstr + sep + \
-                         budchangestr + prcstr + condstr + sep + \
-                         str(baselinecov) + sep + \
-                         str(optimcov) + sep + \
-                         covchangestr + prcstr + condstr
+        # Get all the program names as different results might have different program
+        all_progs = set(self.budgets[0].keys())
+        for scen_key in scen_keys:
+            all_progs = all_progs.union(self.budgets[scen_key].keys())
+        all_progs = sorted(all_progs) # Sort in alphabetical order
+
+        # Make the output
+        outputstr = sep.join(['Output', 'Programs'] + list(scen_keys))  # Create headers
         outputstr += '\n'
-        outputstr += sep.join(['Total', str(baselinetotal), '', str(optimtotal), '', '', '', '', ''])
+        # Budgets first
+        for prog in all_progs:
+            prog_budgets = [self.budgets[scen_key][prog] for scen_key in scen_keys]
+            outputstr += sep.join(['Budget', prog] + prog_budgets)
+        total_budgets = {scen_key: sum(self.budgets[scen_key][:]) for scen_key in scen_keys}
+        outputstr += sep.join(['Budget', 'TOTAL'] + total_budgets.values())
+        outputstr += '\n'
+
+        # % of budget
+        for prog in all_progs:
+            prog_budgets_percent = [self.budgets[scen_key][prog]/total_budgets[scen_key]*100
+                                        for scen_key in scen_keys]
+            outputstr += sep.join(['% of budget', prog] + prog_budgets_percent)
+        outputstr += '\n'
+
+        # % budget change from baseline
+        for prog in all_progs:
+            baseline_prog_budget = self.budgets[baseline_key][prog]
+            prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget*100
+                                    for scen_key in scen_keys]
+            outputstr += sep.join(['% budget change from baseline', prog] + prog_budgets_percent)
+        total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key] * 100
+                                   for scen_key in scen_keys]
+        outputstr += sep.join(['% budget change from baseline', 'TOTAL'] + total_budget_changes)
+        outputstr += '\n'
+
+        # coverage
+        for prog in all_progs:
+            prog_coverages = [self.coverages[scen_key][prog] for scen_key in scen_keys]
+            outputstr += sep.join(['Coverage', prog] + prog_coverages)
+        outputstr += '\n'
+
+        # % coverage change from baseline
+        for prog in all_progs:
+            baseline_prog_coverage = self.coverages[baseline_key][prog]
+            prog_coverages_percent_change = [(self.coverages[scen_key][prog]-baseline_prog_coverage) / baseline_prog_coverage*100
+                                    for scen_key in scen_keys]
+            outputstr += sep.join(['% coverage change from baseline', prog] + prog_coverages_percent)
+        outputstr += '\n'
+
+        # baselinetotal = sum(self.budgets.findbykey('Base').values())
+        # optimtotal    = sum(self.budgets.findbykey('Optimized').values())
+        # for prog, baselinebud in self.budgets.findbykey('Base').items():
+        #     outputstr += '\n'
+        #
+        #     optimbud = self.budgets.findbykey('Optimized')[prog]
+        #     baselinecov = self.coverages.findbykey('Base')[prog]
+        #     if checktype(baselinecov, 'arraylike'):
+        #         baselinecov = baselinecov[0]  # Only pull out the first element if it's an array/list
+        #     if baselinecov is None: baselinecov = 0  # Just reset
+        #     optimcov = self.coverages.findbykey('Optimized')[prog]
+        #     if checktype(optimcov, 'arraylike'):
+        #         optimcov = optimcov[0]  # Only pull out the first element if it's an array/list
+        #     if optimcov is None: optimcov = 0  # Just reset
+        #
+        #     budchange = 0.0  # By default, assume no change
+        #     covchange = 0.0
+        #     if baselinebud > epsbudcov: budchange = (optimbud - baselinebud) / baselinebud  # Ensure budget to divide by is large enough
+        #     if baselinecov > epsbudcov: covchange = (optimcov - baselinecov) / baselinecov
+        #     baselinetotalstr = '%f' % (baselinebud/baselinetotal)
+        #     optimtotalstr    = '%f' % (optimbud/optimtotal)
+        #     covchangestr     = '%f' % covchange
+        #     budchangestr     = '%f' % budchange
+        #     outputstr += sanitizeseps(prog) + sep + str(baselinebud) + sep + \
+        #                  baselinetotalstr + prcstr + sep + \
+        #                  str(optimbud) + sep + \
+        #                  optimtotalstr + prcstr + sep + \
+        #                  budchangestr + prcstr + condstr + sep + \
+        #                  str(baselinecov) + sep + \
+        #                  str(optimcov) + sep + \
+        #                  covchangestr + prcstr + condstr
+        # outputstr += '\n'
+        # outputstr += sep.join(['Total', str(baselinetotal), '', str(optimtotal), '', '', '', '', ''])
 
         return outputstr
 

--- a/optima/results.py
+++ b/optima/results.py
@@ -1007,16 +1007,16 @@ class Multiresultset(Resultset):
                               'Optimized budget', '% optimized budget', '% budget change',
                               'Baseline coverage', 'Optimized coverage', '% coverage change'])  # Create headers
         baselinetotal = sum(self.budgets.findbykey('Base').values())
-        optimtotal    = sum(self.budgets.findbykey('Optim').values())
+        optimtotal    = sum(self.budgets.findbykey('Optimized').values())
         for prog, baselinebud in self.budgets.findbykey('Base').items():
             outputstr += '\n'
 
-            optimbud = self.budgets.findbykey('Optim')[prog]
+            optimbud = self.budgets.findbykey('Optimized')[prog]
             baselinecov = self.coverages.findbykey('Base')[prog]
             if checktype(baselinecov, 'arraylike'):
                 baselinecov = baselinecov[0]  # Only pull out the first element if it's an array/list
             if baselinecov is None: baselinecov = 0  # Just reset
-            optimcov = self.coverages.findbykey('Optim')[prog]
+            optimcov = self.coverages.findbykey('Optimized')[prog]
             if checktype(optimcov, 'arraylike'):
                 optimcov = optimcov[0]  # Only pull out the first element if it's an array/list
             if optimcov is None: optimcov = 0  # Just reset

--- a/optima/results.py
+++ b/optima/results.py
@@ -1009,7 +1009,7 @@ class Multiresultset(Resultset):
         scen_keys = sorted(scen_keys) # sort alphabetically since baseline < optimization baselin < optimized
 
         baseline_key = self.budgets.findkeys('aseline')  ### Baseline scenario looks for "aseline"
-        baseline_key = baseline_key[0] if len(baseline_key) > 0 else 0
+        baseline_key = sorted(baseline_key)[0] if len(baseline_key) > 0 else 0
 
         # Get all the program names as different results might have different program
         all_progs = set(self.budgets[0].keys())

--- a/optima/results.py
+++ b/optima/results.py
@@ -1046,7 +1046,7 @@ class Multiresultset(Resultset):
             prog_budgets_percent_change = [(self.budgets[scen_key][prog]-baseline_prog_budget) / baseline_prog_budget*100
                                     for scen_key in scen_keys]
             outputstr += sep.join(['% budget change from baseline', prog]) + sep
-            outputstr += sep.join(map(str, prog_budgets_percent))
+            outputstr += ('%'+sep).join(map(str, prog_budgets_percent_change))
             outputstr += '\n'
         total_budget_changes = [(total_budgets[scen_key] - total_budgets[baseline_key]) / total_budgets[baseline_key] * 100
                                    for scen_key in scen_keys]

--- a/optima/results.py
+++ b/optima/results.py
@@ -1031,8 +1031,7 @@ class Multiresultset(Resultset):
             outputstr += sep.join(['Budget', prog]) + sep
             outputstr += sep.join(map(str,prog_budgets))
             outputstr += '\n'
-        total_budgets = {scen_key: sum(self.budgets[scen_key][:]) for scen_key in scen_keys}
-        print({scen_key: (self.budgets[scen_key][:]) for scen_key in scen_keys})
+        total_budgets = {scen_key: select_zeroth(self.budgets[scen_key][:].sum(axis=self.budgets[scen_key][:].ndim-1)) for scen_key in scen_keys}
         outputstr += sep.join(['Budget', 'TOTAL']) + sep
         outputstr += sep.join(map(str, total_budgets.values()))
         outputstr += '\n'+'\n'

--- a/optima/results.py
+++ b/optima/results.py
@@ -1031,9 +1031,7 @@ class Multiresultset(Resultset):
             outputstr += sep.join(['Budget', prog]) + sep
             outputstr += sep.join(map(str,prog_budgets))
             outputstr += '\n'
-        total_budgets = {scen_key: select_zeroth(self.budgets[scen_key][:].sum(axis=self.budgets[scen_key][:].ndim-1)) for scen_key in scen_keys}
-        print({scen_key: select_zeroth(self.budgets[scen_key][:].sum(axis=self.budgets[scen_key][:].ndim-1)) for scen_key in scen_keys})
-        print({scen_key: select_zeroth(self.budgets[scen_key][:].sum(axis=0)) for scen_key in scen_keys})
+        total_budgets = {scen_key: select_zeroth(self.budgets[scen_key][:].sum(axis=0)) for scen_key in scen_keys}
         outputstr += sep.join(['Budget', 'TOTAL']) + sep
         outputstr += sep.join(map(str, total_budgets.values()))
         outputstr += '\n'+'\n'


### PR DESCRIPTION
 - Improved `Export data` button Excel file for both Scenarios and Optimization Tab 
   - the `Comparison` tab in the Excel file has an easier to read comparison of budgets and coverages

Add parallel option to runscenarios, which (for speed) creates a copy of the project with only the needed parset and progset. it does this because running in parallel pickles and unpickles (essentially copying) the project anyway, so it is quicker if we copy the project with all the parsets and progsets once, and then the pickling and unpickling is only with the one parset and progset needed for that scenario