### PR TITLE
2.12.1 -> develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Optima Changelog
 
-Projects before `2.11.4` should be able to be migrated to version `2.11.4` without changing the calibration. Versions `2.12.0` and `2.12.1` (planned) both change the calibration (sometimes only slightly).
+Projects before `2.11.4` should be able to be migrated to version `2.11.4` without changing the calibration. Versions `2.12.0` and `2.12.1` both change the calibration (sometimes only slightly).
 
 Versions `2.11.4`, `2.12.0` and later all can be run using the branch `main`. A project will automatically update to the earliest supported version (currently `2.11.4`), but updating a project to the latest version can be done using the FE or `op.migrate(P, 'latest')`
 
@@ -55,14 +55,17 @@ Migration to a new version is done on load `P = get_latest_project("example", mi
  - The Optimization constraints are now proportional to the default budget (latest) for that progset (`proporigconstraints`). This means a 100% min constraint actually means the min budget is the latest budget - as opposed to having to scale it up or down depending on the total budget. If an Optim also has `contraints` and `absconstraints` those will also be followed and reflected in the constraints shown. But if you change the optimization then the `constraints` and `absconstraints` will be removed.
 
 ## [2.12.2] - 
+ALL PLANNED / TODO:
+ - !! TB/HIV co-infection mortality
+ - Change acts to be better balanced
+ - Change acts to either be 0%, 50% or 100% insertive or receptive for a population, not based on the numbers in the Partnerships tab - these numbers are used to calibrate the split of a population's acts with the other populations, not the relative insertive/receptive split.
+ - `Multiresultset.parsetname` and `Multiresultset.progsetname` is now an odict, with a key and value for each result.
  - Change `forcepopsize` to not affect the number of PLHIV. The previous assumption was to remove (or add) people from (or into) the susceptible and the "not on ART" states. Now people only are removed from (or added into) the susceptible states.
 
 
-## [2.12.1] - 2023
-ALL PLANNED / TODO:
- - !! TB/HIV co-infection mortality
- - Change acts to either be 0%, 50% or 100% insertive or receptive for a population, not based on the numbers in the Partnerships tab - these numbers are used to calibrate the split of a population's acts with the other populations, not the relative insertive/receptive split.
- - `Multiresultset.parsetname` and `Multiresultset.progsetname` is now an odict, with a key and value for each result.
+## [2.12.1] - 2024-05-27
+ - Fix `numcirc` being set to 0 in the `Parameterset` upon loading from data - meaning running with just a parset had no VMMC. Running scenarios or programs affecting `numcirc` (eg. with VMMC program) were still working, just not the calibration.
+   - The migration reloads the `numcirc` in every `parset` from the `P.data` which is from the latest loaded spreadsheet (for the parsets that have `numcirc.y = 0`).
 
 
 ## [2.12.0] - 2023-

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -1626,7 +1626,7 @@ def fixzeronumcircparset(project=None, **kwargs):
         # Based on makepars()
         orignumcirc = project.parset().pars['numcirc']
         orignumcircdict = op.dcp(orignumcirc.__dict__)
-        for key in ['m', 't', 'y', 'projectversion']: orignumcircdict.pop(key)
+        for key in ['m', 't', 'y', 'projectversion']: orignumcircdict.pop(key, None)
 
         mpopkeys = [popkey for popno, popkey in enumerate(project.data['pops']['short']) if project.data['pops']['male'][popno]]
 

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -109,6 +109,7 @@ def setmigrations(which='migrations'):
         ('2.11.2', ('2.11.3', '2022-11-02', None,            'Annual data takes precedence over assumption when loading databook, bug fixes, FE Scenario tab add stacked for one scenario + other things.')),
         ('2.11.3', ('2.11.4', '2023-02-07',addallconstraintsoptim, 'Adds absconstraints and proporigconstraints to Optim, model works with initpeople and optimization improvements')),
         ('2.11.4', ('2.12.0', '2023-03-10',addinsertonlyacts,'Adds ANC testing to diagnose mothers to put onto PMTCT, actsreg etc only contain insertive acts, and relhivbirth only reduces birth rate of diagnosed HIV+ potential mothers.')),
+        ('2.12.0', ('2.12.1', '2024-05-27',fixzeronumcircparset,'Reloads numcirc "Number of voluntary medical male circumcisions" from data - was previously overriden to be zero')),
         ])
     
     
@@ -1615,6 +1616,25 @@ def addinsertonlyacts(project=None, **kwargs):
                     par.insertiveonly = False  # Previously generated parsets don't have insertive only
     return None
 
+
+def fixzeronumcircparset(project=None, **kwargs):
+    '''
+    Migration between Optima 2.12.0 and 2.12.1
+    This undos the parset.pars['numcirc'].y[key] = array([0.0]) that used to set `numcirc` to 0
+    '''
+    if project is not None:
+        dataparset = op.Parameterset(name='NewParsetFromData', project=project)
+        dataparset.projectversion = '2.12.1'
+        dataparset.makepars(project.data, start=project.data['years'][0], end=project.data['years'][-1], projectversion='2.12.1', verbose=0)  # Create parameters from data correctly, not setting numcirc to 0
+        replacementnumcirc = dataparset.pars['numcirc']
+        replacementnumcirc.projectversion = '2.12.0'
+
+        for parset in project.parsets.values():
+            allzero = all(parset.pars['numcirc'].y.values() == array([0]))
+            if allzero:
+                parset.pars['numcirc'] = replacementnumcirc
+        raise Exception('bob')
+    return None
 
 ##########################################################################################
 ### REVISION MIGRATION FUNCTIONS

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -1871,7 +1871,9 @@ def loadproj(filename=None, folder=None, verbose=2, die=None, fromdb=False, migr
             P = migrate(origP, migrateversion=migrateversion, verbose=verbose, die=die)
         except Exception as E:
             if die: raise E
-            else:   P = origP # Fail: return unmigrated version
+            else:
+                P = origP # Fail: return unmigrated version
+                print(f'WARNING: Error when trying to update project "{P.name}" from version {P.version}:\n'+str(E))
     else: P = origP # Don't migrate
 
     if P.version not in op.supported_versions:

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1383,10 +1383,11 @@ def makepars(data=None, verbose=2, die=True, fixprops=None, parset=None, project
 
     # Risk transitions - these are time-constant
     pars['risktransit'] = array(data['risktransit'])
-    
-    # Circumcision
-    for key in pars['numcirc'].keys():
-        pars['numcirc'].y[key] = array([0.0]) # Set to 0 for all populations, since program parameter only
+
+    if compareversions(projectversion, "2.12.1") < 0: # Pre-2.12.1 the numcirc data didn't make it to the parset
+        # Circumcision
+        for key in pars['numcirc'].keys():
+            pars['numcirc'].y[key] = array([0.0]) # Set to 0 for all populations, since program parameter only
     
     # Fix treatment from final data year
     for key in ['fixproptx', 'fixpropsupp', 'fixpropdx', 'fixpropcare', 'fixproppmtct']:

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -140,19 +140,19 @@ class Parameterset(object):
         output += '============================================================\n'
         return output
 
-    def getprojectversion(self, projectversion=None, die=False):
+    def getprojectversion(self, projectversion=None, die=False, verbose=2):
         if projectversion is None: projectversion = self.projectversion
         if projectversion is not None:  # We have a version, check that it matches projectref().version
             if isinstance(self.projectref.obj, op.Project) and self.projectref().version != projectversion:
                 err = f'Parset "{self.name}" was provided the projectversion={projectversion} which conflicts with the projectref().version={self.projectref().version}. Using {projectversion}'
                 if die: raise OptimaException(err)
-                else: print('WARNING: '+err)
+                else: printv('WARNING: '+err, 1, verbose)
             return projectversion
         # not provided with a version, get it from the project
         if self.projectref is None or not isinstance(self.projectref.obj, op.Project): # Missing both projectversion and projectref().version
             err = f'Parset "{self.name}" is missing a link to its project and therefore cannot get the project.version'
             if die: raise OptimaException(err)
-            else: print('WARNING: '+err)
+            else: printv('WARNING: '+err, 1, verbose)
             return None
         return self.projectref().version
     
@@ -191,7 +191,8 @@ class Parameterset(object):
             self.projectref = Link(project)
     
     def makepars(self, data=None, fix=True, verbose=2, start=None, end=None, projectversion=None):
-        self.pars = makepars(data=data, verbose=verbose, parset=self, projectversion=self.getprojectversion(projectversion)) # Initialize as list with single entry
+        self.pars = makepars(data=data, verbose=verbose, parset=self, # Initialize as list with single entry
+                             projectversion=self.getprojectversion(projectversion, verbose=verbose, die=False)) # Don't die here if we conflict
         self.fixprops(fix=fix)
         self.popkeys = dcp(self.pars['popkeys']) # Store population keys more accessibly
         if start is None: self.start = data['years'][0] # Store the start year -- if not supplied, use beginning of data
@@ -1267,7 +1268,7 @@ def makepars(data=None, verbose=2, die=True, fixprops=None, parset=None, project
     Version: 2017jun03
     """
     if projectversion is None:
-        try: projectversion = parset.getprojectversion(die=True)
+        try: projectversion = parset.getprojectversion(die=True, verbose=verbose)
         except Exception as e: raise OptimaException('Must pass parset or projectversion to makepars() as the behaviour is version-dependent') from e
 
     printv('Converting data to parameters...', 1, verbose)

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,6 +1,6 @@
-supported_versions = ['2.11.4','2.12.0']
+supported_versions = ['2.11.4','2.12.0','2.12.1']
 revision = '4'
-revisiondate = '2023-12-04'
+revisiondate = '2024-05-27'
 versions_different_databook = ['2.10.13']  # Versions where we start using a different databook format
 
 version = supported_versions[-1]


### PR DESCRIPTION
## [2.12.1] - 2024-05-27
 - Fix `numcirc` being set to 0 in the `Parameterset` upon loading from data - meaning running with just a parset had no VMMC. Running scenarios or programs affecting `numcirc` (eg. with VMMC program) were still working, just not the calibration.
   - The migration reloads the `numcirc` in every `parset` from the `P.data` which is from the latest loaded spreadsheet (for the parsets that have `numcirc.y = 0`).
