### PR TITLE
Bunch of FE fixes

### DIFF
--- a/client/source/js/modules/calibration/calibration.js
+++ b/client/source/js/modules/calibration/calibration.js
@@ -362,7 +362,7 @@ define(['angular', 'underscore'], function (angular, _) {
     $scope.uploadParameterSet = function () {
       console.log('uploadParameterSet');
       rpcService
-          .rpcUpload(
+          .rpcUploadSerial(
               'upload_project_object', [$scope.project.id, 'parset'], {}, '.par')
           .then(function (response) {
             if (response.data.name == 'BadFileFormatError') {

--- a/client/source/js/modules/calibration/calibration.js
+++ b/client/source/js/modules/calibration/calibration.js
@@ -409,7 +409,6 @@ define(['angular', 'underscore'], function (angular, _) {
             .rpcRun(
                 'refresh_parset', [projectService.project.id, $scope.state.parset.id, initialprev])
             .then(function (response) {
-              $scope.state.parset.name = name;
               toastr.success('Parameter set refreshed from data');
               $scope.getCalibrationGraphs();
               rpcService

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -113,12 +113,49 @@ define(['angular' ], function (angular) {
         angular
           .element(tag)
           .change(function(event) {
+            for (var i = 0; i < this.files.length; i++) {
+              var currentFile = this.files[i];
+              $upload
+                .upload({
+                  url: '/api/upload',
+                  fields: {
+                    name: name,
+                    args: JSON.stringify(args),
+                    kwargs: JSON.stringify(kwargs)
+                  },
+                  file: currentFile
+                })
+                .then(
+                  function(response) {
+                    deferred.resolve(response);
+                  },
+                  function(response) {
+                    deferred.reject(response);
+                  }
+                );
+            }
+          })
+          .click();
+        return deferred.promise;
+      }
+
+      function rpcUploadSerial(name, args, kwargs, fileType) {
+        consoleLogCommand("upload", name, args, kwargs, fileType);
+        var tag = '<input type="file" ';
+        if (fileType) {
+          tag += 'accept="' + fileType + '" '
+        }
+        tag += " multiple>";
+        var deferred = $q.defer();
+        angular
+          .element(tag)
+          .change(function(event) {
             promise = new Promise(function (resolve, reject) {resolve('');});
 
-            consoleLogCommand("upload-files", name, "files:", this.files);
+            console.log("upload-files", name, "files:", this.files);
+
             for (var i = 0; i < this.files.length; i++) {
               const currentFile = this.files[i];
-              console.log("upload-files-this", i, currentFile, name, args, kwargs);
               promise = promise.then(
                 function(response) {
                   return $upload.upload({
@@ -165,6 +202,7 @@ define(['angular' ], function (angular) {
         rpcAsyncRun: rpcAsyncRun,
         rpcDownload: rpcDownload,
         rpcUpload: rpcUpload,
+        rpcUploadSerial: rpcUploadSerial,
         getUniqueName: getUniqueName
       };
 

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -113,6 +113,7 @@ define(['angular' ], function (angular) {
         angular
           .element(tag)
           .change(function(event) {
+            consoleLogCommand("upload-files", name, "files:", this.files);
             for (var i = 0; i < this.files.length; i++) {
               var currentFile = this.files[i];
               $upload

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -113,28 +113,37 @@ define(['angular' ], function (angular) {
         angular
           .element(tag)
           .change(function(event) {
+            promise = new Promise(function (resolve, reject) {resolve('');});
+
             consoleLogCommand("upload-files", name, "files:", this.files);
             for (var i = 0; i < this.files.length; i++) {
               var currentFile = this.files[i];
-              $upload
-                .upload({
-                  url: '/api/upload',
-                  fields: {
-                    name: name,
-                    args: JSON.stringify(args),
-                    kwargs: JSON.stringify(kwargs)
-                  },
-                  file: currentFile
-                })
-                .then(
-                  function(response) {
-                    deferred.resolve(response);
-                  },
-                  function(response) {
-                    deferred.reject(response);
-                  }
-                );
+              promise = promise.then(
+                function(response) {
+                  return $upload.upload({
+                    url: '/api/upload',
+                    fields: {
+                      name: name,
+                      args: JSON.stringify(args),
+                      kwargs: JSON.stringify(kwargs)
+                    },
+                    file: currentFile
+                  });
+                },
+                function (response) {
+                  deferred.reject(response);
+                }
+              );
             }
+
+            promise.then(
+              function(response) {
+                deferred.resolve(response);
+              },
+              function(response) {
+                deferred.reject(response);
+              }
+            );
           })
           .click();
         return deferred.promise;

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -118,6 +118,7 @@ define(['angular' ], function (angular) {
             consoleLogCommand("upload-files", name, "files:", this.files);
             for (var i = 0; i < this.files.length; i++) {
               var currentFile = this.files[i];
+              console.log("upload-files-this", i, currentFile, name, args, kwargs);
               promise = promise.then(
                 function(response) {
                   return $upload.upload({

--- a/client/source/js/modules/common/rpc-service.js
+++ b/client/source/js/modules/common/rpc-service.js
@@ -117,7 +117,7 @@ define(['angular' ], function (angular) {
 
             consoleLogCommand("upload-files", name, "files:", this.files);
             for (var i = 0; i < this.files.length; i++) {
-              var currentFile = this.files[i];
+              const currentFile = this.files[i];
               console.log("upload-files-this", i, currentFile, name, args, kwargs);
               promise = promise.then(
                 function(response) {

--- a/client/source/js/modules/optimization/optimization.js
+++ b/client/source/js/modules/optimization/optimization.js
@@ -235,7 +235,7 @@ define(['angular', 'ui.router'], function (angular) {
 
     $scope.uploadOptimization = function(optimization) {
       rpcService
-        .rpcUpload(
+        .rpcUploadSerial(
           'upload_project_object', [projectService.project.id, 'optimization'], {}, '.opt')
         .then(function(response) {
 			if (response.data.name == 'BadFileFormatError') {

--- a/client/source/js/modules/programs/programs.js
+++ b/client/source/js/modules/programs/programs.js
@@ -198,7 +198,7 @@ define(['angular', 'ui.router', './program-modal'], function (angular) {
 
     $scope.uploadProgramSet = function() {
       rpcService
-        .rpcUpload(
+        .rpcUploadSerial(
           'upload_project_object', [projectService.project.id, 'progset'], {}, '.prg')
         .then(function(response) {
 		  if (response.data.name == 'BadFileFormatError') {

--- a/client/source/js/modules/scenarios/program-scenarios-modal.html
+++ b/client/source/js/modules/scenarios/program-scenarios-modal.html
@@ -125,6 +125,14 @@
           margin-bottom: 0.5em;">
       Add program
     </button>
+    <button
+        ng-click="addAllPrograms(yearEntry)"
+        class="btn"
+        style="
+          margin-top: 0.5em;
+          margin-bottom: 0.5em;">
+      Add all programs
+    </button>
   </td>
 
   <td valign="top">

--- a/client/source/js/modules/scenarios/program-scenarios-modal.js
+++ b/client/source/js/modules/scenarios/program-scenarios-modal.js
@@ -83,12 +83,12 @@ define(['angular', 'underscore'], function(angular, _) {
 
         $scope.addAllPrograms = function(yearEntry) {
         console.log('$scope.state.programs', $scope.state.programs)
-          for (newProg in $scope.state.programs) {
+          for (const program of $scope.state.programs) {
             var newProgram = {
-              short: newProg.short,
+              short: program.short,
               value: null
             };
-            console.log('newProg', newProg, 'yearEntry', yearEntry)
+            console.log('program', program, 'newProgram',newProgram, 'yearEntry', yearEntry)
             $scope.selectProgram(yearEntry, newProgram);
             yearEntry.programs.push(newProgram);
             console.log('programs', yearEntry.programs)

--- a/client/source/js/modules/scenarios/program-scenarios-modal.js
+++ b/client/source/js/modules/scenarios/program-scenarios-modal.js
@@ -72,9 +72,9 @@ define(['angular', 'underscore'], function(angular, _) {
           });
         };
 
-        $scope.addProgram = function(yearEntry) {
+        $scope.addProgram = function(yearEntry, progNumber=0) {
           var newProgram = {
-            short: $scope.state.programs[0].short,
+            short: $scope.state.programs[progNumber].short,
             value: null
           };
           $scope.selectProgram(yearEntry, newProgram);
@@ -82,16 +82,8 @@ define(['angular', 'underscore'], function(angular, _) {
         };
 
         $scope.addAllPrograms = function(yearEntry) {
-        console.log('$scope.state.programs', $scope.state.programs)
-          for (program of $scope.state.programs) {
-            var newProgram = {
-              short: program.short,
-              value: null
-            };
-            console.log('program', program, 'newProgram',newProgram, 'yearEntry', yearEntry)
-            $scope.selectProgram(yearEntry, newProgram);
-            yearEntry.programs.push(newProgram);
-            console.log('programs', yearEntry.programs)
+          for (var i = 0; i < $scope.state.programs.length; i++) {
+            $scope.addProgram(yearEntry, i);
           }
         };
 

--- a/client/source/js/modules/scenarios/program-scenarios-modal.js
+++ b/client/source/js/modules/scenarios/program-scenarios-modal.js
@@ -83,7 +83,7 @@ define(['angular', 'underscore'], function(angular, _) {
 
         $scope.addAllPrograms = function(yearEntry) {
         console.log('$scope.state.programs', $scope.state.programs)
-          for (const program of $scope.state.programs) {
+          for (program of $scope.state.programs) {
             var newProgram = {
               short: program.short,
               value: null

--- a/client/source/js/modules/scenarios/program-scenarios-modal.js
+++ b/client/source/js/modules/scenarios/program-scenarios-modal.js
@@ -81,6 +81,17 @@ define(['angular', 'underscore'], function(angular, _) {
           yearEntry.programs.push(newProgram);
         };
 
+        $scope.addAllPrograms = function(yearEntry) {
+          for (newProg in $scope.state.programs) {
+            var newProgram = {
+              short: newProg.short,
+              value: null
+            };
+            $scope.selectProgram(yearEntry, newProgram);
+            yearEntry.programs.push(newProgram);
+          }
+        };
+
         $scope.selectProgram = function(yearEntry, program) {
           if ($scope.scenario_type == "budget") {
             var budgets = budgetsByProgsetId[$scope.scenario.progset_id];

--- a/client/source/js/modules/scenarios/program-scenarios-modal.js
+++ b/client/source/js/modules/scenarios/program-scenarios-modal.js
@@ -72,7 +72,8 @@ define(['angular', 'underscore'], function(angular, _) {
           });
         };
 
-        $scope.addProgram = function(yearEntry, progNumber=0) {
+        $scope.addProgram = function(yearEntry, progNumber) {
+          if (progNumber === undefined) {progNumber = 0;}
           var newProgram = {
             short: $scope.state.programs[progNumber].short,
             value: null

--- a/client/source/js/modules/scenarios/program-scenarios-modal.js
+++ b/client/source/js/modules/scenarios/program-scenarios-modal.js
@@ -82,14 +82,16 @@ define(['angular', 'underscore'], function(angular, _) {
         };
 
         $scope.addAllPrograms = function(yearEntry) {
+        console.log('$scope.state.programs', $scope.state.programs)
           for (newProg in $scope.state.programs) {
             var newProgram = {
               short: newProg.short,
               value: null
             };
+            console.log('newProg', newProg, 'yearEntry', yearEntry)
             $scope.selectProgram(yearEntry, newProgram);
             yearEntry.programs.push(newProgram);
-            console.log(yearEntry.programs)
+            console.log('programs', yearEntry.programs)
           }
         };
 

--- a/client/source/js/modules/scenarios/program-scenarios-modal.js
+++ b/client/source/js/modules/scenarios/program-scenarios-modal.js
@@ -89,6 +89,7 @@ define(['angular', 'underscore'], function(angular, _) {
             };
             $scope.selectProgram(yearEntry, newProgram);
             yearEntry.programs.push(newProgram);
+            console.log(yearEntry.programs)
           }
         };
 

--- a/client/source/js/modules/scenarios/scenarios.js
+++ b/client/source/js/modules/scenarios/scenarios.js
@@ -118,7 +118,7 @@ define([
 
     $scope.uploadScenario = function(scenario) {
       rpcService
-        .rpcUpload(
+        .rpcUploadSerial(
           'upload_project_object', [projectService.project.id, 'scenario'], {}, '.scn')
         .then(function(response) {
 		  if (response.data.name == 'BadFileFormatError') {

--- a/optima/project.py
+++ b/optima/project.py
@@ -377,7 +377,6 @@ class Project(object):
                     raise OptimaException('Unable to add item of type "%s", please supply explicitly' % what)
         structlist = self.getwhat(item=item, what=what)
         self.checkname(structlist, checkabsent=name, overwrite=overwrite)
-        print('project.add() structlist', type(structlist), 'func', structlist.func if hasattr(structlist, 'func') else 'nofunc')
         structlist[name] = item
         if consistentnames: structlist[name].name = name # Make sure names are consistent -- should be the case for everything except results, where keys are UIDs
         if hasattr(structlist[name], 'projectref'): structlist[name].projectref = Link(self) # Fix project links

--- a/optima/project.py
+++ b/optima/project.py
@@ -377,6 +377,7 @@ class Project(object):
                     raise OptimaException('Unable to add item of type "%s", please supply explicitly' % what)
         structlist = self.getwhat(item=item, what=what)
         self.checkname(structlist, checkabsent=name, overwrite=overwrite)
+        print('project.add() structlist', type(structlist), 'func', structlist.func if hasattr(structlist, 'func') else 'nofunc')
         structlist[name] = item
         if consistentnames: structlist[name].name = name # Make sure names are consistent -- should be the case for everything except results, where keys are UIDs
         if hasattr(structlist[name], 'projectref'): structlist[name].projectref = Link(self) # Fix project links

--- a/server/api.py
+++ b/server/api.py
@@ -212,6 +212,7 @@ def get_remote_file():
     full_filename = fn(*args, **kwargs)
 
     dirname, filename = os.path.split(full_filename)
+    print(f' > get_remote_file {fn_name} filenames: {full_filename} = {dirname} {filename}')
 
     response = helpers.send_from_directory(
         dirname,

--- a/server/api.py
+++ b/server/api.py
@@ -235,6 +235,7 @@ def receive_uploaded_file():
         'kwargs': dictionary of named parameters for the function
     """
     file = request.files['file']
+    print("> receive_uploaded_file file %s" % (file))
     filename = secure_filename(file.filename)
     dirname = app.config['UPLOAD_FOLDER']
     if not (os.path.exists(dirname)):

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -962,6 +962,7 @@ def upload_project_object(filename, project_id, obj_type):
     except Exception:
         return { 'name': 'BadFileFormatError' }
     try:
+        obj.uid = op.uuid()  # So we don't add a parset with a different name but same uuid causing a conflict
         if obj_type == "parset":
             project.addparset(parset=obj, overwrite=True)
         elif obj_type == "progset":

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -545,6 +545,9 @@ def create_project(user_id, project_summary):
     db.session.flush()
 
     project = op.Project(name=project_summary["name"])
+    project.settings.start = project_summary["startYear"]
+    project.settings.end   = project_summary["endYear"]
+    project.data["pops"]   = parse.revert_populations_to_pop(project_summary["populations"])
     project.uid = project_entry.id
     save_project(project)
 
@@ -588,7 +591,7 @@ def download_data_spreadsheet(project_id, is_blank=True):
     new_project_template = secure_filename(
         "{}.xlsx".format(project_summary['name']))
     path = templatepath(new_project_template)
-    if is_blank or project.data == op.odict():
+    if is_blank or len(project.data.keys()) == 1:  # Only has project.data['pops']
         path = op.makespreadsheet(
             path,
             pops=project_summary['populations'],

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -582,7 +582,7 @@ def update_project_from_summary(project_summary, is_delete_data=False):
 
 
 def download_data_spreadsheet(project_id, is_blank=True):
-    print(">> download_data_spreadsheet init")
+    print(">> download_data_spreadsheet init: is_blank:", is_blank)
     project = load_project(project_id)
     project_summary = parse.get_project_summary_from_project(project)
     new_project_template = secure_filename(

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -591,7 +591,7 @@ def download_data_spreadsheet(project_id, is_blank=True):
     new_project_template = secure_filename(
         "{}.xlsx".format(project_summary['name']))
     path = templatepath(new_project_template)
-    if is_blank or len(project.data.keys()) == 1:  # Only has project.data['pops']
+    if is_blank or len(project.data.keys()) <= 1:  # Only has project.data['pops']
         path = op.makespreadsheet(
             path,
             pops=project_summary['populations'],

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -589,13 +589,13 @@ def download_data_spreadsheet(project_id, is_blank=True):
         "{}.xlsx".format(project_summary['name']))
     path = templatepath(new_project_template)
     if is_blank or project.data == op.odict():
-        op.makespreadsheet(
+        path = op.makespreadsheet(
             path,
             pops=project_summary['populations'],
             datastart=project_summary["startYear"],
             dataend=project_summary["endYear"])
     else:
-        project.makespreadsheet(filename=path)
+        path = project.makespreadsheet(filename=path)
     return path
 
 

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -942,7 +942,7 @@ def download_project_object(project_id, obj_type, obj_id):
 
     basename = "%s-%s.%s" % (project.name, obj.name, ext)
     filename = get_server_filename(basename)
-    op.saveobj(filename, obj)
+    filename = op.saveobj(filename, obj)
     return filename
 
 

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -588,7 +588,7 @@ def download_data_spreadsheet(project_id, is_blank=True):
     new_project_template = secure_filename(
         "{}.xlsx".format(project_summary['name']))
     path = templatepath(new_project_template)
-    if is_blank:
+    if is_blank or project.data == op.odict():
         op.makespreadsheet(
             path,
             pops=project_summary['populations'],

--- a/server/webapp/dbmodels.py
+++ b/server/webapp/dbmodels.py
@@ -110,7 +110,7 @@ class ProjectDb(db.Model):
         project = self.load()
         filename = os.path.join(loaddir, project.name + ".prj")
         filename = op.saveobj(filename, project)
-        return filename
+        return os.path.basename(filename)
 
     def delete_dependent_objects(self, synchronize_session=False):
         str_project_id = str(self.id)        

--- a/server/webapp/dbmodels.py
+++ b/server/webapp/dbmodels.py
@@ -109,8 +109,8 @@ class ProjectDb(db.Model):
     def as_file(self, loaddir, filename=None):
         project = self.load()
         filename = os.path.join(loaddir, project.name + ".prj")
-        op.saveobj(filename, project)
-        return project.name + ".prj"
+        filename = op.saveobj(filename, project)
+        return filename
 
     def delete_dependent_objects(self, synchronize_session=False):
         str_project_id = str(self.id)        

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1401,6 +1401,7 @@ def revert_constraints(entries, project=None, progsetname=None):
 
 
 def get_default_optimization_summaries(project):
+    print(' > get_default_optimization_summaries project ', project)
     defaults_by_progset_id = {}
     for progsetkey,progset in project.progsets.items():
         progset_id = progset.uid

--- a/server/webapp/parse.py
+++ b/server/webapp/parse.py
@@ -1373,6 +1373,8 @@ def parse_constraints(constraints, project=None, progsetname=None):
     entries = []
     if constraints is None:
         constraints = op.defaultconstraints(project=project, progsetname=None)
+    if constraints is None:
+        return None
     for key, value in constraints['name'].items():
         entries.append({
             'key': key,
@@ -1401,12 +1403,11 @@ def revert_constraints(entries, project=None, progsetname=None):
 
 
 def get_default_optimization_summaries(project):
-    print(' > get_default_optimization_summaries project ', project)
     defaults_by_progset_id = {}
     for progsetkey,progset in project.progsets.items():
         progset_id = progset.uid
         default = {
-            'proporigconstraints': parse_constraints(op.defaultconstraints(project=project, progsetname=progsetkey)),
+            'proporigconstraints': parse_constraints(project=project, constraints=op.defaultconstraints(project=project, progsetname=progsetkey)),
             'objectives': {},
             'tvsettings': normalize_obj(op.defaulttvsettings())
         }


### PR DESCRIPTION
 - Fix "Fix FE program deletes wrong program set" - force new UUID for any object that gets uploaded to the FE
- Fix "When refreshing parsets, the parset name disappears (temporarily)"  - there was a stray line that set the name to ""
- Fix "Can't download databook after creating project" - when creating the project in the FE now the basic data (start end years and populations) gets stored in the project, and when clicking the download spreadsheet button if it only finds that basic information then it downloads a blank spreadsheet
- Add "Parameter scenario, add button to add all programs" - added button for **coverage** and **budget** scenarios not parameter, because they don't need programs
- Fix "Uploading multiple scenarios or optimizations at once doesn't upload all of them" because they were getting uploaded in parallel and so the project would get loaded, a single scenario added and then saved, in the meantime the same thing happened with the other scenario - meaning only one scenario would be added. So added rcpService.rcpUploadSerial which uploads in serial.
- Fix an error in the FE when opening the Optimization tab when you have an empty progset - now the page works as intended but we still need better warnings / errors when you have an optimization that has an empty progset
- Fix certain projects or parsets or progsets not getting downloaded from "Download selected" due to filename sanitization