### PR TITLE
Update sensitivity seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Projects before `2.11.4` should be able to be migrated to version `2.11.4` witho
 
 Versions `2.11.4`, `2.12.0` and later all can be run using the branch `main`. A project will automatically update to the earliest supported version (currently `2.11.4`), but updating a project to the latest version can be done using the FE or `op.migrate(P, 'latest')`
 
+## Revision 5
+ - Update random number generator seeding in `runsim` by seeding a list of `default_rng` objects that are passed through to parameters that need to be sampled within each individual `makesimpars` to both ensure consistency and to avoid all parameters being sampled based on the same seed (e.g. all low or all high)
+
 ## Revision 4
  - Update methods of transmission tracking (`advancedtracking=True`) so `numinciallmethods` is split by regular, casual, commercial acts. `numincimethods` remains the same.
    - This causes `advancedtracking=True` to run ~20-25% slower as there is now 8 methods of transmission instead of 4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Versions `2.11.4`, `2.12.0` and later all can be run using the branch `main`. A 
 
 ## Revision 5
  - Update random number generator seeding in `runsim` by seeding a list of `default_rng` objects that are passed through to parameters that need to be sampled within each individual `makesimpars` to both ensure consistency and to avoid all parameters being sampled based on the same seed (e.g. all low or all high)
+ - When sampling, each parameter will use its own generator seeded by the global seed + a hash of the parameter short name - this means that changing which parameters are sampled will still be consistent for other parameters for the same seed, resulting in more consistent outputs
 
 ## Revision 4
  - Update methods of transmission tracking (`advancedtracking=True`) so `numinciallmethods` is split by regular, casual, commercial acts. `numincimethods` remains the same.

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -140,6 +140,7 @@ def setrevisionmigrations(which='migrations'):
         ('1',   ('2', '2023-12-04', None,                           'Fix bug when deep-copying a `Parameterset`, the `pars` from a different `Parameterset` would get copied in certain cases')),
         ('2',   ('3', '2024-01-18', None,                           'Fix small unpickling bug and FE raises BadFileFormatError when uploading project that it cannot unpickle')),
         ('3',   ('4', '2024-01-18', updatemethodsettings,           'Update methods so `numinciallmethods` is split by regular, casual, commercial')),
+        ('4',   ('5', '2024-06-26', None,                           'Update sampling of parameters to use default_rng to sample more randomly between parameters')),
         ])
 
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -937,7 +937,7 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
                 propnexttime = avbirthrate * relhivbirth * timestepsonpmtct
                 if proptobedx > 0.01: print(f'INFO: {tvec[t]}: Diagnosing {numdxforpmtct:.2f}={proptobedx * 100:.2f}% (wanted {numtobedx:.2f}) of pregnant undiagnosed HIV+ women. Only approx {propnexttime*100:.2f}% of these will be pregnant next time step')
                 propnewdiag = raw_diagcd4[:,:,t].sum(axis=(0,1))/(initrawdiag+eps)-1
-                if propnewdiag > 0.01: print(f'INFO: {tvec[t]}: Increasing number diagnosed this year from {initrawdiag:.3f} to {raw_diag[:,t].sum():.3f} (up {propnewdiag*100:.2f}%)')
+                if propnewdiag > 0.01: print(f'INFO: {tvec[t]}: Increasing number diagnosed this year from {initrawdiag:.3f} to {raw_diagcd4[:,t].sum():.3f} (up {propnewdiag*100:.2f}%)')
                 if abs(numwillbedx - numdxforpmtct) > eps:
                     print(f"WARNING: Tried to diagnose {numwillbedx} out of {numundxhivpospregwomen.sum()} undiagnosed pregnant women but instead diagnosed {numdxforpmtct} at time {tvec[t]}")
         elif calcproppmtct > 1:

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -13,6 +13,7 @@ from optima import Settings, getresults, convertlimits, gettvecdt, loadpartable,
 import optima as op
 from sciris import cp
 import hashlib
