### PR TITLE
Revision 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ Versions `2.11.4`, `2.12.0` and later all can be run using the branch `main`. A 
 
 ## Revision 12
  - `Resultset.quantile` tracks which quantiles where used to generate the results: either a list of 3 floats or `'allsamples'` which keeps all the samples.
- - `model()` takes `flattenraw` keyword to flatten the raw advancedtracking arrays to remove most of the values which are 0. `flattenraw = True` takes ~20% longer but it is more memory efficient and raw results are ~10x smaller. `flattenraw = False` is the default except when running with sensitivity and advancedtracking (which would previously cause OOM errors).
+ - `model()` takes `flattenraw` keyword to flatten the raw advancedtracking arrays to remove most of the values which are 0. `flattenraw = True` takes ~20% longer but it is more memory efficient and raw results are 80-90% smaller (`advancedtracking=True, keepraw=True`). `flattenraw = False` is the default except when running with sensitivity and advancedtracking (which would previously cause OOM errors).
      - **BREAKING CHANGE**: This only applies to `raw['incimethods'], raw['transitpopbypop']` so when those are accessed (even if `flattenraw = False`), you must call it: 
      `raw['incimethods']()` or `raw['transitpopbypop']()` which will unflatten or return the original.
- - **BREAKING CHANGE**: `raw['incionpopbypop']` has been removed as it was just a copy of `raw['incimethods']` ie: `raw['incionpopbypop'] = raw_incionpopbypopmethods.sum(axis=0) # Removes the method of transmission`
+ - **BREAKING CHANGE**: `raw['incionpopbypop']` has been removed as it was just a copy of `raw['incimethods']` (saves ~10% raw results size). Tt was defined as: `raw['incionpopbypop'] = raw_incionpopbypopmethods.sum(axis=0) # Removes the method of transmission`
  - `Resultset.version` and `Resultset.revision` track which version and revision were used to create the results
  - `Resultset.__add__, Resultset.__sub__` work properly (actually subtracts the values) and sames the `.parentnames` and `.operation` in the resultant Resultset
  - `Resultset.pars.func = None` now, if you want to have the `func` which checks the version of the parameters, then add the pars to a `Parameterset`. This was making some project files 10x too big if they were run in parallel.

