### PR TITLE
Fix copy._func not existing when copying and print the error when downloading

### DIFF
--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -111,9 +111,9 @@ define([
                   } else if (isJsonBlob(rejection.data)) { // Used for the rpcDownload which has responseType: 'blob'
                       const responseData = isJsonBlob(rejection.data) ? (rejection.data).text() : rejection.data || {};
                       const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
-                      responseJson.then(function(response) {
+                      responseJson.then(function(response) {  // responseJson is a Promise object so we convert
                         const insideJson = (typeof response === "string") ? JSON.parse(response) : response;
-                        resolve(insideJson);
+                        resolve(insideJson.exception);
                       });
                       resolve(responseJson);
                   } else {
@@ -127,10 +127,6 @@ define([
               getRejectionMessagePromise(rejection)
               .then(function(response) {
                 console.log('inside', response, errorText)
-                if (response !== errorText) { // Used for the rpcDownload which has responseType: 'blob'
-                  const responseJson = (typeof response === "string") ? JSON.parse(response) : response;
-                  errorText = responseJson.exception;
-                }
                 message = 'We are very sorry, but it seems an error has occurred. Please contact us (info@optimamodel.com). In your email, copy and paste the error message below, and please also provide the date and time, your user name, the project you were working on (if applicable), and as much detail as possible about the steps leading up to the error. We apologize for the inconvenience.';
                 var modalService = $injector.get('modalService');
                 modalService.inform(angular.noop, 'Okay', message, 'Server Error', errorText);

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -124,7 +124,7 @@ define([
               .then(function(response) {
                 console.log('inside', response, errorText);
                 if (response !== errorText) {
-                  const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
+                  const responseJson = (typeof response === "string") ? JSON.parse(response) : response;
                   errorText = responseJson.exception;
                 }
                 message = 'We are very sorry, but it seems an error has occurred. Please contact us (info@optimamodel.com). In your email, copy and paste the error message below, and please also provide the date and time, your user name, the project you were working on (if applicable), and as much detail as possible about the steps leading up to the error. We apologize for the inconvenience.';

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -107,9 +107,6 @@ define([
                 errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
               } else if (isJsonBlob(rejection.data)) {
                 reader = new FileReader();
-                reader.addEventListener('loadend', (e) => {
-                  console.log(JSON.parse(e.srcElement['result']));
-                });
                 rejection.data = reader.readAsText(rejection.data);
 //                const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
 //                const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -114,7 +114,8 @@ define([
                       responseJson.then(function(response) {
                         const insideJson = (typeof response === "string") ? JSON.parse(response) : response;
                         resolve(insideJson);
-                      })
+                      });
+                      resolve(responseJson);
                   } else {
                     errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
                   }

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -99,13 +99,23 @@ define([
               var message, errorText;
               console.log('catching error', rejection);
 
-              isJsonBlob = function(data) {
+              isJsonBlob = function(data) { // Used for the rpcDownload which has responseType: 'blob'
                 return data instanceof Blob && data.type === "application/json";
               }
-              console.log('catching error2', isJsonBlob(rejection.data));
 
               if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
                 errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
+              } else if (isJsonBlob(rejection.data)) {
+                reader = new FileReader();
+                reader.addEventListener('loadend', (e) => {
+                  console.log(JSON.parse(e.srcElement['result']));
+                });
+                rejection.data = reader.readAsText(rejection.data);
+//                const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
+//                const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
+//                response.data = responseJson
+                errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
+//                errorText = 'Unknown error, when downloading.\n' + JSON.stringify(rejection, null, 2);
               } else {
                 errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
               }

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -109,7 +109,7 @@ define([
                   if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
                     errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
                   } else if (isJsonBlob(rejection.data)) {
-                      const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
+                      const responseData = isJsonBlob(rejection.data) ? (rejection.data).text() : rejection.data || {};
                       const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
                       resolve(responseJson);
                   } else {

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -106,12 +106,14 @@ define([
               if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
                 errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
               } else if (isJsonBlob(rejection.data)) {
-                out = null;
+                var out = null;
                 reader = new FileReader();
                 reader.addEventListener('loadend', function(e) {
                   out = JSON.parse(e.srcElement['result']);
+                  console.log('inside', out)
                 });
                 reader.readAsText(rejection.data);
+                console.log('outside', out)
                 rejection.data = out;
                 errorText = rejection.data.message || rejection.data.exception || rejection.data.reason || 'Unknown error when downloading project.\n' + JSON.stringify(rejection, null, 2);
               } else {

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -111,11 +111,11 @@ define([
                   } else if (isJsonBlob(rejection.data)) { // Used for the rpcDownload which has responseType: 'blob'
                       const responseData = isJsonBlob(rejection.data) ? (rejection.data).text() : rejection.data || {};
                       const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
-                      responseJson.then(function(response) {  // responseJson is a Promise object so we convert
+                      response = responseJson.then(function(response) {  // responseJson is a Promise object so we convert
                         const insideJson = (typeof response === "string") ? JSON.parse(response) : response;
-                        resolve(insideJson.exception);
+                        return (insideJson.exception);
                       });
-                      resolve(responseJson);
+                      resolve(response);
                   } else {
                     errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
                   }

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -108,10 +108,13 @@ define([
                 return new Promise(function (resolve, reject) {
                   if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
                     errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
-                  } else if (isJsonBlob(rejection.data)) {
+                  } else if (isJsonBlob(rejection.data)) { // Used for the rpcDownload which has responseType: 'blob'
                       const responseData = isJsonBlob(rejection.data) ? (rejection.data).text() : rejection.data || {};
                       const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
-                      resolve(responseJson);
+                      responseJson.then(function(response) {
+                        const insideJson = (typeof response === "string") ? JSON.parse(response) : response;
+                        resolve(insideJson);
+                      })
                   } else {
                     errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
                   }
@@ -122,8 +125,8 @@ define([
 
               getRejectionMessagePromise(rejection)
               .then(function(response) {
-                console.log('inside', response, errorText);
-                if (response !== errorText) {
+                console.log('inside', response, errorText)
+                if (response !== errorText) { // Used for the rpcDownload which has responseType: 'blob'
                   const responseJson = (typeof response === "string") ? JSON.parse(response) : response;
                   errorText = responseJson.exception;
                 }

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -107,6 +107,9 @@ define([
                 errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
               } else if (isJsonBlob(rejection.data)) {
                 reader = new FileReader();
+                reader.addEventListener('loadend', function(e) {
+                  return console.log(JSON.parse(e.srcElement['result']));
+                });
                 rejection.data = reader.readAsText(rejection.data);
 //                const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
 //                const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -114,8 +114,9 @@ define([
                 });
                 reader.readAsText(rejection.data);
                 console.log('outside', out)
-                rejection.data = out;
-                errorText = rejection.data.message || rejection.data.exception || rejection.data.reason || 'Unknown error when downloading project.\n' + JSON.stringify(rejection, null, 2);
+//                rejection.data = out;
+//                errorText = rejection.data.message || rejection.data.exception || rejection.data.reason || 'Unknown error when downloading project.\n' + JSON.stringify(rejection, null, 2);
+                errorText = 'Unknown error when downloading project.\n' + JSON.stringify(rejection, null, 2);
               } else {
                 errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
               }

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -105,22 +105,28 @@ define([
 
               errorText = null;
               getRejectionMessagePromise = function(rejection) {
-                  return new Promise(function (resolve, reject) {
+                return new Promise(function (resolve, reject) {
+                  if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
+                    errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
+                  } else if (isJsonBlob(rejection.data)) {
+                      const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
+                      const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
+                      resolve(responseJson);
+                  } else {
+                    errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
+                  }
+                  resolve(errorText);
 
-                    if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
-                      errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
-                    } else if (isJsonBlob(rejection.data)) {
-                      errorText = 'Unknown error when downloading project.\n' + JSON.stringify(rejection, null, 2);
-                    } else {
-                      errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
-                    }
-                    resolve(errorText);
-
-                  });
+                });
               }
 
               getRejectionMessagePromise(rejection)
-              .then(function(errorText) {
+              .then(function(response) {
+                console.log('inside', response, errorText);
+                if (response !== errorText) {
+                  const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
+                  errorText = responseJson.exception;
+                }
                 message = 'We are very sorry, but it seems an error has occurred. Please contact us (info@optimamodel.com). In your email, copy and paste the error message below, and please also provide the date and time, your user name, the project you were working on (if applicable), and as much detail as possible about the steps leading up to the error. We apologize for the inconvenience.';
                 var modalService = $injector.get('modalService');
                 modalService.inform(angular.noop, 'Okay', message, 'Server Error', errorText);

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -106,17 +106,14 @@ define([
               if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
                 errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
               } else if (isJsonBlob(rejection.data)) {
-//                out = null;
-//                reader = new FileReader();
-//                reader.addEventListener('loadend', function(e) {
-//                  out = JSON.parse(e.srcElement['result']);
-//                });
-//                rejection.data = reader.readAsText(rejection.data);
-//                const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
-//                const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
-//                response.data = responseJson
-//                errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
-                errorText = 'Unknown error, when downloading.\n' + JSON.stringify(rejection, null, 2);
+                out = null;
+                reader = new FileReader();
+                reader.addEventListener('loadend', function(e) {
+                  out = JSON.parse(e.srcElement['result']);
+                });
+                reader.readAsText(rejection.data);
+                rejection.data = out;
+                errorText = rejection.data.message || rejection.data.exception || rejection.data.reason || 'Unknown error when downloading project.\n' + JSON.stringify(rejection, null, 2);
               } else {
                 errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
               }

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -111,11 +111,11 @@ define([
                   } else if (isJsonBlob(rejection.data)) { // Used for the rpcDownload which has responseType: 'blob'
                       const responseData = isJsonBlob(rejection.data) ? (rejection.data).text() : rejection.data || {};
                       const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
-                      response = responseJson.then(function(response) {  // responseJson is a Promise object so we convert
+                      exception = responseJson.then(function(response) {  // responseJson is a Promise object so we convert
                         const insideJson = (typeof response === "string") ? JSON.parse(response) : response;
                         return (insideJson.exception);
                       });
-                      resolve(response);
+                      resolve(exception);
                   } else {
                     errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
                   }

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -129,7 +129,7 @@ define([
                 console.log('inside', response, errorText)
                 message = 'We are very sorry, but it seems an error has occurred. Please contact us (info@optimamodel.com). In your email, copy and paste the error message below, and please also provide the date and time, your user name, the project you were working on (if applicable), and as much detail as possible about the steps leading up to the error. We apologize for the inconvenience.';
                 var modalService = $injector.get('modalService');
-                modalService.inform(angular.noop, 'Okay', message, 'Server Error', errorText);
+                modalService.inform(angular.noop, 'Okay', message, 'Server Error', response);
               })
 
               return $q.reject(rejection);

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -103,30 +103,30 @@ define([
                 return data instanceof Blob && data.type === "application/json";
               }
 
-              errorText = null;
               getRejectionMessagePromise = function(rejection) {
                 return new Promise(function (resolve, reject) {
+                  // Get the message from the rejection
                   if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
-                    errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
-                  } else if (isJsonBlob(rejection.data)) { // Used for the rpcDownload which has responseType: 'blob'
-                      const responseData = isJsonBlob(rejection.data) ? (rejection.data).text() : rejection.data || {};
-                      const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
-                      exception = responseJson.then(function(response) {  // responseJson is a Promise object so we convert
-                        const insideJson = (typeof response === "string") ? JSON.parse(response) : response;
-                        return (insideJson.exception);
-                      });
-                      resolve(exception);
-                  } else {
-                    errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
+                    resolve(rejection.data.message || rejection.data.exception || rejection.data.reason);
                   }
-                  resolve(errorText);
+                  else if (isJsonBlob(rejection.data)) { // Used for the rpcDownload which has responseType: 'blob'
+                    const responseData = isJsonBlob(rejection.data) ? (rejection.data).text() : rejection.data || {};
+                    const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
+                    exception = responseJson.then(function(response) {  // responseJson is a Promise object so we convert
+                      const insideJson = (typeof response === "string") ? JSON.parse(response) : response;
+                      return (insideJson.exception);
+                    });
+                    resolve(exception);
+                  }
+                  else {
+                    resolve('Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2));
+                  }
 
                 });
               }
 
               getRejectionMessagePromise(rejection)
               .then(function(response) {
-                console.log('inside', response, errorText)
                 message = 'We are very sorry, but it seems an error has occurred. Please contact us (info@optimamodel.com). In your email, copy and paste the error message below, and please also provide the date and time, your user name, the project you were working on (if applicable), and as much detail as possible about the steps leading up to the error. We apologize for the inconvenience.';
                 var modalService = $injector.get('modalService');
                 modalService.inform(angular.noop, 'Okay', message, 'Server Error', response);

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -98,6 +98,12 @@ define([
               // is stored in a data.message | data.reason property
               var message, errorText;
               console.log('catching error', rejection);
+
+              isJsonBlob = function(data) {
+                return data instanceof Blob && data.type === "application/json";
+              }
+              console.log('catching error2', isJsonBlob(rejection.data));
+
               if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
                 errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
               } else {

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -120,7 +120,7 @@ define([
               }
 
               getRejectionMessagePromise(rejection)
-              .then(function(response) {
+              .then(function(errorText) {
                 message = 'We are very sorry, but it seems an error has occurred. Please contact us (info@optimamodel.com). In your email, copy and paste the error message below, and please also provide the date and time, your user name, the project you were working on (if applicable), and as much detail as possible about the steps leading up to the error. We apologize for the inconvenience.';
                 var modalService = $injector.get('modalService');
                 modalService.inform(angular.noop, 'Okay', message, 'Server Error', errorText);

--- a/client/source/js/app.js
+++ b/client/source/js/app.js
@@ -106,16 +106,17 @@ define([
               if (rejection.data && (rejection.data.message || rejection.data.exception || rejection.data.reason)) {
                 errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
               } else if (isJsonBlob(rejection.data)) {
-                reader = new FileReader();
-                reader.addEventListener('loadend', function(e) {
-                  return console.log(JSON.parse(e.srcElement['result']));
-                });
-                rejection.data = reader.readAsText(rejection.data);
+//                out = null;
+//                reader = new FileReader();
+//                reader.addEventListener('loadend', function(e) {
+//                  out = JSON.parse(e.srcElement['result']);
+//                });
+//                rejection.data = reader.readAsText(rejection.data);
 //                const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
 //                const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
 //                response.data = responseJson
-                errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
-//                errorText = 'Unknown error, when downloading.\n' + JSON.stringify(rejection, null, 2);
+//                errorText = rejection.data.message || rejection.data.exception || rejection.data.reason;
+                errorText = 'Unknown error, when downloading.\n' + JSON.stringify(rejection, null, 2);
               } else {
                 errorText = 'Unknown error, check Internet connection and try again.\n' + JSON.stringify(rejection, null, 2);
               }

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -102,9 +102,9 @@ define(['angular' ], function (angular) {
               isJsonBlob = function(data) {
                 return data instanceof Blob && data.type === "application/json";
               }
-              const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
-              const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
-              response.data = responseJson
+//              const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
+//              const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
+//              response.data = responseJson
               deferred.reject(response);
             });
         return deferred.promise;

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -101,7 +101,7 @@ define(['angular' ], function (angular) {
               isJsonBlob = function(data) {
                 return data instanceof Blob && data.type === "application/json";
               }
-              const responseData = isJsonBlob(response.data) ? await (response.data).text() : response.data || {};
+              const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
               const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
               response.data = responseJson
               deferred.reject(response);

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -97,6 +97,7 @@ define(['angular' ], function (angular) {
               deferred.resolve(response);
             },
             function(response) {
+              console.log('downloading error',response)
               // Convert error blob to json using https://github.com/axios/axios/issues/3779
               isJsonBlob = function(data) {
                 return data instanceof Blob && data.type === "application/json";

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -97,14 +97,6 @@ define(['angular' ], function (angular) {
               deferred.resolve(response);
             },
             function(response) {
-              console.log('downloading error',response)
-              // Convert error blob to json using https://github.com/axios/axios/issues/3779
-              isJsonBlob = function(data) {
-                return data instanceof Blob && data.type === "application/json";
-              }
-//              const responseData = isJsonBlob(response.data) ? (response.data).text() : response.data || {};
-//              const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
-//              response.data = responseJson
               deferred.reject(response);
             });
         return deferred.promise;

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -101,7 +101,7 @@ define(['angular' ], function (angular) {
               isJsonBlob = function(data) {
                 return data instanceof Blob && data.type === "application/json";
               }
-              const responseData = isJsonBlob(response?.data) ? await (response?.data)?.text() : response?.data || {};
+              const responseData = isJsonBlob(response.data) ? await (response.data).text() : response.data || {};
               const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
               response.data = responseJson
               deferred.reject(response);

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -97,6 +97,11 @@ define(['angular' ], function (angular) {
               deferred.resolve(response);
             },
             function(response) {
+              // Convert error blob to json using https://github.com/axios/axios/issues/3779
+              const isJsonBlob = (data) => data instanceof Blob && data.type === "application/json";
+              const responseData = isJsonBlob(response?.data) ? await (response?.data)?.text() : response?.data || {};
+              const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
+              response.data = responseJson
               deferred.reject(response);
             });
         return deferred.promise;

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -98,7 +98,9 @@ define(['angular' ], function (angular) {
             },
             function(response) {
               // Convert error blob to json using https://github.com/axios/axios/issues/3779
-              const isJsonBlob = (data) => data instanceof Blob && data.type === "application/json";
+              isJsonBlob = function(data) {
+                return data instanceof Blob && data.type === "application/json";
+              }
               const responseData = isJsonBlob(response?.data) ? await (response?.data)?.text() : response?.data || {};
               const responseJson = (typeof responseData === "string") ? JSON.parse(responseData) : responseData;
               response.data = responseJson

--- a/optima/utils.py
+++ b/optima/utils.py
@@ -2497,7 +2497,7 @@ class odict_custom(odict):
 
         self.func = self._func
         del self._func
-        del copy._func
+        if hasattr(copy, '_func'): del copy._func
         return copy
 
 


### PR DESCRIPTION
I am not totally sure why copy.func_ doesn't exist after standard_dcp, but this fix works, because we only need to delete it if we don't have it. This was stopping `dcp(project)` from working

Had to do a little wrangling of the error message for the download because it was a blob so we have to convert to json - which is harder than it sounds - but it works now

Merging this will "reupdate" to the new version