+from scipy.stats import truncnorm
 
 defaultsmoothness = 1.0 # The number of years of smoothing to do by default
 generalkeys = ['male', 'female', 'popkeys', 'injects', 'fromto', 'transmatrix'] # General parameter keys that are just copied
@@ -636,7 +637,7 @@ class Constant(Par):
     
     def sample(self, rng_sampler=None):
         ''' Recalculate ysample '''
-        self.ysample = self.prior.sample(n=1, rng_sampler=rng_sampler)[0]
+        self.ysample = self.prior.sample(n=1, rng_sampler=rng_sampler, best=self.y)[0]
         return None
     
     def updateprior(self, verbose=2):
@@ -700,7 +701,7 @@ class Metapar(Par):
         ''' Recalculate ysample '''
         self.ysample = odict()
         for key in self.keys():
-            self.ysample[key] = self.prior[key].sample(rng_sampler=rng_sampler)[0]
+            self.ysample[key] = self.prior[key].sample(rng_sampler=rng_sampler, best=self.y[key])[0]
         return None
     
     def updateprior(self, verbose=2):
@@ -779,7 +780,7 @@ class Timepar(Par):
     
     def sample(self, rng_sampler=None):
         ''' Recalculate msample '''
-        self.msample = self.prior.sample(n=1, rng_sampler=rng_sampler)[0]
+        self.msample = self.prior.sample(n=1, rng_sampler=rng_sampler, best=self.m)[0]
         return None
     
     def updateprior(self, verbose=2):
@@ -811,7 +812,7 @@ class Timepar(Par):
             if not sample:
                 meta = self.m
             else:
-                if sample=='new' or self.msample is None: self.sample(rng_sampler=rng_sampler) # msample doesn't exist, make it
+                if sample=='new' or self.msample is None: self.sample(rng_sampler=rng_sampler, best=self.m) # msample doesn't exist, make it
                 meta = self.msample
         
         # Set things up and do the interpolation
@@ -854,7 +855,7 @@ class Popsizepar(Par):
     
     def sample(self, rng_sampler=None):
         ''' Recalculate msample -- same as Timepar'''
-        self.msample = self.prior.sample(n=1, rng_sampler=rng_sampler)[0]
+        self.msample = self.prior.sample(n=1, rng_sampler=rng_sampler, best=self.m)[0]
         return None
     
     def updateprior(self, verbose=2):
@@ -888,7 +889,7 @@ class Popsizepar(Par):
             if not sample:
                 meta = self.m
             else:
-                if sample=='new' or self.msample is None: self.sample(rng_sampler=rng_sampler) # msample doesn't exist, make it
+                if sample=='new' or self.msample is None: self.sample(rng_sampler=rng_sampler, best=self.m) # msample doesn't exist, make it
                 meta = self.msample
                 
                 
@@ -941,7 +942,7 @@ class Yearpar(Par):
     def keys(self):
         return None 
     
-    def sample(self, rng_sampler=None):
+    def sample(self, rng_sampler=None, best=None):
         ''' No sampling, so simply return the value '''
         return self.t
     
@@ -966,8 +967,12 @@ class Dist(object):
         output = defaultrepr(self)
         return output
     
-    def sample(self, n=1, rng_sampler=None):
-        ''' Draw random samples from the specified distribution '''
+    def sample(self, n=1, rng_sampler=None, best=None):
+        ''' Draw random samples from the specified distribution 
+        Optionally specify a best value (e.g. the defined parameter value)
+        '''
+        if best is None:
+            best = mean(self.pars) #if not specified take the midpoint
         if self.dist=='uniform':
             if rng_sampler is None:
                 samples = uniform(low=self.pars[0], high=self.pars[1], size=n)
@@ -975,10 +980,11 @@ class Dist(object):
                 samples = rng_sampler.uniform(low=self.pars[0], high=self.pars[1], size=n)
             return samples
         if self.dist=='normal':