--- a/optima/loadtools.py
+++ b/optima/loadtools.py
@@ -1724,6 +1724,7 @@ def refreshlinks(project=None, **kwargs):
     '''
     if project is not None:
         project.restorelinks()
+        project.propagateversion(None, None, vals='all')
         project.results = op.odict()
 
         from types import MethodType

--- a/optima/model.py
+++ b/optima/model.py
@@ -1,11 +1,12 @@
 ## Imports
-from numpy import zeros, exp, maximum, minimum, inf, array, isnan, einsum, floor, ones, power as npow, concatenate as cat, interp, nan, squeeze, isinf, isfinite, argsort, take_along_axis, put_along_axis, expand_dims, ix_, tile, arange, swapaxes, errstate, where, prod, isin
-from optima import OptimaException, printv, dcp, odict, findinds, compareversions, sanitize
+from functools import partial
+from numpy import zeros, exp, maximum, minimum, inf, array, isnan, einsum, floor, ones, power as npow, concatenate as cat, interp, nan, squeeze, isinf, isfinite, argsort, take_along_axis, put_along_axis, expand_dims, ix_, tile, arange, swapaxes, errstate, where, prod, isin, transpose
+from optima import OptimaException, printv, dcp, odict, findinds, compareversions, sanitize, promotetolist, isnumber
 
 __all__ = ['model']
 
 def model(simpars=None, settings=None, version=None, initpeople=None, initprops=None, verbose=None, die=False, debug=False,
-          label=None, startind=None, advancedtracking=False):
+          label=None, startind=None, advancedtracking=False, flattenraw=False):
     """
     Runs Optima's epidemiological model.
 
@@ -1100,16 +1101,87 @@ def model(simpars=None, settings=None, version=None, initpeople=None, initprops=
     raw['otherdeath']     = raw_otherdeath
     raw['emigration']     = raw_emi
     if advancedtracking:
-        raw['diagcd4']        = raw_diagcd4
-        raw['incionpopbypop'] = raw_incionpopbypopmethods.sum(axis=0) # Removes the method of transmission
-        raw['incimethods']    = raw_incionpopbypopmethods
-        raw['transitpopbypop']= raw_transitpopbypop
-        raw['props']          = raw_propsarr
+        raw['diagcd4']         = raw_diagcd4
+        raw['incimethods']     = flatten_unflatten_func(raw_incionpopbypopmethods, axes_flatten=(0, 1, 2, 3), doflatten=flattenraw) # Axis 0 is method, 1 is acquired pop, 2-3 is cd4 state and pop of from pop
+        raw['transitpopbypop'] = flatten_unflatten_func(raw_transitpopbypop, axes_flatten=(0, 1, 2), doflatten=flattenraw)
+        raw['props']           = raw_propsarr
 
     checkfornegativepeople(people) # Check only once for negative people, right before finishing
 
     return raw # Return raw results
 
+
+def return_original(arr, indices=None):
+    if indices is not None:
+        slicer = [slice(None) for axis in range(arr.ndim)]
+        axes = list(range(arr.ndim))
+        for axis, axisindices in indices.items():
+            axis = axes[axis]
+            slicer[axis] = axisindices
+        slicer = tuple(slicer)
+        output = arr[slicer]
+        return output
+
+    return arr
+
+def flatten_unflatten_func(arr, axes_flatten, doflatten):
+    if not doflatten: return partial(return_original, arr=arr)
+    original_shape = arr.shape
+
+    other_axes = [ax for ax in range(arr.ndim) if ax not in axes_flatten]
+    reordered_axes = list(axes_flatten) + list(other_axes)
+
+    nonzero_inds = where(arr.any(axis=tuple(other_axes)))
+
+    transposed = transpose(arr, reordered_axes)
+    flattened = transposed[nonzero_inds]
+
+    return partial(unflatten, flattened=flattened, axes_flatten=axes_flatten, original_shape=original_shape, reordered_axes=reordered_axes, nonzero_inds=nonzero_inds)
+
+def unflatten(flattened, axes_flatten, original_shape, reordered_axes, nonzero_inds, indices=None):
+    """
+        indices: A dictionary with {axis: indicesforthataxis}
+    """
+    this_shape = original_shape
+    if indices is not None and indices:
+        slicer = [slice(None) for axis in range(flattened.ndim)]
+        axes = list(range(len(original_shape)))
+        original_shape = list(original_shape)
+
+        new_shape = list(original_shape)
+        new_reordered_axes = list(reordered_axes)
+
+        for axis, axisindices in indices.items():
+            axis = axes[axis]
+            if axis in axes_flatten: raise OptimaException(f'Cannot efficiently index by axis {axis} when that is one of the flattened axes')
+            axis_index_in_flat = list(reordered_axes).index(axis) - len(axes_flatten) + 1
+            slicer[axis_index_in_flat] = axisindices
+
+            if isnumber(axisindices):
+                new_shape[axis] = None
+                new_reordered_axes = [ax if ax < axis else ax - 1 for ax in new_reordered_axes if ax != axis]
+
+        slicer = tuple(slicer)
+        flattened = flattened[slicer]
+
+        i = 1
+        for ax,shape in enumerate(new_shape):
+            if ax in axes_flatten: continue
+            if shape == None: continue
+
+            new_shape[ax] = flattened.shape[i]
+            i += 1
+
+        new_shape = [shape for shape in new_shape if shape is not None]
+
+        original_shape = tuple(new_shape)
+        reordered_axes = new_reordered_axes
+
+
+    unflattened = zeros(original_shape, dtype=flattened.dtype)
+    unflattened_transposed = transpose(unflattened, reordered_axes)
+    unflattened_transposed[nonzero_inds] = flattened
+    return unflattened
 
 def do_births(t, npts, dt, eps, birthratesarr, relhivbirth, people, npops, version, undx, dx, alldx, alltx, allplhiv, sus,mtct,nstates,dxnottx,
               motherpops, childpops, notmotherpops, effmtct, pmtcteff, plhivmap, advancedtracking, settings, mtctgroupmap, tvec,

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -193,7 +193,7 @@ class Parameterset(object):
             self.projectref = Link(project)
         if self.pars is not None:
             if not isinstance(self.pars, odict_custom):
-                self.pars = odict_custom(self.pars, func=self.checkpropagateversion)
+                self.pars = odict_custom(self.pars, func=None)
             self.pars.func = self.checkpropagateversion
     
     def makepars(self, data=None, fix=True, verbose=2, start=None, end=None, projectversion=None):

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -191,6 +191,10 @@ class Parameterset(object):
     def restorelinks(self, project=None):
         if project is not None:
             self.projectref = Link(project)
+        if self.pars is not None:
+            if not isinstance(self.pars, odict_custom):
+                self.pars = odict_custom(self.pars, func=self.checkpropagateversion)
+            self.pars.func = self.checkpropagateversion
     
     def makepars(self, data=None, fix=True, verbose=2, start=None, end=None, projectversion=None):
         self.pars = makepars(data=data, verbose=verbose, parset=self, # Initialize as list with single entry

--- a/optima/parameters.py
+++ b/optima/parameters.py
@@ -889,7 +889,7 @@ class Popsizepar(Par):
             if not sample:
                 meta = self.m
             else:
-                if sample=='new' or self.msample is None: self.sample(rng_sampler=rng_sampler, best=self.m) # msample doesn't exist, make it
+                if sample=='new' or self.msample is None: self.sample(rng_sampler=rng_sampler) # msample doesn't exist, make it
                 meta = self.msample
                 
                 

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -79,7 +79,7 @@ class Programset(object):
             self.projectref = Link(project)
         if self.programs is not None:
             if not isinstance(self.programs, odict_custom):
-                self.programs = odict_custom(self.programs, func=self.checkpropagateversion)
+                self.programs = odict_custom(self.programs, func=None)
             self.programs.func = self.checkpropagateversion
 
     def propagateversion(self, odict, keys, values, die=True):

--- a/optima/programs.py
+++ b/optima/programs.py
@@ -74,6 +74,14 @@ class Programset(object):
         if name == 'projectversion' and hasattr(self, 'programs') and self.programs is not None:
             self.propagateversion(None, None, self.programs.values())
 
+    def restorelinks(self, project=None):
+        if project is not None:
+            self.projectref = Link(project)
+        if self.programs is not None:
+            if not isinstance(self.programs, odict_custom):
+                self.programs = odict_custom(self.programs, func=self.checkpropagateversion)
+            self.programs.func = self.checkpropagateversion
+
     def propagateversion(self, odict, keys, values, die=True):
         ''' Dies because it should be able to add .projectversion to a Program'''
         values = promotetolist(values)

--- a/optima/project.py
+++ b/optima/project.py
@@ -636,7 +636,7 @@ class Project(object):
                budget=None, coverage=None, budgetyears=None, data=None, n=1, sample=None, tosample=None, randseed=None,
                addresult=True, overwrite=True, keepraw=False, doround=False, die=True, debug=False, verbose=None,
                parsetname=None, progsetname=None, resultname=None, label=None, smoothness=None,
-               advancedtracking=None, parallel=False, ncpus=None, quantiles=None, **kwargs):
+               advancedtracking=None, parallel=False, parallelizer=None, ncpus=None, quantiles=None, **kwargs):
         ''' 
         This function runs a single simulation, or multiple simulations if n>1. This is the
         core function for actually running the model!!!!!!
