### PR TITLE
Revision 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Projects before `2.11.4` should be able to be migrated to version `2.11.4` witho
 
 Versions `2.11.4`, `2.12.0` and later all can be run using the branch `main`. A project will automatically update to the earliest supported version (currently `2.11.4`), but updating a project to the latest version can be done using the FE or `op.migrate(P, 'latest')`
 
+## Revision 2
+Fix bug when deep-copying a `Parameterset`, the `pars` from a different `Parameterset` would get copied in certain cases (make sure to pass `memodict` along when deep-copying).
+
 ## Revision 1
 Can run multiple different supported versions with the same branch! Currently supported: `[2.11.4, 2.12.0]`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Optima Changelog
 
-Projects before `2.11.4` should be able to be migrated to version `2.11.4` without changing the calibration. Versions `2.12.0` and `2.12.1` both change the calibration (sometimes only slightly).
+Projects before `2.11.4` should be able to be migrated to version `2.11.4` without changing the calibration. Versions `2.12.0` and `2.12.1` (planned) both change the calibration (sometimes only slightly).
 
-Versions `2.11.4` and later all can be run using the branch `EECA-training-2022` (currently on `2.11.4`) or `updates-june-2022` (currently on `2.12.0`). These branches have the same code except for `version.py` which changes the behaviour.
-To use a different version, change it without committing in `optima/version.py`.
+Versions `2.11.4`, `2.12.0` and later all can be run using the branch `main`. A project will automatically update to the earliest supported version (currently `2.11.4`), but updating a project to the latest version can be done using the FE or `op.migrate(P, 'latest')`
 
 ## Revision 1
 Can run multiple different supported versions with the same branch! Currently supported: `[2.11.4, 2.12.0]`

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -135,7 +135,8 @@ def setrevisionmigrations(which='migrations'):
 
     migrations = op.odict([
         # Orig     New       Date         Migration           Description
-        ('0',   ('1', '2023-10-17', parsandprograms_odictcustom,   'Add P.revision, change Parameterset.pars and Programset.programs from odict to odict_custom and link them')),
+        ('0',   ('1', '2023-10-17', parsandprograms_odictcustom,    'Add P.revision, change Parameterset.pars and Programset.programs from odict to odict_custom and link them')),
+        ('1',   ('2', '2023-12-04', None,                           'Fix bug when deep-copying a `Parameterset`, the `pars` from a different `Parameterset` would get copied in certain cases')),
         ])
 
 

--- a/optima/results.py
+++ b/optima/results.py
@@ -1268,7 +1268,7 @@ def exporttoexcel(filename=None, outdict=None):
         formats = dict()
         formats['plain'] = workbook.add_format({})
         formats['bold'] = workbook.add_format({'bg_color': colors['edgyblue'], 'bold': True})
-        formats['number'] = workbook.add_format({'bg_color': colors['fadedstrawberry'], 'num_format': 0x04})
+        formats['number'] = workbook.add_format({'bg_color': colors['fadedstrawberry'], 'num_format': 0x00})
         formats['percent'] = workbook.add_format({'bg_color': colors['fadedstrawberry'], 'num_format': 0x09})
         formats['header'] = workbook.add_format({'bg_color': colors['gentlegreen'], 'color': colors['white'], 'bold': True})
         formats['increase'] = workbook.add_format({'bg_color': colors['increasegreen'], 'num_format': 0x09})

--- a/optima/results.py
+++ b/optima/results.py
@@ -593,7 +593,7 @@ class Resultset(object):
 
         return None
 
-    def export(self, filename=None, folder=None, bypop=True, sep=',', ind=None, key=None, sigfigs=3, writetofile=True, asexcel=True, verbose=2):
+    def export(self, filename=None, folder=None, bypop=True, sep=',', ind=None, key=None, sigfigs=None, writetofile=True, asexcel=True, verbose=2):
         """ Method for exporting results to an Excel or CSV file """
 
         # Handle export by either index or key -- WARNING, still inelegant at best! Accepts key or ind, not both

--- a/optima/utils.py
+++ b/optima/utils.py
@@ -1484,7 +1484,7 @@ def standard_cp(obj):
     obj.__copy__    = obj._cp
     return output
 
-def standard_dcp(obj, memodict={}):
+def standard_dcp(obj, memodict):
     ''' Function that stores the __deepcopy__ so that we can use the standard
         copy.deepcopy() to copy it and return to the original __deepcopy__
         NOT THE SAME AS DCP since that will use the __deepcopy__ of the object (as intended)
@@ -2493,7 +2493,7 @@ class odict_custom(odict):
         self._func = self.func
         self.func = None
 
-        copy = standard_dcp(self)
+        copy = standard_dcp(self, memodict)
 
         self.func = self._func
         del self._func

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,6 +1,6 @@
 supported_versions = ['2.11.4','2.12.0']
-revision = '1'
-revisiondate = '2023-10-26'
+revision = '2'
+revisiondate = '2023-12-04'
 versions_different_databook = ['2.10.13']  # Versions where we start using a different databook format
 
 version = supported_versions[-1]

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -1101,7 +1101,7 @@ def download_result_data(result_id):
     if not dirname:
         dirname = TEMPLATEDIR
     result = load_result_by_id(result_id)
-    return result.export(folder=dirname, sigfigs=3)
+    return result.export(folder=dirname)
 
 
 def load_result_by_optimization(project, optimization):

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -1101,7 +1101,7 @@ def download_result_data(result_id):
     if not dirname:
         dirname = TEMPLATEDIR
     result = load_result_by_id(result_id)
-    return result.export(folder=dirname)
+    return result.export(folder=dirname, sigfigs=3)
 
 
 def load_result_by_optimization(project, optimization):


### PR DESCRIPTION
Fix bug when deep-copying a `Parameterset`, the `pars` from a different `Parameterset` would get copied in certain cases (make sure to pass `memodict` along when deep-copying).
