### PR TITLE
Fix / clean up PMTCT and MTCT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ ALL PLANNED / TODO:
 # [2.12.2] - 2024-07-12
  - Clean up MTCT code and fix problems:
    - MTCT of people on ART was being double-counted
-   - Total births was too high - wasn't taking `relhivbirth` into account (but didn't add extra MTCT, just extra susceptible births)
+   - CHANGES to tx and dx split of PMTCT !!
  - Fix rare negative people issue when FOI is very high - make FOI = min(FOI, 1)
 
 ## [2.12.1] - 2024-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,11 +67,16 @@ ALL PLANNED / TODO:
  - Change `forcepopsize` to not affect the number of PLHIV. The previous assumption was to remove (or add) people from (or into) the susceptible and the "not on ART" states. Now people only are removed from (or added into) the susceptible states.
 
 
-# [2.12.2] - 2024-07-12
+# [2.12.2] - 2024-07-17
  - Clean up MTCT code and fix problems:
    - MTCT of people on ART was being double-counted
-   - CHANGES to tx and dx split of PMTCT !!
- - Fix rare negative people issue when FOI is very high - make FOI = min(FOI, 1)
+   - Changed who PMTCT goes to based on their diagnosis / treatment state:
+     - Previously went randomly to anyone diagnosed, including people diagnosed but not in care. This meant some pregnant people on ART were not getting PMTCT but they were getting the low probability of transmission from being on ART.
+     - eg: 100 preg people on ART, 100 preg people who are dx but not on ART, data PMTCT: 100 on PMTCT -> 50 dx (not on ART people) on PMTCT, 50 people on ART also on PMTCT, 50 people on ART but not PMTCT = 150 births at the lower probability of being on PMTCT
+     - Now: first give PMTCT to anyone on ART, then if there is more PMTCT spots, put any diagnosed people not on ART onto PMTCT. Then if there is more PMTCT spots, try to diagnose people to put onto PMTCT (they can go onto ART next time step if there is spots).
+     - eg: 100 preg people on ART, 100 preg people who are dx but not on ART, data PMTCT: 100 on PMTCT -> *Only* 100 on ART also PMTCT = 100 births on PMTCT
+     - NOTE: this can mean that populations which have more people on ART get more PMTCT if there is only enough spots for the number of people on ART
+ - Fix rare negative people issue when FOI is very high (when probability of infection for a population is >1) - make FOI = min(FOI, 1)
 
 ## [2.12.1] - 2024-05-27
  - Fix `numcirc` being set to 0 in the `Parameterset` upon loading from data - meaning running with just a parset had no VMMC. Running scenarios or programs affecting `numcirc` (eg. with VMMC program) were still working, just not the calibration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Migration to a new version is done on load `P = get_latest_project("example", mi
  - An error will show if making a program with the same long or short name as another one.
  - The Optimization constraints are now proportional to the default budget (latest) for that progset (`proporigconstraints`). This means a 100% min constraint actually means the min budget is the latest budget - as opposed to having to scale it up or down depending on the total budget. If an Optim also has `contraints` and `absconstraints` those will also be followed and reflected in the constraints shown. But if you change the optimization then the `constraints` and `absconstraints` will be removed.
 
-## [2.12.2] - 
+## [2.12.3] - 
 ALL PLANNED / TODO:
  - !! TB/HIV co-infection mortality
  - Change acts to be better balanced
@@ -66,6 +66,12 @@ ALL PLANNED / TODO:
  - `Multiresultset.parsetname` and `Multiresultset.progsetname` is now an odict, with a key and value for each result.
  - Change `forcepopsize` to not affect the number of PLHIV. The previous assumption was to remove (or add) people from (or into) the susceptible and the "not on ART" states. Now people only are removed from (or added into) the susceptible states.
 
+
+# [2.12.2] - 2024-07-12
+ - Clean up MTCT code and fix problems:
+   - MTCT of people on ART was being double-counted
+   - Total births was too high - wasn't taking `relhivbirth` into account (but didn't add extra MTCT, just extra susceptible births)
+ - Fix rare negative people issue when FOI is very high - make FOI = min(FOI, 1)
 
 ## [2.12.1] - 2024-05-27
  - Fix `numcirc` being set to 0 in the `Parameterset` upon loading from data - meaning running with just a parset had no VMMC. Running scenarios or programs affecting `numcirc` (eg. with VMMC program) were still working, just not the calibration.

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -110,7 +110,7 @@ def setmigrations(which='migrations'):
         ('2.11.3', ('2.11.4', '2023-02-07',addallconstraintsoptim, 'Adds absconstraints and proporigconstraints to Optim, model works with initpeople and optimization improvements')),
         ('2.11.4', ('2.12.0', '2023-03-10',addinsertonlyacts,'Adds ANC testing to diagnose mothers to put onto PMTCT, actsreg etc only contain insertive acts, and relhivbirth only reduces birth rate of diagnosed HIV+ potential mothers.')),
         ('2.12.0', ('2.12.1', '2024-05-27',fixzeronumcircparset,'Reloads numcirc "Number of voluntary medical male circumcisions" from data - was previously overriden to be zero')),
-        ('2.12.1', ('2.12.2', '2024-05-27',None , 'Fix MTCT being double-counting MTCT of people on ART')),
+        ('2.12.1', ('2.12.2', '2024-07-12',None ,            'Fix MTCT: previously double-counting MTCT of people on ART')),
         ])
     
     

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -110,6 +110,7 @@ def setmigrations(which='migrations'):
         ('2.11.3', ('2.11.4', '2023-02-07',addallconstraintsoptim, 'Adds absconstraints and proporigconstraints to Optim, model works with initpeople and optimization improvements')),
         ('2.11.4', ('2.12.0', '2023-03-10',addinsertonlyacts,'Adds ANC testing to diagnose mothers to put onto PMTCT, actsreg etc only contain insertive acts, and relhivbirth only reduces birth rate of diagnosed HIV+ potential mothers.')),
         ('2.12.0', ('2.12.1', '2024-05-27',fixzeronumcircparset,'Reloads numcirc "Number of voluntary medical male circumcisions" from data - was previously overriden to be zero')),
+        ('2.12.1', ('2.12.2', '2024-05-27',None , 'Fix MTCT being double-counting MTCT of people on ART')),
         ])
     
     

--- a/optima/model.py
+++ b/optima/model.py
@@ -853,7 +853,7 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
         ### Calculate births
         ##############################################################################################################
 
-        undxhivbirths, dxhivbirths, thisproppmtct = do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, version, undx, dx, alldx, alltx, allplhiv, sus,mtct,nstates,
+        undxhivbirths, dxhivbirths, thisproppmtct = do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, version, undx, dx, alldx, alltx, allplhiv, sus,mtct,nstates,dxnottx,
               motherpops, childpops, notmotherpops, effmtct, pmtcteff, plhivmap, advancedtracking, settings,
               numpmtct, proppmtct, raw_inci, raw_incibypop, raw_diagcd4, raw_incionpopbypopmethods, raw_mtct,
               raw_births, raw_hivbirths, raw_dxforpmtct, raw_receivepmtct, debug)
@@ -1111,7 +1111,7 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
     return raw # Return raw results
 
 
-def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, version, undx, dx, alldx, alltx, allplhiv, sus,mtct,nstates,
+def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, version, undx, dx, alldx, alltx, allplhiv, sus,mtct,nstates,dxnottx,
               motherpops, childpops, notmotherpops, effmtct, pmtcteff, plhivmap, advancedtracking, settings,
               numpmtct, proppmtct, raw_inci, raw_incibypop, raw_diagcd4, raw_incionpopbypopmethods, raw_mtct,
               raw_births, raw_hivbirths, raw_dxforpmtct, raw_receivepmtct, debug):

--- a/optima/model.py
+++ b/optima/model.py
@@ -30,9 +30,6 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
     if initpeople is not None and initprops is None:
         print('WARNING, results with initpeople are unreliable if you don\'t also provide the full vectors of propdx, propcare etc through initprops!')
 
-    # PMTCT behaviour
-    oldbehaviour = compareversions(version,"2.12.0") < 0 # Remove new pmtct behaviour from 2.11.x versions and before
-
     # Extract key items
     popkeys         = simpars['popkeys']
     npops           = len(popkeys)

--- a/optima/model.py
+++ b/optima/model.py
@@ -130,6 +130,7 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
     mtct            = settings.mtct                 # Infection via MTCT
     nonmtctmethods  = sorted(settings.nonmtctmethods)
     nmethods        = settings.nmethods
+    dxnottx         = [state for state in alldx if state not in alltx]
 
     allcd4          = [acute,gt500,gt350,gt200,gt50,lt50]
 
@@ -1138,18 +1139,17 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         return undxhivbirths, dxhivbirths, 0.0
 
     timestepsonpmtct = 1./dt # Specify the number of timesteps on which mothers are on PMTCT -- # WARNING: remove hard-coding
-    _sus,_undx,_dxnottx,_alltx, _all = range(5) # Start with underscore to not override other variables
-    nummothers = zeros((len(motherpops),5)) # nummothers is mothers in this timestep since birthratesarr is per timestep since # birth = simpars['birth']*dt
+    _sus,_undx,_dxnottx,_alltx = range(4) # Start with underscore to not override other variables
+    nummothers = zeros((len(motherpops),4)) # nummothers is mothers in this timestep since birthratesarr is per timestep since # birth = simpars['birth']*dt
 
-    nummothers[:,_sus]    = people[ix_(sus, motherpops, [t])].sum(axis=(0,2))   * birthratesarr[motherpops,:,t].sum(axis=1)
-    nummothers[:,_undx]   = people[ix_(undx, motherpops, [t])].sum(axis=(0,2))  * birthratesarr[motherpops,:,t].sum(axis=1)  # THIS LINE
-    nummothers[:,_dxnottx]= people[ix_(alldx, motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
-    nummothers[:,_alltx]  = people[ix_(alltx, motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
 
-    nummothers[:, _all] = people[ix_(range(settings.nstates), motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1)
+    nummothers[:,_sus]    = people[ix_(sus, motherpops, [t])].sum(axis=(0,2))     * birthratesarr[motherpops,:,t].sum(axis=1)
+    nummothers[:,_undx]   = people[ix_(undx, motherpops, [t])].sum(axis=(0,2))    * birthratesarr[motherpops,:,t].sum(axis=1)  # THIS LINE
+    nummothers[:,_dxnottx]= people[ix_(dxnottx, motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
+    nummothers[:,_alltx]  = people[ix_(alltx, motherpops, [t])].sum(axis=(0,2))   * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
 
-    nummothers_allplhiv = lambda _nummothers: _nummothers[:, _undx] + _nummothers[:, _dxnottx]
-    nummothers_alldx    = lambda _nummothers:                         _nummothers[:, _dxnottx]
+    nummothers_allplhiv = lambda _nummothers: _nummothers[:, _undx] + _nummothers[:, _dxnottx] + _nummothers[:, _alltx]
+    nummothers_alldx    = lambda _nummothers:                         _nummothers[:, _dxnottx] + _nummothers[:, _alltx]
     nummothers_all      = lambda _nummothers: _nummothers[:,_sus] + nummothers_allplhiv(_nummothers)
 
     # old behaviour is proppmtctofdx =  numpmtct/ dxpregwomen, and proppmtct = numpmtct / dxpregwomen
@@ -1220,7 +1220,7 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         births = zeros((10, len(motherpops),len(childpops)))
         _allbirths, _fromhivpos, _fromundx, _fromdxnottx, _fromalltx, mtct_fromundx, mtct_fromdxnottx, mtct_fromalltx, pmtct_received, mtct_fromonpmtct = range(10)
 
-        births[_allbirths]   = einsum('ij,i->ij', thisbirthrates, nummothers[:,_all])
+        births[_allbirths]   = einsum('ij,i->ij', thisbirthrates, nummothers_all(nummothers))
         births[_fromhivpos]  = einsum('ij,i->ij', thisbirthrates, nummothers_allplhiv(nummothers))
         # _fromundx + _fromdxnottx + _fromalltx = _fromhivpos
         births[_fromundx]    = einsum('ij,i->ij', thisbirthrates, nummothers[:,_undx])
@@ -1337,8 +1337,8 @@ def deprecated_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npop
             numdxhivpospregwomen[:]   += thispoptobedx
             # The below code looks weird but is right - in order to match the changes to the num giving birth (numundxhivpospregwomen) this is saying that we diagnose more mothers than we actually did.
             # However, this does give the right number of people on PMTCT - otherwise only a small percentage of them will actually go onto PMTCT. And we don't actually put them into the diagnosed class
-            numpotmothers[:, _undx]   -= thispoptobedx / (totalbirthrate) # assuming all diagnosed by ANC will go onto PMTCT
-            numpotmothers[:, _alldx]  += thispoptobedx / (totalbirthrate) # eps not small enough
+            numpotmothers[:, _undx]   -= thispoptobedx / (totalbirthrate + eps*eps) # assuming all diagnosed by ANC will go onto PMTCT
+            numpotmothers[:, _alldx]  += thispoptobedx / (totalbirthrate + eps*eps) # eps not small enough
             thisnumpmtct              += thispoptobedx.sum(axis=0)
 
         if t < npts-1:

--- a/optima/model.py
+++ b/optima/model.py
@@ -667,11 +667,11 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
 
         forceinffullsex = ones((len(sus), nstates, nallsexacts))
         # only effallprev[:,:] is time dependent
-        forceinffullsex[:,:,:] *= 1 - einsum('m,m,m,mi,km->ikm', fracactssexarr[:,t], transsexarr[:,t],
-                                            condarr[:,t], alleff[:,t,:][pop1,:], effallprev[:,pop2])
+        forceinffullsex[:,:,:] *= 1 - minimum(einsum('m,m,m,mi,km->ikm', fracactssexarr[:,t], transsexarr[:,t],
+                                            condarr[:,t], alleff[:,t,:][pop1,:], effallprev[:,pop2]), 1)
 
-        forceinffullsex[:,:,:] *= npow(1 - einsum('m,m,mi,km,m->ikm', transsexarr[:,t], condarr[:,t], alleff[pop1,t,:], effallprev[:,pop2],
-                            (wholeactssexarr[:,t].astype(int) != 0) ), wholeactssexarr[:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
+        forceinffullsex[:,:,:] *= npow(1 - minimum(einsum('m,m,mi,km,m->ikm', transsexarr[:,t], condarr[:,t], alleff[pop1,t,:], effallprev[:,pop2],
+                            (wholeactssexarr[:,t].astype(int) != 0) ),1), wholeactssexarr[:,t].astype(int))  # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
 
         for inds in regularityinds:  # Loops over the indices of acts for regular, casual, commercial so we don't overlap with pop1,pop2 pairs
             forceinffull[:,pop1[inds],:,pop2[inds]] *= swapaxes(swapaxes(forceinffullsex[:,:,inds],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension
@@ -698,11 +698,11 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
         pop2 = injpartnerarr[:, 1]
         forceinffullinj = ones((len(sus), nstates, len(pop1)))
 
-        forceinffullinj[:,:,:] *= 1 - einsum(',,m,m,m,km,i->ikm',transinj, osteff[t], sharing[pop1,t], prepeff[pop1,t],
-                                              fracactsinjarr[:,t], effallprev[:,pop2], [1,1]) # The [1,1] applies the same risk to both circs and uncircs, as it does not matter
+        forceinffullinj[:,:,:] *= 1 - minimum(einsum(',,m,m,m,km,i->ikm',transinj, osteff[t], sharing[pop1,t], prepeff[pop1,t],
+                                              fracactsinjarr[:,t], effallprev[:,pop2], [1,1]),1) # The [1,1] applies the same risk to both circs and uncircs, as it does not matter
 
-        forceinffullinj[:,:,:] *= npow(1 - einsum(',,m,m,km,i,m->ikm',transinj, osteff[t], sharing[pop1,t], prepeff[pop1,t],
-                                                      effallprev[:,pop2], [1,1], (wholeactsinjarr[:,t].astype(int) != 0) ),
+        forceinffullinj[:,:,:] *= npow(1 - minimum(einsum(',,m,m,km,i,m->ikm',transinj, osteff[t], sharing[pop1,t], prepeff[pop1,t],
+                                                      effallprev[:,pop2], [1,1], (wholeactsinjarr[:,t].astype(int) != 0) ),1),
                                         wholeactsinjarr[:,t].astype(int))   # If wholeacts[t] == 0, then this will equal one so will not change forceinffull
 
         forceinffull[:,pop1,:,pop2] *= swapaxes(swapaxes(forceinffullinj[:,:,:],1,2),0,1)  # Slicing a more than 2d array puts the pop1,pop2 in the first dimension

--- a/optima/model.py
+++ b/optima/model.py
@@ -1231,16 +1231,6 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
     births[mtct_fromdxnottx] = births[_fromdxnottx] * (proppmtctofdxnottx*pmtcteff[t] + (1-proppmtctofdxnottx)*effmtct[t])
     births[mtct_fromalltx]   = births[_fromalltx] * pmtcteff[t] # (proppmtctoftx*pmtcteff[t] + (1-proppmtctoftx)*pmtcteff[t])  # People on pmtct get pmtcteff[t], and people on art only also get pmtcteff[t] probability
 
-# current
-# 100 on ART, 100 dx not on ART, 100 on PMTCT -> 50 dx on PMTCT, 50 ART on PMTCT, 50 ART not PMTCT = 150 births on PMTCT
-# 100 on ART, 100 dx not on ART, 100 on PMTCT -> 100 on ART also PMTCT = 100 births on PMTCT
-
-# new
-# 100 on ART, 100 dx not on ART, 150 on PMTCT -> 100 on ART also PMTCT, 50 dx not on ART on PMTCT = 150 births on PMTCT
-# 100 on ART, 100 undx, 150 on PMTCT -> dx 50 -> 100 on ART also PMTCT, 50 dx not on ART on PMTCT = 150 births on PMTCT
-# proppmtctart -> 1 -> proppmtctdxnottx > 1
-#
-
     births[pmtct_received]   = births[_fromdxnottx] * proppmtctofdxnottx + births[_fromalltx] * proppmtctoftx
     births[mtct_fromonpmtct] = births[pmtct_received] * pmtcteff[t] # Don't include this in total, this would double up on dx, tx pmtct births
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -854,7 +854,7 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
         ##############################################################################################################
 
         undxhivbirths, dxhivbirths, thisproppmtct = do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, version, undx, dx, alldx, alltx, allplhiv, sus,mtct,nstates,dxnottx,
-              motherpops, childpops, notmotherpops, effmtct, pmtcteff, plhivmap, advancedtracking, settings, mtctgroupmap,
+              motherpops, childpops, notmotherpops, effmtct, pmtcteff, plhivmap, advancedtracking, settings, mtctgroupmap, tvec,
               numpmtct, proppmtct, raw_inci, raw_incibypop, raw_diagcd4, raw_incionpopbypopmethods, raw_mtct,
               raw_births, raw_hivbirths, raw_dxforpmtct, raw_receivepmtct, debug)
 
@@ -1112,7 +1112,7 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
 
 
 def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, version, undx, dx, alldx, alltx, allplhiv, sus,mtct,nstates,dxnottx,
-              motherpops, childpops, notmotherpops, effmtct, pmtcteff, plhivmap, advancedtracking, settings, mtctgroupmap,
+              motherpops, childpops, notmotherpops, effmtct, pmtcteff, plhivmap, advancedtracking, settings, mtctgroupmap, tvec,
               numpmtct, proppmtct, raw_inci, raw_incibypop, raw_diagcd4, raw_incionpopbypopmethods, raw_mtct,
               raw_births, raw_hivbirths, raw_dxforpmtct, raw_receivepmtct, debug):
 
@@ -1177,7 +1177,7 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         if debug:
             numwillbedx = proptobedx * nummothers[_undx, :].sum()
             initrawdiag = raw_diagcd4[:,:,t].sum(axis=(0,1))
-            numdxforpmtct += thispoptobedx.sum()  # in this timestep aka not annualised
+            numdxforpmtct = thispoptobedx.sum()  # in this timestep aka not annualised
 
         # Update outputs
         raw_diagcd4[:,motherpops,t]  += thispoptobedx             /dt  # annualise
@@ -1193,12 +1193,12 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
             if (people[undx,:,t+1] < 0).any():
                 print(f"WARNING: Tried to diagnose {thispoptobedx} pregnant HIV+ women from populations {motherpops} but this made the people negative:{people[undx,p1,t+1]}")
         if debug:
-            totalbirthrate = array(totalbirthrate)
+            totalbirthrate = array(thisbirthrates)
             avbirthrate = sum(totalbirthrate[totalbirthrate!=0]) / sum(totalbirthrate!=0)
-            propnexttime = avbirthrate * relhivbirth * timestepsonpmtct
-            if proptobedx > 0.01: print(f'INFO: {tvec[t]}: Diagnosing {numdxforpmtct:.2f}={proptobedx * 100:.2f}% (wanted {numtobedx:.2f}) of pregnant undiagnosed HIV+ women. Only approx {propnexttime*100:.2f}% of these will be pregnant next time step')
+            # propnexttime = avbirthrate * relhivbirth * timestepsonpmtct
+            if proptobedx > 0.01: print(f'DEBUG: {tvec[t]}: Diagnosing {numdxforpmtct:.2f}={proptobedx * 100:.2f}% (wanted {numtobedx:.2f}) of pregnant undiagnosed HIV+ women.')
             propnewdiag = raw_diagcd4[:,:,t].sum(axis=(0,1))/(initrawdiag+eps)-1
-            if propnewdiag > 0.01: print(f'INFO: {tvec[t]}: Increasing number diagnosed this year from {initrawdiag:.3f} to {raw_diag[:,t].sum():.3f} (up {propnewdiag*100:.2f}%)')
+            if propnewdiag > 0.01: print(f'DEBUG: {tvec[t]}: Increasing number diagnosed this year from {initrawdiag:.3f} to {raw_diagcd4[:,:,t].sum():.3f} (up {propnewdiag*100:.2f}%)')
             if abs(numwillbedx - numdxforpmtct) > eps:
                 print(f"WARNING: Tried to diagnose {numwillbedx} out of {numundxhivpospregwomen.sum()} undiagnosed pregnant women but instead diagnosed {numdxforpmtct} at time {tvec[t]}")
     elif proppmtctofdxnottx > 1:

--- a/optima/model.py
+++ b/optima/model.py
@@ -130,6 +130,7 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
     mtct            = settings.mtct                 # Infection via MTCT
     nonmtctmethods  = sorted(settings.nonmtctmethods)
     nmethods        = settings.nmethods
+    dxnottx         = [state for state in alldx if state not in alltx]
 
     allcd4          = [acute,gt500,gt350,gt200,gt50,lt50]
 
@@ -1138,18 +1139,17 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         return undxhivbirths, dxhivbirths, 0.0
 
     timestepsonpmtct = 1./dt # Specify the number of timesteps on which mothers are on PMTCT -- # WARNING: remove hard-coding
-    _sus,_undx,_dxnottx,_alltx, _all = range(5) # Start with underscore to not override other variables
-    nummothers = zeros((len(motherpops),5)) # nummothers is mothers in this timestep since birthratesarr is per timestep since # birth = simpars['birth']*dt
+    _sus,_undx,_dxnottx,_alltx = range(4) # Start with underscore to not override other variables
+    nummothers = zeros((len(motherpops),4)) # nummothers is mothers in this timestep since birthratesarr is per timestep since # birth = simpars['birth']*dt
 
-    nummothers[:,_sus]    = people[ix_(sus, motherpops, [t])].sum(axis=(0,2))   * birthratesarr[motherpops,:,t].sum(axis=1)
-    nummothers[:,_undx]   = people[ix_(undx, motherpops, [t])].sum(axis=(0,2))  * birthratesarr[motherpops,:,t].sum(axis=1)  # THIS LINE
-    nummothers[:,_dxnottx]= people[ix_(alldx, motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
-    nummothers[:,_alltx]  = people[ix_(alltx, motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
 
-    nummothers[:, _all] = people[ix_(range(settings.nstates), motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1)
+    nummothers[:,_sus]    = people[ix_(sus, motherpops, [t])].sum(axis=(0,2))     * birthratesarr[motherpops,:,t].sum(axis=1)
+    nummothers[:,_undx]   = people[ix_(undx, motherpops, [t])].sum(axis=(0,2))    * birthratesarr[motherpops,:,t].sum(axis=1)  # THIS LINE
+    nummothers[:,_dxnottx]= people[ix_(dxnottx, motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
+    nummothers[:,_alltx]  = people[ix_(alltx, motherpops, [t])].sum(axis=(0,2))   * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
 
-    nummothers_allplhiv = lambda _nummothers: _nummothers[:, _undx] + _nummothers[:, _dxnottx]
-    nummothers_alldx    = lambda _nummothers:                         _nummothers[:, _dxnottx]
+    nummothers_allplhiv = lambda _nummothers: _nummothers[:, _undx] + _nummothers[:, _dxnottx] + _nummothers[:, _alltx]
+    nummothers_alldx    = lambda _nummothers:                         _nummothers[:, _dxnottx] + _nummothers[:, _alltx]
     nummothers_all      = lambda _nummothers: _nummothers[:,_sus] + nummothers_allplhiv(_nummothers)
 
     # old behaviour is proppmtctofdx =  numpmtct/ dxpregwomen, and proppmtct = numpmtct / dxpregwomen
@@ -1220,7 +1220,7 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         births = zeros((10, len(motherpops),len(childpops)))
         _allbirths, _fromhivpos, _fromundx, _fromdxnottx, _fromalltx, mtct_fromundx, mtct_fromdxnottx, mtct_fromalltx, pmtct_received, mtct_fromonpmtct = range(10)
 
-        births[_allbirths]   = einsum('ij,i->ij', thisbirthrates, nummothers[:,_all])
+        births[_allbirths]   = einsum('ij,i->ij', thisbirthrates, nummothers_all(nummothers))
         births[_fromhivpos]  = einsum('ij,i->ij', thisbirthrates, nummothers_allplhiv(nummothers))
         # _fromundx + _fromdxnottx + _fromalltx = _fromhivpos
         births[_fromundx]    = einsum('ij,i->ij', thisbirthrates, nummothers[:,_undx])
@@ -1233,7 +1233,7 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         births[mtct_fromalltx]   = births[_fromalltx] * pmtcteff[t] # (proppmtctofdx*pmtcteff[t] + (1-proppmtctofdx)*pmtcteff[t])  # People on pmtct get pmtcteff[t], and people on art only also get pmtcteff[t] probability
 
         # Don't include this in total, this would double up on dx, tx pmtct births
-        births[pmtct_received]   = (births[_fromdxnottx]) * proppmtctofdx
+        births[pmtct_received]   = (births[_fromdxnottx] + births[_fromalltx]) * proppmtctofdx
         births[mtct_fromonpmtct] = (births[_fromdxnottx] + births[_fromalltx]) * proppmtctofdx * pmtcteff[t]
 
         # Outputs and update raw_s
@@ -1245,9 +1245,6 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         raw_receivepmtct[motherpops, t] = births[pmtct_received].sum(axis=1) * timestepsonpmtct # annualise / convert from births to preg women
         raw_mtct[childpops, t] += (births[mtct_fromundx] + births[mtct_fromdxnottx] + births[mtct_fromalltx]).sum(axis=0)/dt
         raw_inci[childpops,t] += raw_mtct[childpops,t]  # already annualised
-
-        print(t,version, undxhivbirths.sum(), dxhivbirths.sum(), births[_allbirths].sum(), raw_receivepmtct[motherpops, t].sum(), proppmtctofdx, proppmtctofplhiv)
-
 
         state_distribution_plhiv_from = array([array([people[ix_([state], motherpops, [t])].sum(axis=(0,2)) if state in group else [0.]*len(motherpops) for state in settings.allstates]) for group in (undx, alldx, alltx)])
         with errstate(divide='ignore', invalid='ignore'):
@@ -1340,8 +1337,8 @@ def deprecated_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npop
             numdxhivpospregwomen[:]   += thispoptobedx
             # The below code looks weird but is right - in order to match the changes to the num giving birth (numundxhivpospregwomen) this is saying that we diagnose more mothers than we actually did.
             # However, this does give the right number of people on PMTCT - otherwise only a small percentage of them will actually go onto PMTCT. And we don't actually put them into the diagnosed class
-            numpotmothers[:, _undx]   -= thispoptobedx / (totalbirthrate+eps*eps*eps) # assuming all diagnosed by ANC will go onto PMTCT
-            numpotmothers[:, _alldx]  += thispoptobedx / (totalbirthrate+eps*eps*eps) # eps not small enough
+            numpotmothers[:, _undx]   -= thispoptobedx / (totalbirthrate + eps*eps) # assuming all diagnosed by ANC will go onto PMTCT
+            numpotmothers[:, _alldx]  += thispoptobedx / (totalbirthrate + eps*eps) # eps not small enough
             thisnumpmtct              += thispoptobedx.sum(axis=0)
 
         if t < npts-1:
@@ -1388,7 +1385,6 @@ def deprecated_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npop
         dxhivbirths[childpops]   += (mtctdx + mtcttx + mtctpmtct).sum(axis=0)  # Births add to dx
 
         raw_receivepmtct[motherpops, t] += (thisreceivepmtct * timestepsonpmtct).sum(axis=1)  # annualise / convert from births to preg women
-        print(t,version, undxhivbirths.sum(), dxhivbirths.sum(), popbirths.sum(), raw_receivepmtct[motherpops, t].sum(), calcproppmtct, thisproppmtct, )
         raw_mtct[childpops, t] += thispopmtct.sum(axis=0)/dt
         state_distribution_plhiv_from = einsum('ij,i->ij', people[:,motherpops,t], plhivmap)
 

--- a/optima/model.py
+++ b/optima/model.py
@@ -1138,18 +1138,16 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         return undxhivbirths, dxhivbirths, 0.0
 
     timestepsonpmtct = 1./dt # Specify the number of timesteps on which mothers are on PMTCT -- # WARNING: remove hard-coding
-    _sus,_undx,_dxnottx,_alltx, _all = range(5) # Start with underscore to not override other variables
-    nummothers = zeros((len(motherpops),5)) # nummothers is mothers in this timestep since birthratesarr is per timestep since # birth = simpars['birth']*dt
+    _sus,_undx,_dxnottx,_alltx = range(4) # Start with underscore to not override other variables
+    nummothers = zeros((len(motherpops),4)) # nummothers is mothers in this timestep since birthratesarr is per timestep since # birth = simpars['birth']*dt
 
     nummothers[:,_sus]    = people[ix_(sus, motherpops, [t])].sum(axis=(0,2))   * birthratesarr[motherpops,:,t].sum(axis=1)
     nummothers[:,_undx]   = people[ix_(undx, motherpops, [t])].sum(axis=(0,2))  * birthratesarr[motherpops,:,t].sum(axis=1)  # THIS LINE
     nummothers[:,_dxnottx]= people[ix_(alldx, motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
     nummothers[:,_alltx]  = people[ix_(alltx, motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1) * relhivbirth  # THIS LINE
 
-    nummothers[:, _all] = people[ix_(range(settings.nstates), motherpops, [t])].sum(axis=(0,2)) * birthratesarr[motherpops,:,t].sum(axis=1)
-
     nummothers_allplhiv = lambda _nummothers: _nummothers[:, _undx] + _nummothers[:, _dxnottx] + _nummothers[:, _alltx]
-    nummothers_alldx    = lambda _nummothers:                         _nummothers[:, _dxnottx]
+    nummothers_alldx    = lambda _nummothers:                         _nummothers[:, _dxnottx] + _nummothers[:, _alltx]
     nummothers_all      = lambda _nummothers: _nummothers[:,_sus] + nummothers_allplhiv(_nummothers)
 
     # old behaviour is proppmtctofdx =  numpmtct/ dxpregwomen, and proppmtct = numpmtct / dxpregwomen
@@ -1220,7 +1218,7 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         births = zeros((10, len(motherpops),len(childpops)))
         _allbirths, _fromhivpos, _fromundx, _fromdxnottx, _fromalltx, mtct_fromundx, mtct_fromdxnottx, mtct_fromalltx, pmtct_received, mtct_fromonpmtct = range(10)
 
-        births[_allbirths]   = einsum('ij,i->ij', thisbirthrates, nummothers[:,_all])
+        births[_allbirths]   = einsum('ij,i->ij', thisbirthrates, nummothers_all(nummothers))
         births[_fromhivpos]  = einsum('ij,i->ij', thisbirthrates, nummothers_allplhiv(nummothers))
         # _fromundx + _fromdxnottx + _fromalltx = _fromhivpos
         births[_fromundx]    = einsum('ij,i->ij', thisbirthrates, nummothers[:,_undx])
@@ -1371,11 +1369,13 @@ def deprecated_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npop
     # Calculate actual births, MTCT, and PMTCT
     if len(motherpops) and len(childpops):
         thisbirthrates = birthratesarr[:,:,t][ix_(motherpops,childpops)]
+        # print(t,version, 'mothers', numpotmothers[:, _all].sum(), motherpops, childpops, thisbirthrates.shape,thisbirthrates.sum(axis=1))
         popbirths      = einsum('ij,i->ij', thisbirthrates, numpotmothers[motherpops, _all])
         hivposbirths   = einsum('ij,i->ij', thisbirthrates, numpotmothers[motherpops, _allplhiv])
         mtctundx       = einsum('ij,i->ij', thisbirthrates, numpotmothers[motherpops, _undx]) * effmtct[t] # Births to undiagnosed mothers
         mtcttx         = einsum('ij,i->ij', thisbirthrates, numpotmothers[motherpops, _alltx]) * pmtcteff[t] # Births to mothers on treatment
         thiseligbirths = einsum('ij,i->ij', thisbirthrates, numpotmothers[motherpops, _alldx]) # Births to diagnosed mothers eligible for PMTCT
+        # print(t, version, 'mothers2', popbirths.sum(), motherpops, childpops, thisbirthrates.shape,thisbirthrates.sum(axis=1))
 
         thisreceivepmtct =  thiseligbirths * calcproppmtct
         mtctpmtct        = (thiseligbirths * calcproppmtct)     * pmtcteff[t] # MTCT from those receiving PMTCT
@@ -1398,6 +1398,6 @@ def deprecated_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npop
         raw_hivbirths[motherpops, t] += hivposbirths.sum(axis=1) /dt
 
         raw_inci[:,t] += raw_mtct[:,t] # Update infections acquired based on PMTCT calculation
-        raw_incibypop[:,motherpops,t] += raw_mtctfrom # Update infections caused based on PMTCT
+        raw_incibypop[:,:,t] += raw_mtctfrom # Update infections caused based on PMTCT
 
     return undxhivbirths, dxhivbirths, thisproppmtct

--- a/optima/model.py
+++ b/optima/model.py
@@ -1139,7 +1139,7 @@ def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, versi
         return undxhivbirths, dxhivbirths, 0.0
 
     timestepsonpmtct = 1./dt # Specify the number of timesteps on which mothers are on PMTCT -- # WARNING: remove hard-coding
-    _sus,_undx,_dxnottx,_alltx = range(4) # Start with underscore to not override other variables
+    _all,_undx,_dxnottx,_alltx = range(4) # Start with underscore to not override other variables
     nummothers = zeros((4, len(motherpops))) # nummothers is mothers in this timestep since birthratesarr is per timestep since # birth = simpars['birth']*dt
 
     thisbirthrates = birthratesarr[motherpops,:,t].sum(axis=1)

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,4 +1,4 @@
-supported_versions = ['2.11.4','2.12.0','2.12.1']
+supported_versions = ['2.11.4','2.12.0','2.12.1','2.12.2']
 revision = '5'
 revisiondate = '2024-05-27'
 versions_different_databook = ['2.10.13']  # Versions where we start using a different databook format

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,6 @@ setup(
         'xlrd==1.2.0', #WARNING temporary to read xlsx files and needs to to be replaced with a migration to openpyxl
         'xlsxwriter',
         'sciris>=3.0.0',
+        'scipy',
     ],
 )


### PR DESCRIPTION
 - Clean up MTCT code and fix problems:
   - MTCT of people on ART was being double-counted
   - Total births was too high - wasn't taking `relhivbirth` into account (but didn't add extra MTCT, just extra susceptible births)
 - Fix rare negative people issue when FOI is very high - make FOI = min(FOI, 1)