### PR TITLE
Revision 3 fix unpickling error

### DIFF
--- a/optima/__init__.py
+++ b/optima/__init__.py
@@ -74,6 +74,11 @@ else:
     from sciris import cpu_count
 del sc_version; del sc_versiondate
 
+# Some pickled projects expect there to be a function sc.sc_fileio._unpickleMethod
+def blank_function(a,b,c): pass # raise Exception('sc.sc_fileio._unpickleMethod is gone, don\'t try to use it')
+sc.sc_fileio._unpickleMethod = blank_function
+del blank_function
+
 # Color definitions
 from .colortools import *
 

--- a/optima/__init__.py
+++ b/optima/__init__.py
@@ -76,8 +76,9 @@ del sc_version; del sc_versiondate
 
 # Some pickled projects expect there to be a function sc.sc_fileio._unpickleMethod
 def blank_function(a,b,c): pass # raise Exception('sc.sc_fileio._unpickleMethod is gone, don\'t try to use it')
-sc.sc_fileio._unpickleMethod = blank_function
-del blank_function
+from sciris import sc_fileio
+sc_fileio._unpickleMethod = blank_function
+del blank_function, sc_fileio
 
 # Color definitions
 from .colortools import *

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -1833,7 +1833,7 @@ def loadproj(filename=None, folder=None, verbose=2, die=None, fromdb=False, migr
         migraterevision='latest'=True, False, or a specific revision (only latest is supported)
     '''
     if fromdb:    origP = op.loadstr(filename) # Load from database
-    else:         origP = op.loadobj(filename=filename, folder=folder, verbose=(True if verbose>2 else None if verbose>0 else False)) # Normal usage case: load from file
+    else:         origP = op.loadobj(filename=filename, folder=folder, verbose=(True if verbose>2 else None if verbose>0 else False), die=die) # Normal usage case: load from file
 
 
     if migrateversion:

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -137,6 +137,7 @@ def setrevisionmigrations(which='migrations'):
         # Orig     New       Date         Migration           Description
         ('0',   ('1', '2023-10-17', parsandprograms_odictcustom,    'Add P.revision, change Parameterset.pars and Programset.programs from odict to odict_custom and link them')),
         ('1',   ('2', '2023-12-04', None,                           'Fix bug when deep-copying a `Parameterset`, the `pars` from a different `Parameterset` would get copied in certain cases')),
+        ('2',   ('3', '2024-01-18', None,                           'Fix small unpickling bug and FE raises BadFileFormatError when uploading project that it cannot unpickle')),
         ])
 
 

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,5 +1,5 @@
 supported_versions = ['2.11.4','2.12.0']
-revision = '2'
+revision = '3'
 revisiondate = '2023-12-04'
 versions_different_databook = ['2.10.13']  # Versions where we start using a different databook format
 

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -750,7 +750,7 @@ def create_project_from_prj_file(prj_filename, user_id, other_names):
     """
     print(">> create_project_from_prj_file '%s'" % prj_filename)
     try:
-        project = op.loadproj(prj_filename)
+        project = op.loadproj(prj_filename, die=True)
     except Exception:
         return { 'projectId': 'BadFileFormatError' }
     project.name = get_unique_name(project.name, other_names)

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -486,6 +486,7 @@ def update_project_version(project_id, db_session=None):
 
 def load_project_summary_from_project_record(project_record):
     project = load_project_from_record(project_record)
+    print('PROJCET4', project)
     project_summary = parse.get_project_summary_from_project(project)
     project_summary['id'] = project_record.id
     project_summary['userId'] = project_record.user_id

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -432,6 +432,8 @@ def save_project(project, db_session=None, is_skip_result=False):
     project_record.save_obj(project)
     db_session.add(project_record)
     db_session.commit()
+    print('PROJCET2,', project)
+    print('PROJCET3,', load_project_from_record(project_record))
 
 
 def load_project_from_record(project_record):

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -432,8 +432,6 @@ def save_project(project, db_session=None, is_skip_result=False):
     project_record.save_obj(project)
     db_session.add(project_record)
     db_session.commit()
-    print('PROJCET2,', project.progsets[0])
-    print('PROJCET3,', load_project_from_record(project_record).progsets[0])
 
 
 def load_project_from_record(project_record):
@@ -486,7 +484,6 @@ def update_project_version(project_id, db_session=None):
 
 def load_project_summary_from_project_record(project_record):
     project = load_project_from_record(project_record)
-    print('PROJCET4', project.progsets[0])
     project_summary = parse.get_project_summary_from_project(project)
     project_summary['id'] = project_record.id
     project_summary['userId'] = project_record.user_id
@@ -754,11 +751,9 @@ def create_project_from_prj_file(prj_filename, user_id, other_names):
     print(">> create_project_from_prj_file '%s'" % prj_filename)
     try:
         project = op.loadproj(prj_filename, die=True)
-    except Exception as e:
-        raise e
+    except Exception:
         return { 'projectId': 'BadFileFormatError' }
     project.name = get_unique_name(project.name, other_names)
-    print('PROJCET', project.progsets[0])
     save_project_as_new(project, user_id)
     return { 'projectId': str(project.uid) }
 

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -755,6 +755,7 @@ def create_project_from_prj_file(prj_filename, user_id, other_names):
         raise e
         return { 'projectId': 'BadFileFormatError' }
     project.name = get_unique_name(project.name, other_names)
+    print('PROJCET', project)
     save_project_as_new(project, user_id)
     return { 'projectId': str(project.uid) }
 

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -751,7 +751,8 @@ def create_project_from_prj_file(prj_filename, user_id, other_names):
     print(">> create_project_from_prj_file '%s'" % prj_filename)
     try:
         project = op.loadproj(prj_filename, die=True)
-    except Exception:
+    except Exception as e:
+        raise e
         return { 'projectId': 'BadFileFormatError' }
     project.name = get_unique_name(project.name, other_names)
     save_project_as_new(project, user_id)

--- a/server/webapp/dataio.py
+++ b/server/webapp/dataio.py
@@ -432,8 +432,8 @@ def save_project(project, db_session=None, is_skip_result=False):
     project_record.save_obj(project)
     db_session.add(project_record)
     db_session.commit()
-    print('PROJCET2,', project)
-    print('PROJCET3,', load_project_from_record(project_record))
+    print('PROJCET2,', project.progsets[0])
+    print('PROJCET3,', load_project_from_record(project_record).progsets[0])
 
 
 def load_project_from_record(project_record):
@@ -486,7 +486,7 @@ def update_project_version(project_id, db_session=None):
 
 def load_project_summary_from_project_record(project_record):
     project = load_project_from_record(project_record)
-    print('PROJCET4', project)
+    print('PROJCET4', project.progsets[0])
     project_summary = parse.get_project_summary_from_project(project)
     project_summary['id'] = project_record.id
     project_summary['userId'] = project_record.user_id
@@ -758,7 +758,7 @@ def create_project_from_prj_file(prj_filename, user_id, other_names):
         raise e
         return { 'projectId': 'BadFileFormatError' }
     project.name = get_unique_name(project.name, other_names)
-    print('PROJCET', project)
+    print('PROJCET', project.progsets[0])
     save_project_as_new(project, user_id)
     return { 'projectId': str(project.uid) }
 


### PR DESCRIPTION
I think the old version of python (3.7) plus old packages needed ``sc_fileio._unpickleMethod`` to have a value.

 I think this will only get used when unpickling those projects that were pickled using the older version.

I don't think it should have any negative consequences

The FE showing an error when uploading a project that it cannot unpickle is better than no error initially but then an error later when trying to open it.