@@ -701,7 +701,7 @@ class Project(object):
 
         else: # Run in parallel
             all_kwargs = {'settings':self.settings, 'version':self.version, 'die':die, 'debug':debug, 'verbose':verbose, 'label':self.name, 'advancedtracking':advancedtracking, **kwargs}
-            try: rawlist = parallelize(model, iterarg=simparslist, kwargs=all_kwargs, ncpus=ncpus) # ACTUALLY RUN THE MODEL
+            try: rawlist = parallelize(model, iterarg=simparslist, kwargs=all_kwargs, ncpus=ncpus, parallelizer=parallelizer) # ACTUALLY RUN THE MODEL
             except:
                 printv('\nWARNING: Could not run in parallel probably because this process is already running in parallel. Trying in serial...', 1, verbose)
                 rawlist = []

--- a/optima/project.py
+++ b/optima/project.py
@@ -91,23 +91,26 @@ class Project(object):
             self.propagateversion(None, None, 'all')
 
     def propagateversion(self, odict, keys, vals):
-        if vals == 'all':
-            vals = []
-            if self.parsets  is not None: vals.extend(self.parsets.values())
-            if self.progsets is not None: vals.extend(self.progsets.values())
-        vals = promotetolist(vals)
-        for val in vals:
-            val.projectversion = self.version
+        if hasattr(self, 'version'):
+            if vals == 'all':
+                vals = []
+                if self.parsets  is not None: vals.extend(self.parsets.values())
+                if self.progsets is not None: vals.extend(self.progsets.values())
+            vals = promotetolist(vals)
+            for val in vals:
+                val.projectversion = self.version
 
     def checkversion(self, odict, keys, values):