-            if rng_sampler is None:
-                return normal(loc=self.pars[0], scale=self.pars[1], size=n)
-            else:
-                return rng_sampler.normal(loc=self.pars[0], scale=self.pars[1], size=n)
+            #Take a normal distribution centered on the best value assuming the low and high values represent a 95% confidence interval but rejecting samples outside of this range (to avoid model errors)
+            normal_samples = truncnorm.rvs(a=-2, b=2, loc=0, scale=0.5, size=n, random_state=rng_sampler) #+-2 standard deviations = 95% confidence interval
+            #rescale to the best/low/high
+            rescaling_factors = array([(best-self.pars[0]) if sample<0 else self.pars[1]-best for sample in normal_samples])
+            return best + normal_samples*rescaling_factors 
         else:
             errormsg = 'Distribution "%s" not defined; available choices are: uniform, normal' % self.dist
             raise OptimaException(errormsg)

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -983,8 +983,10 @@ class Dist(object):
             #Take a normal distribution centered on the best value assuming the low and high values represent a 95% confidence interval but rejecting samples outside of this range (to avoid model errors)
             normal_samples = truncnorm.rvs(a=-2, b=2, loc=0, scale=0.5, size=n, random_state=rng_sampler) #+-2 standard deviations = 95% confidence interval
             #rescale to the best/low/high
-            rescaling_factors = array([(best-self.pars[0]) if sample<0 else self.pars[1]-best for sample in normal_samples])
-            return best + normal_samples*rescaling_factors 
+            normal_samples[normal_samples < 0] *= (best - self.pars[0])
+            normal_samples[normal_samples > 0] *= (self.pars[1] - best)
+            normal_samples += best
+            return normal_samples
         else:
             errormsg = 'Distribution "%s" not defined; available choices are: uniform, normal' % self.dist
             raise OptimaException(errormsg)

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -13,6 +13,8 @@ from optima import Settings, getresults, convertlimits, gettvecdt, loadpartable,
 import optima as op
 from sciris import cp
 
+MAXSEED = 2**31-1
+
 defaultsmoothness = 1.0 # The number of years of smoothing to do by default
 generalkeys = ['male', 'female', 'popkeys', 'injects', 'fromto', 'transmatrix'] # General parameter keys that are just copied
 staticmatrixkeys = ['birthtransit','agetransit','risktransit'] # Static keys that are also copied, but differently :)
@@ -635,7 +637,7 @@ class Constant(Par):
     
     def sample(self, randseed=None):
         ''' Recalculate ysample '''
-        self.ysample = self.prior.sample(n=1, randseed=randseed)[0]
+        self.ysample = self.prior.sample(n=1, randseed=randseed, hashval=hash(self.short))[0]
         return None
     
     def updateprior(self, verbose=2):
@@ -699,7 +701,7 @@ class Metapar(Par):
         ''' Recalculate ysample '''
         self.ysample = odict()
         for key in self.keys():
-            self.ysample[key] = self.prior[key].sample(randseed=randseed)[0]
+            self.ysample[key] = self.prior[key].sample(randseed=randseed, hashval=hash(self.short+key))[0]
         return None
     
     def updateprior(self, verbose=2):
@@ -778,7 +780,7 @@ class Timepar(Par):
     
     def sample(self, randseed=None):
         ''' Recalculate msample '''
-        self.msample = self.prior.sample(n=1, randseed=randseed)[0]
+        self.msample = self.prior.sample(n=1, randseed=randseed, hashval=hash(self.short))[0]
         return None
     
     def updateprior(self, verbose=2):
@@ -853,7 +855,7 @@ class Popsizepar(Par):
     
     def sample(self, randseed=None):
         ''' Recalculate msample -- same as Timepar'''
