### PR TITLE
Update for xlsxwriter 3.2.2 compatibility

### DIFF
--- a/optima/makespreadsheet.py
+++ b/optima/makespreadsheet.py
@@ -287,10 +287,10 @@ class OptimaFormats:
         self.formats['number']       = self.book.add_format({'locked':0, 'num_format':0x04, 'bg_color':OptimaFormats.BG_COLOR, 'border':1, 'border_color':OptimaFormats.BORDER_COLOR})
         self.formats['general']      = self.book.add_format({'locked':0, 'num_format':0x00, 'bg_color':OptimaFormats.BG_COLOR, 'border':1, 'border_color':OptimaFormats.BORDER_COLOR})
         self.formats['optional']     = self.book.add_format({'locked':0, 'num_format':0x00, 'bg_color':OptimaFormats.OPT_COLOR,'border':1, 'border_color':OptimaFormats.BORDER_COLOR})
-        self.formats['info_header']  = self.book.add_format({'align':'center','valign':'vcenter', 'color':'#D5AA1D','fg_color':'#0E0655', 'font_size':20})
+        self.formats['info_header']  = self.book.add_format({'align':'center','valign':'vcenter', 'font_color':'#D5AA1D','fg_color':'#0E0655', 'font_size':20})
         self.formats['grey']         = self.book.add_format({'fg_color':'#EEEEEE', 'text_wrap':True})
         self.formats['orange']       = self.book.add_format({'fg_color':'#FFC65E', 'text_wrap':True})
-        self.formats['info_url']     = self.book.add_format({'fg_color':'#EEEEEE', 'text_wrap':True, 'color':'blue','align':'center'})
+        self.formats['info_url']     = self.book.add_format({'fg_color':'#EEEEEE', 'text_wrap':True, 'font_color':'blue','align':'center'})
         self.formats['grey_bold']    = self.book.add_format({'fg_color':'#EEEEEE','bold':True})
         self.formats['merge_format'] = self.book.add_format({'bold': 1,'align': 'center','text_wrap':True})
 

--- a/optima/results.py
+++ b/optima/results.py
@@ -1308,7 +1308,7 @@ def exporttoexcel(filename=None, outdict=None):
         formats['bold'] = workbook.add_format({'bg_color': colors['edgyblue'], 'bold': True})
         formats['number'] = workbook.add_format({'bg_color': colors['fadedstrawberry'], 'num_format': 0x00})
         formats['percent'] = workbook.add_format({'bg_color': colors['fadedstrawberry'], 'num_format': 0x09})
-        formats['header'] = workbook.add_format({'bg_color': colors['gentlegreen'], 'color': colors['white'], 'bold': True})
+        formats['header'] = workbook.add_format({'bg_color': colors['gentlegreen'], 'font_color': colors['white'], 'bold': True})
         formats['increase'] = workbook.add_format({'bg_color': colors['increasegreen'], 'num_format': 0x09})
         formats['decrease'] = workbook.add_format({'bg_color': colors['decreasered'], 'num_format': 0x09})
         


### PR DESCRIPTION
xlsxwriter 3.2.2 deprecated `workbook.add_format({'color':XXX})` in favour of 'font_color', 'font' -> 'font_name' , 'size' -> 'font_size'