-        values = promotetolist(values)
-        for val in values:
-            if not hasattr(val, 'projectversion'):
-                raise OptimaException(f'Cannot add {type(val)} "{val.name if hasattr(val, "name") else None}" to Project "{self.name}" because it is '
-                                      f'missing a projectversion so it might not be compatible with Project.version={self.version}')
-            if val.projectversion is not None and val.projectversion != self.version:
-                raise OptimaException(f'Cannot add {type(val)} "{val.name if hasattr(val, "name") else None}" to project "{self.name}" because it has '
-                                      f'a different version {val.projectversion} than the project {self.version}')
+        if hasattr(self, 'version'):
+            values = promotetolist(values)
+            for val in values:
+                if not hasattr(val, 'projectversion'):
+                    raise OptimaException(f'Cannot add {type(val)} "{val.name if hasattr(val, "name") else None}" to Project "{self.name}" because it is '
+                                          f'missing a projectversion so it might not be compatible with Project.version={self.version}')
+                    val.projectversion = self.version
+                if val.projectversion is not None and val.projectversion != self.version:
+                    raise OptimaException(f'Cannot add {type(val)} "{val.name if hasattr(val, "name") else None}" to project "{self.name}" because it has '
+                                          f'a different version {val.projectversion} than the project {self.version}')
 
     def checkpropagateversionlink(self, odict, keys, vals):
         vals = promotetolist(vals)
@@ -600,7 +603,7 @@ class Project(object):
         for itemname in ['parsets','progsets']:
             item = getattr(self, itemname)
             if not isinstance(item, odict_custom):
-                setattr(self, itemname, odict_custom(item, func=self.checkpropagateversionlink))
+                setattr(self, itemname, odict_custom(item, func=None))
             item.func = self.checkpropagateversionlink
         return None
 

--- a/optima/results.py
+++ b/optima/results.py
@@ -342,8 +342,13 @@ class Resultset(object):
         def assemble(key, sumaxis=None, call=False):
             ''' Assemble results into an array '''
             if call:
-                # thisindices = None if type(assembleindices) == slice and assembleindices == slice(None) else {-1:assembleindices}
-                output = array([raw[i][key]()[...,assembleindices] if sumaxis is None else raw[i][key]()[...,assembleindices].sum(axis=sumaxis) for i in range(nraw)])
+                def callandindex(func):
+                    if memoryefficient:  # Assumes assembleindices is array
+                        return func(indices={-1:assembleindices})  # More efficient to index before unflattening as copies less data but changes results very slightly, 2.12.3 change
+                    else:
+                        return func()[...,assembleindices]
+
+                output = array([callandindex(raw[i][key]) if sumaxis is None else callandindex(raw[i][key]).sum(axis=sumaxis) for i in range(nraw)])
             else:
                 output = array([raw[i][key][...,assembleindices] if sumaxis is None else raw[i][key][...,assembleindices].sum(axis=sumaxis) for i in range(nraw)])
             return output