-        self.msample = self.prior.sample(n=1, randseed=randseed)[0]
+        self.msample = self.prior.sample(n=1, randseed=randseed, hashval=hash(self.short))[0]
         return None
     
     def updateprior(self, verbose=2):
@@ -965,9 +967,9 @@ class Dist(object):
         output = defaultrepr(self)
         return output
     
-    def sample(self, n=1, randseed=None):
+    def sample(self, n=1, randseed=None, hashval=0):
         ''' Draw random samples from the specified distribution '''
-        if randseed is not None: seed(randseed) # Reset the random seed, if specified
+        if randseed is not None: seed((randseed+hashval) % MAXSEED) # Reset the random seed, if specified
         if self.dist=='uniform':
             samples = uniform(low=self.pars[0], high=self.pars[1], size=n)
             return samples

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -1517,8 +1517,7 @@ def makesimpars(pars, name=None, keys=None, start=None, end=None, dt=None, tvec=
         try: projectversion = pars['popsize'].getprojectversion(die=True)
         except Exception as e: raise OptimaException('Must pass projectversion to makesimpars() as the behaviour is version-dependent') from e
 
-    rng_sampler = default_rng(randseed)
-
+    rng_sampler = default_rng(randseed) #a single random nummber generator to pass through to all parameters that need sampling for reproducibility if seeded
 
     # Copy default keys by default
     for key in generalkeys: simpars[key] = dcp(pars[key])

--- a/optima/project.py
+++ b/optima/project.py
@@ -4,7 +4,7 @@ from optima import loadspreadsheet, model, gitinfo, defaultscenarios, makesimpar
 from optima import defaultobjectives, autofit, runscenarios, optimize, multioptimize, tvoptimize, outcomecalc, icers # Import functions
 from optima import supported_versions, revision, cpu_count # Get current version
 from numpy import argmin, argsort, nan, ceil
-from numpy.random import seed, randint
+from numpy.random import seed, randint, default_rng
 from time import time
 from sciris import parallelize
 
@@ -677,16 +677,16 @@ class Project(object):
         if simpars is None: # Optionally run with a precreated simpars instead
             simparslist = [] # Needs to be a list
             if n>1 and sample is None: sample = 'new' # No point drawing more than one sample unless you're going to use uncertainty
-            if randseed is not None: seed(randseed) # Reset the random seed, if specified
+            rng_sampler = default_rng(randseed)
             if start is None: 
                 try:    start = self.parsets[parsetname].start # Try to get start from parameter set, but don't worry if it doesn't exist
                 except: start = self.settings.start # Else, specify the start year from the project
             if end is None: 
                 try:    end   = self.parsets[parsetname].end # Ditto
                 except: end   = self.settings.end # Ditto
-            for i in range(n):
-                maxint = 2**31-1 # See https://en.wikipedia.org/wiki/2147483647_(number)
-                sampleseed = randint(0,maxint) if sample is not None else None
+            maxint = 2**31-1 # See https://en.wikipedia.org/wiki/2147483647_(number)
+            sampleseeds = rng_sampler.integers(0, maxint, n)
+            for sampleseed in sampleseeds:
                 simparslist.append(makesimpars(pars, projectversion=self.version, start=start, end=end, dt=dt, tvec=tvec, settings=self.settings, name=parsetname, sample=sample, tosample=tosample, randseed=sampleseed, smoothness=smoothness))
         else:
             simparslist = promotetolist(simpars)

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,5 +1,5 @@
 supported_versions = ['2.11.4','2.12.0','2.12.1']
-revision = '4'
+revision = '5'
 revisiondate = '2024-05-27'
 versions_different_databook = ['2.10.13']  # Versions where we start using a different databook format
 


### PR DESCRIPTION
Update random number generator seeding in `runsim` by seeding a list of `default_rng` objects that are passed through to parameters that need to be sampled within each individual `makesimpars` to both ensure consistency and to avoid all parameters being sampled based on the same seed (e.g. all low or all high)