--- a/optima/results.py
+++ b/optima/results.py
@@ -5,9 +5,9 @@ Version: 2018nov19
 """
 
 from optima import OptimaException, Link, Settings, odict, pchip, plotpchip, sigfig # Classes/functions
-from optima import uuid, today, makefilepath, getdate, printv, dcp, objrepr, defaultrepr, sanitizefilename, sanitize # Printing/file utilities
+from optima import revision, compareversions, supported_versions, uuid, today, makefilepath, getdate, printv, dcp, objrepr, defaultrepr, sanitizefilename, sanitize # Printing/file utilities
 from optima import quantile, findinds, findnearest, promotetolist, promotetoarray, checktype # Numeric utilities
-from numpy import array, nan, zeros, arange, shape, maximum, log, swapaxes
+from numpy import array, nan, zeros, arange, shape, maximum, log, swapaxes, array_equal
 from numbers import Number
 from xlsxwriter import Workbook
 
@@ -64,6 +64,10 @@ class Resultset(object):
         self.parsetuid = parsetuid
         self.progsetname = progsetname
         self.advancedtracking = advancedtracking
+        self.revision = revision
+        self.version = None
+        self.quantiles = quantiles if quantiles is not None else [0.5, 0.25, 0.75]  # Default quantiles is IQR
+        if self.quantiles in ['keepall', 'keep', 'all', 'allsamples']: self.quantiles = 'allsamples' # 'allsamples' is the designated name
 
         # Turn inputs into lists if not already
         if raw is None: raise OptimaException('To generate results, you must feed in model output: none provided')
@@ -74,6 +78,7 @@ class Resultset(object):
         if project is not None:
             if data is None: data = project.data # Copy data if not supplied -- DO worry if data don't exist!
             if settings is None: settings = project.settings
+            self.version = project.version
 
         # Fundamental quantities -- populated by project.runsim()
         if keepraw: self.raw = raw # Keep raw, but only if asked
@@ -83,10 +88,10 @@ class Resultset(object):
         self.projectref = Link(project) # ...and just store the whole project
         self.projectinfo = project.getinfo() # Store key info from the project separately in case the link breaks
         if pars is not None:
-            self.pars = pars # Keep pars
+            self.pars = pars.cp() # Keep pars, but remove the .func that links it to the parset
         else: # Try various other ways of getting pars
             if parsetname is not None and parsetname in self.projectref().parsets.keys():
-                self.pars = self.projectref().parsets[parsetname].pars
+                self.pars = self.projectref().parsets[parsetname].pars.cp()
             else: raise OptimaException('To generate results, you must feed in a parset or pardict: none provided')
         self.data = dcp(data) # Store data
         self.budget = budget if budget is not None else odict() # Store budget
@@ -154,7 +159,7 @@ class Resultset(object):
         for healthkey,healthname in zip(self.settings.healthstates, self.settings.healthstatesfull): # Health keys: ['susreg', 'progcirc', 'undx', 'dx', 'care', 'lost', 'usvl', 'svl']
             self.other['only'+healthkey]   = Result(healthname) # Pick out only people in these health states
             
-        if domake: self.make(raw, verbose=verbose, quantiles=quantiles, doround=doround, advancedtracking=advancedtracking)
+        if domake: self.make(raw, verbose=verbose, doround=doround, advancedtracking=advancedtracking)
     
     
     def __repr__(self):
@@ -181,7 +186,7 @@ class Resultset(object):
         
         # Keep the properties of this first one
         R1 = dcp(self) 
-        R1.name += ' + ' + R2.name
+        # R1.name += ' + ' + R2.name
         R1.uid = uuid()
         R1.created = today()
         
@@ -196,10 +201,13 @@ class Resultset(object):
             raise OptimaException(errormsg)
         
         R = self._checkresultset(R2)
-        popsize1 = dcp(R.main['popsize'])
-        popsize2 = dcp(R2.main['popsize'])
         if   operation=='add': R.name += ' + ' + R2.name
         elif operation=='sub': R.name += ' - ' + R2.name
+        R.parentnames = (self.name, R2.name)  # Saves a reference to the parent results in the sum/difference result
+        R.operation = operation
+
+        popsize1 = dcp(self.main['popsize'])
+        popsize2 = dcp(R2.main['popsize'])
 
         R.projectref = self.projectref # ...and just store the whole project
         
@@ -225,9 +233,11 @@ class Resultset(object):
                 resultsobjs[typekey].tot  = 0*res1.tot  # Reset
                 resultsobjs[typekey].pops = 0*res1.pops # Reset
                 for t in range(shape(res1.tot)[-1]):
-                    resultsobjs[typekey].tot[:,t] = (res1.tot[:,t]*popsize1.tot[0,t] + res2.tot[:,t]*popsize2.tot[0,t]) / (popsize1.tot[0,t] + popsize2.tot[0,t])
+                    if   operation=='add': resultsobjs[typekey].tot[:,t] = (res1.tot[:,t]*popsize1.tot[0,t] + res2.tot[:,t]*popsize2.tot[0,t]) / (popsize1.tot[0,t] + popsize2.tot[0,t])
+                    elif operation=='sub': resultsobjs[typekey].tot[:,t] = (res1.tot[:,t]*popsize1.tot[0,t] - res2.tot[:,t]*popsize2.tot[0,t]) / (popsize1.tot[0,t] + popsize2.tot[0,t])
                     for p in range(len(R.popkeys)):
-                        resultsobjs[typekey].pops[:,p,t] = (res1.pops[:,p,t]*popsize1.pops[0,p,t] + res2.pops[:,p,t]*popsize2.pops[0,p,t]) / (popsize1.pops[0,p,t] + popsize2.pops[0,p,t])
+                        if   operation=='add': resultsobjs[typekey].pops[:,p,t] = (res1.pops[:,p,t]*popsize1.pops[0,p,t] + res2.pops[:,p,t]*popsize2.pops[0,p,t]) / (popsize1.pops[0,p,t] + popsize2.pops[0,p,t])
+                        elif operation=='sub': resultsobjs[typekey].pops[:,p,t] = (res1.pops[:,p,t]*popsize1.pops[0,p,t] - res2.pops[:,p,t]*popsize2.pops[0,p,t]) / (popsize1.pops[0,p,t] + popsize2.pops[0,p,t])
             else: # It's a number, can just sum the arrays
                 for attr in ['pops', 'tot']:
                     if   operation=='add': this = getattr(res1, attr) + getattr(res2, attr)
@@ -248,7 +258,8 @@ class Resultset(object):
         return R
             
         
-    def make(self, raw, quantiles=None, annual=True, verbose=2, doround=False, lifeexpectancy=None, discountrate=None, yllconstrained=None, advancedtracking=False):
+    def make(self, raw, annual=True, verbose=2, doround=False, lifeexpectancy=None, discountrate=None, yllconstrained=None,
+             advancedtracking=False, memoryefficient=None):
         """
         Gather standard results into a form suitable for plotting with uncertainties.
         Life expectancy is measured in years, and the discount rate is in absolute
@@ -259,7 +270,6 @@ class Resultset(object):
         
         
         # Initialize
-        if quantiles      is None: quantiles      = [0.5, 0.25, 0.75] # Can't be a kwarg since mutable
         if lifeexpectancy is None: lifeexpectancy = 80 # 80 year life expectancy
         if discountrate   is None: discountrate   = 0.03 # Discounting of 3% for YLL only
         if yllconstrained is None: yllconstrained = False # False by default (count all YLL for deaths incurred during model run), True = count only YLL within the timeframe of the model run, to be used with care if at all
@@ -278,7 +288,7 @@ class Resultset(object):
         # Define functions
         def process(rawdata, percent=False):
             ''' Process the outputs -- sort into quantiles and optionally round if it's a number '''
-            processed = quantile(rawdata, quantiles=quantiles) # Calculate the quantiles
+            processed = quantile(rawdata, quantiles=self.quantiles) # Calculate the quantiles
             if doround and not percent: processed = processed.round() # Optionally round
             return processed
         
@@ -319,11 +329,23 @@ class Resultset(object):
                 naninds = list(set(range(nyears)) - set(validinds))
                 processed[blh][0][naninds] = nan # Convert back to nan if no data entered for any population
             return processed
-        
-        
-        def assemble(key):
+
+        if memoryefficient is None:
+            memoryefficient = compareversions(self.version if self.version is not None else supported_versions[-1], '2.12.3') >= 0
+
+        if memoryefficient: # More memory efficient to index the raw arrays when assembling, not after
+            assembleindices = indices
+            indices = slice(None)
+        else:
+            assembleindices = slice(None)
+
+        def assemble(key, sumaxis=None, call=False):
             ''' Assemble results into an array '''
-            output = dcp(array([raw[i][key] for i in range(nraw)]))
+            if call:
+                # thisindices = None if type(assembleindices) == slice and assembleindices == slice(None) else {-1:assembleindices}
+                output = array([raw[i][key]()[...,assembleindices] if sumaxis is None else raw[i][key]()[...,assembleindices].sum(axis=sumaxis) for i in range(nraw)])
+            else:
+                output = array([raw[i][key][...,assembleindices] if sumaxis is None else raw[i][key][...,assembleindices].sum(axis=sumaxis) for i in range(nraw)])
             return output
         
         # Initialize arrays
@@ -354,9 +376,9 @@ class Resultset(object):
         data         = self.data
         if advancedtracking:
             alldiagcd4         = assemble('diagcd4')
-            alltransitpopbypop = assemble('transitpopbypop')
-            allincionpopbypop  = assemble('incionpopbypop')
-            allincimethods     = assemble('incimethods')
+            alltransitpopbypop = assemble('transitpopbypop',            call=True)
+            allincionpopbypop  = assemble('incimethods', sumaxis=(0,2), call=True)
+            allincimethods     = assemble('incimethods', sumaxis=(2,3), call=True)
 
         # Actually do calculations
         self.main['prev'].pops = process(allpeople[:,allplhiv,:,:][:,:,:,indices].sum(axis=1) / (eps+allpeople[:,:,:,indices].sum(axis=1)), percent=True) # Axis 1 is health state
@@ -576,15 +598,14 @@ class Resultset(object):
             self.other['propundxcd4lt350'].pops = process(allpeople[:,undxcd4lt350,:,:][:,:,:,indices].sum(axis=1)/maximum(allpeople[:,undx,:,:][:,:,:,indices].sum(axis=1),eps))
             self.other['propundxcd4lt350'].tot  = process(allpeople[:,undxcd4lt350,:,:][:,:,:,indices].sum(axis=(1,2))/maximum(allpeople[:,undx,:,:][:,:,:,indices].sum(axis=(1,2)),eps))
 
-            self.other['numincionpopbypop'].pops = process(allincionpopbypop[:, :, :, :, indices].sum(axis=2))  # Axis 2 is health state of causers
-            self.other['numincionpopbypop'].tot  = process(allincionpopbypop[:, :, :, :, indices].sum(axis=(2, 3)))  # Axis 3 is causer populations
+            self.other['numincionpopbypop'].pops = process(allincionpopbypop[:, :, :, indices])
+            self.other['numincionpopbypop'].tot  = process(allincionpopbypop[:, :, :, indices].sum(axis=2))  # Axis 2 is causer populations
             # Uncomment the lines below to check that numincionpopbypop is being calculated properly compared with numinci - it will show as data on the plots
             # self.other['numincionpopbypop'].datatot = process(array([allinci[:,:,indices],allinci[:,:,indices],allinci[:,:,indices]])) # summing over both causing state and population gives total per acquired population
             # self.other['numincionpopbypop'].estimate = False  # Not an estimate because the model produced the "data" - should match up
 
-            self.other['numinciallmethods'].pops = process(swapaxes(allincimethods[:,:,:,:,:,indices].sum(axis=(3,4)),1,2))  # Axis 3 is health state of causers, axis 4 is causer population
-                                                                    # put population acquired into axis 1, method into axis 2
-            self.other['numinciallmethods'].tot  = process(allincimethods[:,:,:,:,:,indices].sum(axis=(2,3,4)))  # Sum over everything except, axis 0:scenario, axis 1:method, axis 5:time
+            self.other['numinciallmethods'].pops = process(swapaxes(allincimethods[:,:,:,indices], 1, 2))  # put population acquired into axis 1, method into axis 2
+            self.other['numinciallmethods'].tot  = process(allincimethods[:,:,:,indices].sum(axis=2))  # Sum over everything except, axis 0:scenario, axis 1:method, axis 5:time
 
             self.other['numincimethods'].pops = process(swapaxes(swapaxes(array([self.other['numinciallmethods'].pops[:,:,methodinds,:].sum(axis=2) for methodinds in self.settings.methodindsgroups]),0,1),1,2))
             self.other['numincimethods'].tot  = process(swapaxes(         array([self.other['numinciallmethods'].tot[:,methodinds,:].sum(axis=1) for methodinds in self.settings.methodindsgroups])   ,0,1))
@@ -602,6 +623,23 @@ class Resultset(object):
             self.other['only'+healthkey].tot =  process(allpeople[:,healthinds,:,:][:,:,:,indices].sum(axis=(1,2))) # Axis 1 is populations
 
         return None
+
+    def quantile(self, quantiles=None):
+        if self.quantiles != 'allsamples':
+            print(f'Warning: calling quantile on a Resultset that is already quantiled (with quantiles={self.quantiles}) could result in unexpected quantiles')
+
+        if quantiles is None:
+            quantiles = [0.5, 0.25, 0.75]
+        if quantiles in ['keepall', 'keep', 'all', 'allsamples']:
+            quantiles = 'allsamples'
+
+        self.quantiles = quantiles
+
+        for key,res in self.main.items() + self.other.items():
+            res.pops = quantile(res.pops, self.quantiles)
+            res.tot = quantile(res.tot, self.quantiles)
+
+        return self
 
     def export(self, filename=None, folder=None, bypop=True, sep=',', ind=None, key=None, sigfigs=None, writetofile=True, asexcel=True, exportother=False, verbose=2):
         """ Method for exporting results to an Excel or CSV file """
@@ -636,7 +674,7 @@ class Resultset(object):
         if exportother:
             otherkeys = self.other.keys()
             for otherkey in otherkeys:
-                try: #put this in a try-except as not all 'other' outputs are in the correct form e.g. incionpopbypop has a different shape to others to capture detailed transmission.
+                try: #put this in a try-except as not all 'other' outputs are in the correct form e.g. incimethods has a different shape to others to capture detailed transmission.
                     thisoutputstr = ''
                     if bypop: thisoutputstr += '\n' # Add a line break between different indicators
                     if bypop: popkeys = ['tot']+self.popkeys  # include total even for bypop -- WARNING, don't try to change this!
@@ -859,7 +897,7 @@ class Resultset(object):
 
 class Multiresultset(Resultset):
     ''' Structure for holding multiple kinds of results, e.g. from an optimization, or scenarios '''
-    def __init__(self, resultsetlist=None, name=None):
+    def __init__(self, resultsetlist=None, name=None, keepresultsetlist=False):
         # Basic info
         self.name = name if name else 'default'
         self.uid = uuid()
@@ -875,9 +913,13 @@ class Multiresultset(Resultset):
         elif type(resultsetlist) in [odict, dict]: resultsetlist = resultsetlist.values() # Convert from odict to list
         elif resultsetlist is None: raise OptimaException('To generate multi-results, you must feed in a list of result sets: none provided')
         else: raise OptimaException('Resultsetlist type "%s" not understood' % str(type(resultsetlist)))
+        self.rawresultsets = None
+        if keepresultsetlist:
+            self.rawresultsets = odict({result.name:result for result in resultsetlist})
+            assert array_equal(self.rawresultsets.keys(), self.resultsetnames), f'Cannot create rawresultsets when names conflict: {self.resultsetnames}'
         
         # Fundamental quantities -- populated by project.runsim()
-        setupattrs = ['tvec', 'dt', 'popkeys', 'projectinfo', 'projectref', 'parsetname', 'progsetname', 'pars', 'data', 'datayears', 'settings'] # Attributes that should be the same across all results sets
+        setupattrs = ['tvec', 'dt', 'popkeys', 'projectinfo', 'projectref', 'parsetname', 'progsetname', 'pars', 'data', 'datayears', 'settings', 'quantiles', 'version', 'revision'] # Attributes that should be the same across all results sets
         for attr in setupattrs: setattr(self, attr, None) # Shared attributes across all resultsets
 
         # Main and other results -- time series, by population -- get right structure, but clear out results -- WARNING, must match format above!
@@ -901,6 +943,7 @@ class Multiresultset(Resultset):
             for attr in setupattrs:
                 orig = getattr(self, attr)
                 new = getattr(rset, attr)
+                if hasattr(new, 'func'): new.func = None # remove pars.func, it will get added back if it gets added to a parset
                 self.setup[key][attr] = new # Copy here too
                 if orig is None: setattr(self, attr, new) # For most purposes, only need one copy of these things since won't differ
             

--- a/optima/utils.py
+++ b/optima/utils.py
@@ -311,7 +311,7 @@ def printdata(data, name='Variable', depth=1, maxlen=40, indent='', level=0, sho
         else: datastring=''
         return string+datastring
     
-    string = printentry(data).replace('\n',' \ ') # Remove newlines
+    string = printentry(data).replace('\n',r' \ ') # Remove newlines
     print(level*'..' + indent + name + ' | ' + string)
 
     if depth>0:
@@ -1248,8 +1248,8 @@ def sanitizefilename(rawfilename):
     returns a "sanitized" version that is more usable.
     '''
     import re # Import regular expression package.
-    filtername = re.sub('[\!\?\"\'<>]', '', rawfilename) # Erase certain characters we don't want at all: !, ?, ", ', <, >
-    filtername = re.sub('[:/\\\*\|,]', '_', filtername) # Change certain characters that might be being used as separators from what they were to underscores: space, :, /, \, *, |, comma
+    filtername = re.sub(r'[\!\?\"\'<>]', '', rawfilename) # Erase certain characters we don't want at all: !, ?, ", ', <, >
+    filtername = re.sub(r'[:/\\\*\|,]', '_', filtername) # Change certain characters that might be being used as separators from what they were to underscores: space, :, /, \, *, |, comma
     return filtername # Return the sanitized file name.
 
 

--- a/optima/version.py
+++ b/optima/version.py
@@ -1,6 +1,6 @@
 supported_versions = ['2.11.4','2.12.0','2.12.1','2.12.2']  # (note: ' not " because setup.py)
-revision = '11'
-revisiondate = '2024-11-01'
+revision = '12'
+revisiondate = '2025-09-13'
 versions_different_databook = ['2.10.13']  # Versions where we start using a different databook format
 
 version = supported_versions[-1]


### PR DESCRIPTION
See CHANGELOG.md

A couple of breaking changes:
 - `model()` takes `flattenraw` keyword to flatten the raw advancedtracking arrays to remove most of the values which are 0. `flattenraw = True` takes ~20% longer but it is more memory efficient and raw results are 80-90% smaller (`advancedtracking=True, keepraw=True`). `flattenraw = False` is the default except when running with sensitivity and advancedtracking (which would previously cause OOM errors).
     - **BREAKING CHANGE**: This only applies to `raw['incimethods'], raw['transitpopbypop']` so when those are accessed (even if `flattenraw = False`), you must call it: 
     `raw['incimethods']()` or `raw['transitpopbypop']()` which will unflatten or return the original.
 - **BREAKING CHANGE**: `raw['incionpopbypop']` has been removed as it was just a copy of `raw['incimethods']` (saves ~10% raw results size). Tt was defined as: `raw['incionpopbypop'] = raw_incionpopbypopmethods.sum(axis=0) # Removes the method of transmission`

But I have updated the uses of these in `analyses` in the PR for analyses

Exact same results - except for 2.12.3 which isn't active yet, but it is more time/memory efficient.